### PR TITLE
fix(wl): implement zwlr_data_control_manager_v1 to eliminate clipboar…

### DIFF
--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -10,7 +10,8 @@ use halley_config::RuntimeTuning;
 
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
-    delegate_compositor, delegate_data_device, delegate_seat, delegate_shm, delegate_xdg_shell,
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_primary_selection,
+    delegate_seat, delegate_shm, delegate_xdg_shell,
     input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus},
     reexports::wayland_server::{Client, Resource, backend::ObjectId, protocol::wl_seat},
     utils::Serial,
@@ -22,6 +23,8 @@ use smithay::{
             data_device::{
                 ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
             },
+            primary_selection::PrimarySelectionState,
+            wlr_data_control::{DataControlHandler, DataControlState},
         },
         shell::xdg::{
             PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
@@ -56,6 +59,8 @@ pub struct HalleyWlState {
     pub shm_state: ShmState,
     pub seat_state: SeatState<Self>,
     pub data_device_state: DataDeviceState,
+    pub primary_selection_state: PrimarySelectionState,
+    pub data_control_state: DataControlState,
     pub seat: Seat<Self>,
 
     pub field: Field,
@@ -132,12 +137,20 @@ impl HalleyWlState {
         let now = Instant::now();
         let mut seat_state = SeatState::new();
         let seat = seat_state.new_wl_seat(dh, "halley");
+        let primary_selection_state = PrimarySelectionState::new::<HalleyWlState>(dh);
+        let data_control_state = DataControlState::new::<HalleyWlState, _>(
+            dh,
+            Some(&primary_selection_state),
+            |_| true,
+        );
         let mut out = Self {
             compositor_state: CompositorState::new::<HalleyWlState>(dh),
             xdg_shell_state: XdgShellState::new::<HalleyWlState>(dh),
             shm_state: ShmState::new::<HalleyWlState>(dh, vec![]),
             seat_state,
             data_device_state: DataDeviceState::new::<HalleyWlState>(dh),
+            primary_selection_state,
+            data_control_state,
             seat,
 
             field: Field::new(),

--- a/crates/halley-wl/src/state/wayland_handlers.rs
+++ b/crates/halley-wl/src/state/wayland_handlers.rs
@@ -1,4 +1,6 @@
 use super::*;
+use smithay::wayland::selection::primary_selection::{PrimarySelectionHandler, PrimarySelectionState};
+use smithay::wayland::selection::wlr_data_control::DataControlState;
 use eventline::info;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -139,3 +141,19 @@ impl XdgShellHandler for HalleyWlState {
 }
 
 delegate_xdg_shell!(HalleyWlState);
+
+impl PrimarySelectionHandler for HalleyWlState {
+    fn primary_selection_state(&self) -> &PrimarySelectionState {
+        &self.primary_selection_state
+    }
+}
+
+delegate_primary_selection!(HalleyWlState);
+
+impl DataControlHandler for HalleyWlState {
+    fn data_control_state(&self) -> &DataControlState {
+        &self.data_control_state
+    }
+}
+
+delegate_data_control!(HalleyWlState);


### PR DESCRIPTION
fixed Halley causing ghost processes and minimizing active window when copy/paste

wl-clipboard falls back to spawning a real toplevel surface when the compositor doesn't advertise zwlr_data_control_manager_v1. Every clipboard read/write from neovim (or any wl-clipboard consumer) was triggering new_toplevel, creating a node, stealing interaction focus, and demoting the active window — then leaving a zombie process behind when the surface was destroyed.

Wire up Smithay's built-in wlr-data-control support:
- Add PrimarySelectionState so middle-click paste also works natively
- Add DataControlState advertising the protocol on compositor init
- Implement and delegate PrimarySelectionHandler + DataControlHandler

Clients that support zwlr_data_control_manager_v1 (wl-clipboard, wl-copy, wl-paste, cliphist, etc.) will now use the data-control path: zero surfaces, zero toplevels, zero focus steals, zero ghost processes.