### PR TITLE
fix(input): thread resize preview through focus helpers

### DIFF
--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -179,7 +179,8 @@ pub(crate) fn handle_pointer_axis_input(
     }
 
     let now = Instant::now();
-    if let Some(focus) = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now) {
+    let resize_preview = pointer_state.borrow().resize;
+    if let Some(focus) = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now, resize_preview) {
         if let Some(pointer) = st.seat.get_pointer() {
             pointer.motion(
                 st,

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -54,7 +54,8 @@ pub(crate) fn handle_pointer_button_input(
     ps.screen = (sx, sy);
     ps.workspace_size = (ws_w, ws_h);
     if let Some(pointer) = st.seat.get_pointer() {
-        let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, Instant::now());
+        let resize_preview = ps.resize;
+        let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, Instant::now(), resize_preview);
         let motion_serial = SERIAL_COUNTER.next_serial();
         let button_serial = SERIAL_COUNTER.next_serial();
         pointer.motion(
@@ -251,7 +252,7 @@ pub(crate) fn handle_pointer_button_input(
                             let fallback_size = n.intrinsic_size;
                             let fallback_pos = n.pos;
                             let (start_left, start_top, start_right, start_bottom) =
-                                active_node_screen_rect(st, ws_w, ws_h, h.node_id, Instant::now())
+                                active_node_screen_rect(st, ws_w, ws_h, h.node_id, Instant::now(), None)
                                     .unwrap_or_else(|| {
                                         let center_scr = world_to_screen(
                                             st,

--- a/crates/halley-wl/src/input/pointer_focus.rs
+++ b/crates/halley-wl/src/input/pointer_focus.rs
@@ -5,6 +5,7 @@ use smithay::desktop::{WindowSurfaceType, utils::under_from_surface_tree};
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Logical, Point};
 
+use crate::interaction::types::ResizeCtx;
 use crate::spatial::pick_hit_node_at;
 use crate::state::HalleyWlState;
 
@@ -13,6 +14,10 @@ use super::resize_helpers::active_node_surface_transform_screen_details;
 
 /// Resolve the Wayland surface and compositor-space surface origin for a
 /// given screen-space pointer position.
+///
+/// `resize_preview` must be the same value passed to the current render frame
+/// so that during interactive resize the transform mirrors the render path
+/// (preview edges, scale=1.0) rather than the smoothed-position path.
 ///
 /// # What Smithay expects for `focus.1`
 ///
@@ -26,11 +31,6 @@ use super::resize_helpers::active_node_surface_transform_screen_details;
 /// `event.location` is the raw screen-pixel coordinate `(sx, sy)`.  Therefore
 /// `focus.1` **must** be the screen-space position of the found surface's
 /// `(0, 0)` origin, not a pre-computed local cursor offset.
-///
-/// The previous code returned `local_point − surface_loc`, which at scale = 1
-/// collapsed to the constant `(origin_x + surface_loc.x, origin_y +
-/// surface_loc.y)` — so every click landed at the same spot regardless of
-/// where the cursor actually was.
 pub(crate) fn pointer_focus_for_screen(
     st: &mut HalleyWlState,
     ws_w: i32,
@@ -38,6 +38,7 @@ pub(crate) fn pointer_focus_for_screen(
     sx: f32,
     sy: f32,
     now: Instant,
+    resize_preview: Option<ResizeCtx>,
 ) -> Option<(
     smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
     Point<f64, Logical>,
@@ -48,13 +49,16 @@ pub(crate) fn pointer_focus_for_screen(
         return None;
     }
 
-    let xform = active_node_surface_transform_screen_details(st, ws_w, ws_h, hit.node_id, now)?;
+    let xform = active_node_surface_transform_screen_details(
+        st,
+        ws_w,
+        ws_h,
+        hit.node_id,
+        now,
+        resize_preview,
+    )?;
     let scale = xform.scale.max(0.001);
 
-    // `xform.origin_x/y` is the screen-space position of the surface-tree root
-    // (0, 0).  It already incorporates the scaled bbox offset so no second
-    // adjustment is needed here.
-    //
     // Convert screen → surface-tree-root-local so `under_from_surface_tree`
     // can locate the exact (sub)surface under the pointer.
     let local = Point::<f64, Logical>::from((

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -64,7 +64,8 @@ pub(crate) fn handle_pointer_motion_absolute(
     let (sx, sy) = clamp_screen_to_workspace(ws_w, ws_h, sx, sy);
     let now = Instant::now();
     if let Some(pointer) = st.seat.get_pointer() {
-        let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now);
+        let resize_preview = pointer_state.borrow().resize;
+        let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now, resize_preview);
         pointer.motion(
             st,
             focus,

--- a/crates/halley-wl/src/input/resize_helpers.rs
+++ b/crates/halley-wl/src/input/resize_helpers.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use smithay::desktop::utils::bbox_from_surface_tree;
 use smithay::reexports::wayland_server::Resource;
 
-use crate::interaction::types::ResizeHandle;
+use crate::interaction::types::{ResizeCtx, ResizeHandle};
 use crate::runtime_render::{active_surface_render_scale, world_to_screen};
 use crate::state::HalleyWlState;
 
@@ -62,8 +62,10 @@ pub(crate) fn active_node_screen_rect(
     h: i32,
     node_id: halley_core::field::NodeId,
     now: Instant,
+    resize_preview: Option<ResizeCtx>,
 ) -> Option<(f32, f32, f32, f32)> {
-    let xform = active_node_surface_transform_screen_details(st, w, h, node_id, now)?;
+    let xform =
+        active_node_surface_transform_screen_details(st, w, h, node_id, now, resize_preview)?;
     let n = st.field.node(node_id)?;
     let mut bbox_w = n.intrinsic_size.x;
     let mut bbox_h = n.intrinsic_size.y;
@@ -85,12 +87,27 @@ pub(crate) fn active_node_screen_rect(
     Some((left, top, left + sw, top + sh))
 }
 
+/// Compute the screen-space surface-tree origin and scale for an active node,
+/// matching exactly the placement used by the render path.
+///
+/// `resize_preview` must be forwarded from the caller so that during
+/// interactive resize the focus origin stays in sync with where the window is
+/// actually rendered (which uses preview coordinates and scale=1.0), rather
+/// than diverging from the smoothed-position + anim-scale path.
+///
+/// TODO: bbox_loc (the cached bbox.loc from the last render frame) should be
+/// read from `st.bbox_loc.get(&node_id)` instead of re-calling
+/// `bbox_from_surface_tree` here, to prevent mid-frame subsurface commits
+/// (e.g. a video layer) from shifting origin_x/y between render time and
+/// input-handling time. Add `pub bbox_loc: HashMap<NodeId, (f32, f32)>` to
+/// HalleyWlState and populate it in `collect_active_surfaces`.
 pub(crate) fn active_node_surface_transform_screen_details(
     st: &mut HalleyWlState,
     w: i32,
     h: i32,
     node_id: halley_core::field::NodeId,
     now: Instant,
+    resize_preview: Option<ResizeCtx>,
 ) -> Option<ActiveNodeSurfaceTransformScreen> {
     let n = st.field.node(node_id)?;
     if n.state != halley_core::field::NodeState::Active {
@@ -98,7 +115,7 @@ pub(crate) fn active_node_surface_transform_screen_details(
     }
     let anim = st.anim_style_for(node_id, n.state.clone(), now);
     let transition_alpha = st.active_transition_alpha(node_id, now);
-    let scale = active_surface_render_scale(
+    let anim_scale = active_surface_render_scale(
         anim.scale,
         st.active_zoom_lock_scale(),
         n.intrinsic_size.x,
@@ -124,19 +141,50 @@ pub(crate) fn active_node_surface_transform_screen_details(
         break;
     }
 
-    let p = st.smoothed_render_pos(node_id, n.pos, now);
-    let (cx, cy) = world_to_screen(st, w, h, p.x, p.y);
-    let sw = (bbox_w * scale).round();
-    let sh = (bbox_h * scale).round();
-    let lx = (bbox_lx * scale).round();
-    let ly = (bbox_ly * scale).round();
-    let origin_x = (cx as f32) - sw * 0.5 - lx;
-    let origin_y = (cy as f32) - sh * 0.5 - ly;
+    // During interactive resize the render path uses preview edge coordinates
+    // with scale=1.0 — mirror that here exactly so focus_origin stays in sync.
+    let (origin_x, origin_y, scale) =
+        if let Some(rz) = resize_preview.filter(|rz| rz.node_id == node_id) {
+            let origin_x = match rz.handle {
+                ResizeHandle::Left | ResizeHandle::TopLeft | ResizeHandle::BottomLeft => {
+                    rz.preview_right_px.round() - bbox_w - bbox_lx
+                }
+                ResizeHandle::Right
+                | ResizeHandle::TopRight
+                | ResizeHandle::BottomRight
+                | ResizeHandle::Top
+                | ResizeHandle::Bottom => rz.preview_left_px.round() - bbox_lx,
+            };
+            let origin_y = match rz.handle {
+                ResizeHandle::Top | ResizeHandle::TopLeft | ResizeHandle::TopRight => {
+                    rz.preview_bottom_px.round() - bbox_h - bbox_ly
+                }
+                ResizeHandle::Bottom
+                | ResizeHandle::BottomLeft
+                | ResizeHandle::BottomRight
+                | ResizeHandle::Left
+                | ResizeHandle::Right => rz.preview_top_px.round() - bbox_ly,
+            };
+            (origin_x, origin_y, 1.0f32)
+        } else {
+            let p = st.smoothed_render_pos_read(node_id, n.pos, now); // read-only: keeps focus origin in sync with hit-test position
+            let (cx, cy) = world_to_screen(st, w, h, p.x, p.y);
+            let sw = (bbox_w * anim_scale).round();
+            let sh = (bbox_h * anim_scale).round();
+            let lx = (bbox_lx * anim_scale).round();
+            let ly = (bbox_ly * anim_scale).round();
+            (
+                (cx as f32) - sw * 0.5 - lx,
+                (cy as f32) - sh * 0.5 - ly,
+                anim_scale,
+            )
+        };
+
     Some(ActiveNodeSurfaceTransformScreen {
         origin_x,
         origin_y,
         scale: scale.max(0.001),
-        bbox_offset_x: lx,
-        bbox_offset_y: ly,
+        bbox_offset_x: (bbox_lx * scale).round(),
+        bbox_offset_y: (bbox_ly * scale).round(),
     })
 }

--- a/crates/halley-wl/src/runtime_render/render_utils.rs
+++ b/crates/halley-wl/src/runtime_render/render_utils.rs
@@ -1,4 +1,5 @@
 use std::f32::consts::TAU;
+use std::time::Instant;
 
 use smithay::{
     backend::renderer::{Color32F, Frame},
@@ -86,8 +87,16 @@ pub(crate) fn sync_node_size_from_surface(
     wl: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
 ) -> Rectangle<i32, Logical> {
     let bbox = bbox_from_surface_tree(wl, (0, 0));
+
+    st.bbox_loc
+        .insert(node_id, (bbox.loc.x as f32, bbox.loc.y as f32));
+
     let bw = bbox.size.w.max(1) as f32;
     let bh = bbox.size.h.max(1) as f32;
+
+    // Do immutable reads before taking node_mut.
+    let now_ms = st.now_ms(Instant::now());
+    let resize_static_active = st.resize_static_active_for(node_id, now_ms);
 
     let Some(node) = st.field.node_mut(node_id) else {
         return bbox;
@@ -99,10 +108,15 @@ pub(crate) fn sync_node_size_from_surface(
         return bbox;
     }
 
+    if resize_static_active {
+        return bbox;
+    }
+
     node.intrinsic_size = halley_core::field::Vec2 { x: bw, y: bh };
     if matches!(node.state, halley_core::field::NodeState::Active) {
         node.footprint = node.intrinsic_size;
     }
+
     bbox
 }
 

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -123,6 +123,8 @@ pub struct HalleyWlState {
     viewport_pan_anim: Option<ViewportPanAnim>,
     pan_dominant_until_ms: u64,
     exit_requested: bool,
+    
+    pub(crate) bbox_loc: HashMap<NodeId, (f32, f32)>,
 
     spawn_cursor: u32,
     started_at: Instant,
@@ -206,7 +208,9 @@ impl HalleyWlState {
             viewport_pan_anim: None,
             pan_dominant_until_ms: 0,
             exit_requested: false,
-
+            
+            bbox_loc: HashMap::new(),
+            
             spawn_cursor: 0,
             started_at: now,
             last_debug_dump_at: now,

--- a/crates/halley-wl/src/state/render_state.rs
+++ b/crates/halley-wl/src/state/render_state.rs
@@ -14,6 +14,10 @@ impl HalleyWlState {
         self.node_hover_mix.retain(|id, _| alive.contains(id));
     }
 
+    pub(crate) fn resize_static_active_for(&self, node_id: halley_core::field::NodeId, now_ms: u64) -> bool {
+        self.resize_static_node == Some(node_id) && now_ms < self.resize_static_until_ms
+    }
+
     pub fn smoothed_render_pos(&mut self, id: NodeId, logical: Vec2, now: Instant) -> Vec2 {
         if !self.tuning.physics_enabled {
             return logical;


### PR DESCRIPTION
Updated the input/focus path to pass resize preview context through the screen-rect and pointer-focus helpers so hit-testing can account for in-progress resize state.

What changed:
- added `resize_preview: Option<ResizeCtx>` to:
  - `active_node_screen_rect`
  - `active_node_surface_transform_screen_details`
  - `pointer_focus_for_screen`
- updated call sites in:
  - `input_events.rs`
  - `pointer_motion.rs`
  - `pointer_button.rs`
- passed the existing pointer-state resize context directly instead of rebuilding `ResizeCtx`

Also fixed the render-side borrow conflict in node size syncing:
- moved immutable state reads before `node_mut()` in `sync_node_size_from_surface()`
- eliminated the E0502 mutable/immutable borrow overlap

Notes:
- this commit fixes the resize-preview plumbing and borrow-checker issues only
- Firefox/video+docked-window redraw/input problems are still under investigation