### PR TITLE
refactor(focus): collapse dual-ring logic into a single focus-ring model

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 
-use halley_core::decay::RingDecayPolicy;
+use halley_core::decay::FocusRingDecayPolicy;
 use halley_core::field::Vec2;
-use halley_core::viewport::{EyeRing, FocusRings, Viewport};
+use halley_core::viewport::{FocusRing, Viewport};
 
 use super::{Keybinds, LaunchBinding};
 use crate::keybinds::evdev_to_key_name;
@@ -18,16 +18,14 @@ pub struct RuntimeTuning {
     pub viewport_center: Vec2,
     pub viewport_size: Vec2,
 
-    pub ring_primary_rx: f32,
-    pub ring_primary_ry: f32,
-    pub ring_secondary_rx: f32,
-    pub ring_secondary_ry: f32,
-    pub ring_rotation_rad: f32,
+    pub focus_ring_rx: f32,
+    pub focus_ring_ry: f32,
+    pub focus_ring_rotation_rad: f32,
 
     pub primary_hot_inner_frac: f32,
     pub primary_to_preview_ms: u64,
     pub primary_preview_to_node_ms: u64,
-    pub secondary_to_node_ms: u64,
+
     pub dev_enabled: bool,
     pub dev_show_geometry_overlay: bool,
     pub dev_zoom_decay_enabled: bool,
@@ -35,8 +33,10 @@ pub struct RuntimeTuning {
     pub dev_anim_enabled: bool,
     pub dev_anim_state_change_ms: u64,
     pub dev_anim_bounce: f32,
+
     pub cluster_distance_px: f32,
     pub cluster_dwell_ms: u64,
+
     pub non_overlap_gap_px: f32,
     pub non_overlap_active_gap_scale: f32,
     pub new_window_on_top: bool,
@@ -46,10 +46,12 @@ pub struct RuntimeTuning {
     pub center_window_to_mouse: bool,
     pub restore_last_active_on_pan_return: bool,
     pub physics_enabled: bool,
+
     pub keybinds: Keybinds,
     pub keybind_launch_command: String,
     pub launch_bindings: Vec<LaunchBinding>,
     pub quit_requires_shift: bool,
+
     pub tty_viewports: Vec<ViewportOutputConfig>,
     pub env: HashMap<String, String>,
 }
@@ -74,15 +76,15 @@ impl Default for RuntimeTuning {
                 x: 1920.0,
                 y: 1080.0,
             },
-            ring_primary_rx: 820.0,
-            ring_primary_ry: 420.0,
-            ring_secondary_rx: 920.0,
-            ring_secondary_ry: 460.0,
-            ring_rotation_rad: 0.0,
+
+            focus_ring_rx: 820.0,
+            focus_ring_ry: 420.0,
+            focus_ring_rotation_rad: 0.0,
+
             primary_hot_inner_frac: 0.88,
             primary_to_preview_ms: 1_200_000,
             primary_preview_to_node_ms: 60_000,
-            secondary_to_node_ms: 300_000,
+
             dev_enabled: false,
             dev_show_geometry_overlay: false,
             dev_zoom_decay_enabled: true,
@@ -90,8 +92,10 @@ impl Default for RuntimeTuning {
             dev_anim_enabled: true,
             dev_anim_state_change_ms: 360,
             dev_anim_bounce: 1.45,
+
             cluster_distance_px: 280.0,
             cluster_dwell_ms: 900,
+
             non_overlap_gap_px: 20.0,
             non_overlap_active_gap_scale: 0.22,
             new_window_on_top: true,
@@ -101,10 +105,12 @@ impl Default for RuntimeTuning {
             center_window_to_mouse: false,
             restore_last_active_on_pan_return: true,
             physics_enabled: true,
+
             keybinds: Keybinds::default(),
             keybind_launch_command: String::new(),
             launch_bindings: Vec::new(),
             quit_requires_shift: true,
+
             tty_viewports: Vec::new(),
             env: HashMap::from([
                 ("XCURSOR_THEME".to_string(), "Adwaita".to_string()),
@@ -142,7 +148,6 @@ impl RuntimeTuning {
             if value.is_empty() {
                 continue;
             }
-            // Runtime env controls are configured by trusted local config.
             unsafe { env::set_var(key, value) };
         }
     }
@@ -156,22 +161,23 @@ impl RuntimeTuning {
         self.viewport_size.x = self.viewport_size.x.clamp(320.0, 16_000.0);
         self.viewport_size.y = self.viewport_size.y.clamp(240.0, 16_000.0);
 
-        self.ring_primary_rx = self.ring_primary_rx.clamp(8.0, 16_000.0);
-        self.ring_primary_ry = self.ring_primary_ry.clamp(8.0, 16_000.0);
-        self.ring_secondary_rx = self.ring_secondary_rx.clamp(16.0, 16_000.0);
-        self.ring_secondary_ry = self.ring_secondary_ry.clamp(16.0, 16_000.0);
-        self.ring_rotation_rad = self
-            .ring_rotation_rad
+        self.focus_ring_rx = self.focus_ring_rx.clamp(8.0, 16_000.0);
+        self.focus_ring_ry = self.focus_ring_ry.clamp(8.0, 16_000.0);
+        self.focus_ring_rotation_rad = self
+            .focus_ring_rotation_rad
             .clamp(-std::f32::consts::PI, std::f32::consts::PI);
+
         self.primary_hot_inner_frac = self.primary_hot_inner_frac.clamp(0.1, 1.0);
         self.primary_to_preview_ms = self.primary_to_preview_ms.clamp(250, 7_200_000);
         self.primary_preview_to_node_ms = self.primary_preview_to_node_ms.clamp(250, 7_200_000);
-        self.secondary_to_node_ms = self.secondary_to_node_ms.clamp(250, 7_200_000);
+
         self.dev_zoom_decay_min_frac = self.dev_zoom_decay_min_frac.clamp(0.005, 0.5);
         self.dev_anim_state_change_ms = self.dev_anim_state_change_ms.clamp(30, 3_000);
         self.dev_anim_bounce = self.dev_anim_bounce.clamp(0.0, 3.0);
+
         self.cluster_distance_px = self.cluster_distance_px.clamp(24.0, 4_000.0);
         self.cluster_dwell_ms = self.cluster_dwell_ms.clamp(0, 30_000);
+
         self.non_overlap_gap_px = self.non_overlap_gap_px.clamp(0.0, 256.0);
         self.non_overlap_active_gap_scale = self.non_overlap_active_gap_scale.clamp(0.0, 1.2);
         self.non_overlap_bump_damping = self.non_overlap_bump_damping.clamp(0.05, 1.0);
@@ -186,25 +192,18 @@ impl RuntimeTuning {
         Viewport::new(self.viewport_center, self.viewport_size)
     }
 
-    pub fn rings(&self) -> FocusRings {
-        FocusRings {
-            primary: EyeRing::new(
-                self.ring_primary_rx,
-                self.ring_primary_ry,
-                self.ring_rotation_rad,
-            ),
-            secondary: EyeRing::new(
-                self.ring_secondary_rx,
-                self.ring_secondary_ry,
-                self.ring_rotation_rad,
-            ),
-        }
+    pub fn focus_ring(&self) -> FocusRing {
+        FocusRing::new(
+            self.focus_ring_rx,
+            self.focus_ring_ry,
+            self.focus_ring_rotation_rad,
+        )
     }
 
-    pub fn ring_decay_policy(&self) -> RingDecayPolicy {
-        let mut p = RingDecayPolicy::new(self.secondary_to_node_ms);
-        p.primary_to_preview_ms = self.primary_to_preview_ms;
-        p.primary_preview_to_node_ms = self.primary_preview_to_node_ms;
+    pub fn focus_ring_decay_policy(&self) -> FocusRingDecayPolicy {
+        let mut p = FocusRingDecayPolicy::new();
+        p.inside_to_preview_ms = self.primary_to_preview_ms;
+        p.preview_to_node_ms = self.primary_preview_to_node_ms;
         p
     }
 
@@ -242,12 +241,14 @@ fn default_config_path() -> PathBuf {
             return Path::new(trimmed).join("halley/halley.rune");
         }
     }
+
     if let Ok(home) = env::var("HOME") {
         let trimmed = home.trim();
         if !trimmed.is_empty() {
             return Path::new(trimmed).join(".config/halley/halley.rune");
         }
     }
+
     PathBuf::from("halley.rune")
 }
 

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -208,41 +208,36 @@ fn load_viewport_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 }
 
 fn load_focus_ring_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.ring_primary_rx = pick_f32(
+    out.focus_ring_rx = pick_f32(
         cfg,
-        &["focus-ring.primary-rx", "focus-ring.primary_rx"],
-        out.ring_primary_rx,
+        &["focus-ring.rx", "focus-ring.radius-x", "focus-ring.radius_x"],
+        out.focus_ring_rx,
     );
-    out.ring_primary_ry = pick_f32(
+    out.focus_ring_ry = pick_f32(
         cfg,
-        &["focus-ring.primary-ry", "focus-ring.primary_ry"],
-        out.ring_primary_ry,
+        &["focus-ring.ry", "focus-ring.radius-y", "focus-ring.radius_y"],
+        out.focus_ring_ry,
     );
-
-    out.ring_secondary_rx = pick_f32(
-        cfg,
-        &["focus-ring.secondary-rx", "focus-ring.secondary_rx"],
-        out.ring_secondary_rx,
-    );
-    out.ring_secondary_ry = pick_f32(
-        cfg,
-        &["focus-ring.secondary-ry", "focus-ring.secondary_ry"],
-        out.ring_secondary_ry,
-    );
-    out.ring_rotation_rad = pick_f32(
+    out.focus_ring_rotation_rad = pick_f32(
         cfg,
         &["focus-ring.rotation-rad", "focus-ring.rotation_rad"],
-        out.ring_rotation_rad,
+        out.focus_ring_rotation_rad,
+    );
+
+    // Transitional compatibility with the older config shape.
+    out.focus_ring_rx = pick_f32(
+        cfg,
+        &["focus-ring.primary-rx", "focus-ring.primary_rx"],
+        out.focus_ring_rx,
+    );
+    out.focus_ring_ry = pick_f32(
+        cfg,
+        &["focus-ring.primary-ry", "focus-ring.primary_ry"],
+        out.focus_ring_ry,
     );
 }
 
 fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.secondary_to_node_ms = pick_u64(
-        cfg,
-        &["nodes.collapse-delay", "nodes.collapse_delay"],
-        out.secondary_to_node_ms,
-    );
-
     out.primary_to_preview_ms = pick_u64(
         cfg,
         &[

--- a/crates/halley-core/src/decay.rs
+++ b/crates/halley-core/src/decay.rs
@@ -1,6 +1,5 @@
 use crate::field::{Field, NodeId, NodeKind, Vec2};
-
-use crate::viewport::{FocusRings, RingZone, Viewport};
+use crate::viewport::{FocusRing, FocusZone, Viewport};
 
 #[cfg(test)]
 use crate::field::NodeState;
@@ -36,7 +35,6 @@ impl DecayPolicy {
 pub fn tick_decay(field: &mut Field, now_ms: u64, policy: DecayPolicy, focused: Option<NodeId>) {
     debug_assert!(policy.node_after_ms >= policy.preview_after_ms);
 
-    // Collect ids first to avoid borrow fights.
     let ids: Vec<NodeId> = field.nodes().keys().copied().collect();
 
     for id in ids {
@@ -64,58 +62,47 @@ pub fn tick_decay(field: &mut Field, now_ms: u64, policy: DecayPolicy, focused: 
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct RingDecayPolicy {
-    /// In the Primary ring:
-    /// - age < primary_to_preview_ms => Hot/Active
-    /// - age < primary_to_preview_ms + primary_preview_to_node_ms => Warm/Preview
+pub struct FocusRingDecayPolicy {
+    /// Inside the focus ring:
+    /// - age < inside_to_preview_ms => Hot/Active
+    /// - age < inside_to_preview_ms + preview_to_node_ms => Warm/Preview
     /// - otherwise => Cold/Node
-    pub primary_to_preview_ms: u64,
+    pub inside_to_preview_ms: u64,
 
-    /// Additional time spent in Preview before Node once primary_to_preview_ms is reached.
-    pub primary_preview_to_node_ms: u64,
+    /// Additional time spent in Preview before Node once inside_to_preview_ms is reached.
+    pub preview_to_node_ms: u64,
 
-    /// When in Secondary ring:
-    /// - immediately Warm
-    pub secondary_preview: bool,
-
-    /// When in Secondary ring and age >= secondary_to_node_ms => Cold
-    pub secondary_to_node_ms: u64,
-
-    /// When Outside secondary ring => immediately Cold
+    /// Outside the focus ring:
+    /// - if true => immediately Cold/Node
     pub outside_immediate_cold: bool,
 }
 
-impl RingDecayPolicy {
-    pub fn new(secondary_to_node_ms: u64) -> Self {
+impl FocusRingDecayPolicy {
+    pub fn new() -> Self {
         Self {
-            primary_to_preview_ms: 1_200_000,
-            primary_preview_to_node_ms: 60_000,
-            secondary_preview: true,
-            secondary_to_node_ms,
+            inside_to_preview_ms: 1_200_000,
+            preview_to_node_ms: 60_000,
             outside_immediate_cold: true,
         }
     }
 }
 
-/// Ring-aware decay:
-/// - Primary ring: Hot, then Preview, then Node based on primary timers
-/// - Secondary ring: Warm immediately; after secondary_to_node_ms => Cold
-/// - Outside: Cold immediately
+/// Focus-ring-aware decay:
+/// - Inside focus ring: Hot, then Preview, then Node based on timers
+/// - Outside focus ring: Cold immediately
 /// - Focused node: Hot
 /// - Core nodes do not decay
-pub fn tick_decay_rings(
+pub fn tick_decay_focus_ring(
     field: &mut Field,
     vp: &Viewport,
     now_ms: u64,
-    rings: FocusRings,
-    policy: RingDecayPolicy,
+    focus_ring: FocusRing,
+    policy: FocusRingDecayPolicy,
     focused: Option<NodeId>,
 ) {
-    // Collect ids first to avoid borrow fights.
     let ids: Vec<NodeId> = field.nodes().keys().copied().collect();
 
     for id in ids {
-        // Copy the pieces we need, then release the immutable borrow before mutating.
         let (kind, pos, intrinsic_size, last_touch_ms) = {
             let Some(n) = field.node(id) else { continue };
             (n.kind.clone(), n.pos, n.intrinsic_size, n.last_touch_ms)
@@ -130,13 +117,14 @@ pub fn tick_decay_rings(
             continue;
         }
 
-        let zone = dominant_ring_zone(rings, vp.center, pos, intrinsic_size);
+        let zone = dominant_focus_zone(focus_ring, vp.center, pos, intrinsic_size);
 
         match zone {
-            RingZone::Primary => {
+            FocusZone::Inside => {
                 let age = now_ms.saturating_sub(last_touch_ms);
-                let to_preview = policy.primary_to_preview_ms;
-                let to_node = to_preview.saturating_add(policy.primary_preview_to_node_ms);
+                let to_preview = policy.inside_to_preview_ms;
+                let to_node = to_preview.saturating_add(policy.preview_to_node_ms);
+
                 if age >= to_node {
                     field.set_decay_level(id, DecayLevel::Cold);
                 } else if age >= to_preview {
@@ -145,46 +133,47 @@ pub fn tick_decay_rings(
                     field.set_decay_level(id, DecayLevel::Hot);
                 }
             }
-            RingZone::Secondary => {
-                // Warm immediately (or Hot if configured)
-                if policy.secondary_preview {
-                    field.set_decay_level(id, DecayLevel::Warm);
-                } else {
-                    field.set_decay_level(id, DecayLevel::Hot);
-                }
-
-                let age = now_ms.saturating_sub(last_touch_ms);
-                if age >= policy.secondary_to_node_ms {
-                    field.set_decay_level(id, DecayLevel::Cold);
-                }
-            }
-            RingZone::Outside => {
+            FocusZone::Outside => {
                 if policy.outside_immediate_cold {
                     field.set_decay_level(id, DecayLevel::Cold);
                 } else {
-                    field.set_decay_level(id, DecayLevel::Cold);
+                    let age = now_ms.saturating_sub(last_touch_ms);
+                    let to_preview = policy.inside_to_preview_ms;
+                    let to_node = to_preview.saturating_add(policy.preview_to_node_ms);
+
+                    if age >= to_node {
+                        field.set_decay_level(id, DecayLevel::Cold);
+                    } else if age >= to_preview {
+                        field.set_decay_level(id, DecayLevel::Warm);
+                    } else {
+                        field.set_decay_level(id, DecayLevel::Hot);
+                    }
                 }
             }
         }
     }
 }
 
-fn dominant_ring_zone(rings: FocusRings, vp_center: Vec2, pos: Vec2, footprint: Vec2) -> RingZone {
+fn dominant_focus_zone(
+    focus_ring: FocusRing,
+    vp_center: Vec2,
+    pos: Vec2,
+    footprint: Vec2,
+) -> FocusZone {
     // Approximate "where the window mostly is" using a small deterministic sample grid.
     // Majority semantics:
-    // - >50% in primary => Primary
-    // - else >50% inside secondary (primary+secondary) => Secondary
-    // - else => Outside
+    // - >50% inside => Inside
+    // - otherwise => Outside
     let w = footprint.x.abs();
     let h = footprint.y.abs();
+
     if w < 1.0 || h < 1.0 {
-        return rings.zone(vp_center, pos);
+        return focus_ring.zone(vp_center, pos);
     }
 
     let sx = 5usize;
     let sy = 5usize;
-    let mut c_primary = 0usize;
-    let mut c_secondary = 0usize;
+    let mut inside = 0usize;
 
     let min_x = pos.x - w * 0.5;
     let min_y = pos.y - h * 0.5;
@@ -197,24 +186,20 @@ fn dominant_ring_zone(rings: FocusRings, vp_center: Vec2, pos: Vec2, footprint: 
                 x: min_x + tx * w,
                 y: min_y + ty * h,
             };
-            match rings.zone(vp_center, p) {
-                RingZone::Primary => c_primary += 1,
-                RingZone::Secondary => c_secondary += 1,
-                RingZone::Outside => {}
+
+            if focus_ring.zone(vp_center, p) == FocusZone::Inside {
+                inside += 1;
             }
         }
     }
 
     let total = (sx * sy) as f32;
-    let p_primary = c_primary as f32 / total;
-    let p_inside_secondary = (c_primary + c_secondary) as f32 / total;
+    let frac_inside = inside as f32 / total;
 
-    if p_primary > 0.5 {
-        RingZone::Primary
-    } else if p_inside_secondary > 0.5 {
-        RingZone::Secondary
+    if frac_inside > 0.5 {
+        FocusZone::Inside
     } else {
-        RingZone::Outside
+        FocusZone::Outside
     }
 }
 
@@ -222,13 +207,9 @@ fn dominant_ring_zone(rings: FocusRings, vp_center: Vec2, pos: Vec2, footprint: 
 mod tests {
     use super::*;
     use crate::field::Vec2;
-    use crate::viewport::{EyeRing, FocusRings};
 
-    fn default_rings() -> FocusRings {
-        FocusRings {
-            primary: EyeRing::new(50.0, 30.0, 0.0),
-            secondary: EyeRing::new(200.0, 120.0, 0.0),
-        }
+    fn default_focus_ring() -> FocusRing {
+        FocusRing::new(50.0, 30.0, 0.0)
     }
 
     #[test]
@@ -282,111 +263,86 @@ mod tests {
     }
 
     #[test]
-    fn primary_ring_never_decays() {
+    fn inside_focus_ring_near_center_stays_hot() {
         let mut f = Field::new();
         let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let policy = RingDecayPolicy::new(5 * 60 * 1000);
+        let ring = default_focus_ring();
+        let policy = FocusRingDecayPolicy::new();
 
-        tick_decay_rings(&mut f, &vp, 999_999, rings, policy, None);
+        tick_decay_focus_ring(&mut f, &vp, 999_999, ring, policy, None);
 
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
         assert_eq!(f.node(a).unwrap().state, NodeState::Active);
     }
 
     #[test]
-    fn near_primary_edge_defaults_to_preview() {
+    fn inside_focus_ring_can_decay_to_preview() {
         let mut f = Field::new();
-        // default_rings().primary radius_x is 50; x=49 is barely inside.
         let a = f.spawn_surface("A", Vec2 { x: 49.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let policy = RingDecayPolicy::new(5_000);
+        let ring = default_focus_ring();
+        let mut policy = FocusRingDecayPolicy::new();
+        policy.inside_to_preview_ms = 1000;
+        policy.preview_to_node_ms = 5000;
 
-        tick_decay_rings(&mut f, &vp, 1_000, rings, policy, None);
+        tick_decay_focus_ring(&mut f, &vp, 1500, ring, policy, None);
+
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Warm);
         assert_eq!(f.node(a).unwrap().state, NodeState::Preview);
     }
 
     #[test]
-    fn majority_secondary_beats_center_inside_primary() {
+    fn inside_focus_ring_can_decay_to_node() {
         let mut f = Field::new();
-        // Center is just inside primary ring (x=49 in rx=50),
-        // but wide footprint puts most samples in secondary.
-        let a = f.spawn_surface("A", Vec2 { x: 49.0, y: 0.0 }, Vec2 { x: 200.0, y: 40.0 });
+        let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let mut policy = RingDecayPolicy::new(5_000);
-        policy.primary_hot_inner_frac = 1.0; // disable inner hot cut to isolate zone classification
+        let ring = default_focus_ring();
+        let mut policy = FocusRingDecayPolicy::new();
+        policy.inside_to_preview_ms = 1000;
+        policy.preview_to_node_ms = 5000;
 
-        tick_decay_rings(&mut f, &vp, 1_000, rings, policy, None);
-        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Warm);
-        assert_eq!(f.node(a).unwrap().state, NodeState::Preview);
-    }
+        tick_decay_focus_ring(&mut f, &vp, 7000, ring, policy, None);
 
-    #[test]
-    fn mostly_outside_secondary_goes_node_immediately() {
-        let mut f = Field::new();
-        // Only a small left slice is inside secondary; most of area is outside.
-        let a = f.spawn_surface("A", Vec2 { x: 210.0, y: 0.0 }, Vec2 { x: 80.0, y: 80.0 });
-        assert!(f.touch(a, 0));
-
-        let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let policy = RingDecayPolicy::new(5_000);
-
-        tick_decay_rings(&mut f, &vp, 1_000, rings, policy, None);
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Cold);
         assert_eq!(f.node(a).unwrap().state, NodeState::Node);
     }
 
     #[test]
-    fn secondary_ring_goes_preview_then_node_after_threshold() {
+    fn outside_focus_ring_goes_cold_immediately() {
         let mut f = Field::new();
-        // Place in secondary ring but outside primary.
-        let a = f.spawn_surface("A", Vec2 { x: 100.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
+        let a = f.spawn_surface("A", Vec2 { x: 500.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let policy = RingDecayPolicy::new(5_000);
+        let ring = default_focus_ring();
+        let policy = FocusRingDecayPolicy::new();
 
-        tick_decay_rings(&mut f, &vp, 1_000, rings, policy, None);
-        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Warm);
-        assert_eq!(f.node(a).unwrap().state, NodeState::Preview);
+        tick_decay_focus_ring(&mut f, &vp, 1000, ring, policy, None);
 
-        tick_decay_rings(&mut f, &vp, 6_000, rings, policy, None);
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Cold);
         assert_eq!(f.node(a).unwrap().state, NodeState::Node);
     }
 
     #[test]
-    fn outside_secondary_immediately_cold() {
+    fn focused_node_stays_hot_with_focus_ring_policy() {
         let mut f = Field::new();
-        let a = f.spawn_surface(
-            "A",
-            Vec2 {
-                x: 10_000.0,
-                y: 0.0,
-            },
-            Vec2 { x: 10.0, y: 10.0 },
-        );
+        let a = f.spawn_surface("A", Vec2 { x: 500.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
-        let rings = default_rings();
-        let policy = RingDecayPolicy::new(5_000);
+        let ring = default_focus_ring();
+        let policy = FocusRingDecayPolicy::new();
 
-        tick_decay_rings(&mut f, &vp, 1_000, rings, policy, None);
+        tick_decay_focus_ring(&mut f, &vp, 999_999, ring, policy, Some(a));
 
-        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Cold);
-        assert_eq!(f.node(a).unwrap().state, NodeState::Node);
+        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
+        assert_eq!(f.node(a).unwrap().state, NodeState::Active);
     }
 }

--- a/crates/halley-core/src/viewport.rs
+++ b/crates/halley-core/src/viewport.rs
@@ -62,30 +62,28 @@ impl Viewport {
     }
 }
 
-/// Which focus-ring zone a point is in (relative to a viewport center).
+/// Which focus zone a point is in (relative to a viewport center).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RingZone {
-    Primary,
-    Secondary,
+pub enum FocusZone {
+    Inside,
     Outside,
 }
 
-/// An "eye ring" modeled as a rotated ellipse in Field coordinates.
+/// A focus ring modeled as a rotated ellipse in Field coordinates.
 ///
 /// We use normalized ellipse distance:
 ///   d2 = (x'/rx)^2 + (y'/ry)^2
 /// If d2 <= 1 => inside.
 ///
-/// This is deterministic, cheap, and gives you the "eye" vibe via ellipse + rotation.
-/// If you later want a truer eye shape, you can replace just `contains()`.
+/// This is deterministic, cheap, and keeps the current ellipse/eye-like model.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EyeRing {
+pub struct FocusRing {
     pub radius_x: f32,
     pub radius_y: f32,
     pub rotation_rad: f32,
 }
 
-impl EyeRing {
+impl FocusRing {
     pub fn new(radius_x: f32, radius_y: f32, rotation_rad: f32) -> Self {
         Self {
             radius_x,
@@ -98,6 +96,14 @@ impl EyeRing {
         self.normalized_distance2(center, p) <= 1.0
     }
 
+    pub fn zone(&self, vp_center: Vec2, p: Vec2) -> FocusZone {
+        if self.contains(vp_center, p) {
+            FocusZone::Inside
+        } else {
+            FocusZone::Outside
+        }
+    }
+
     /// Return normalized squared distance inside this ellipse:
     /// d2 = (x'/rx)^2 + (y'/ry)^2
     /// - d2 <= 1.0: inside/on boundary
@@ -108,8 +114,7 @@ impl EyeRing {
 
         let (s, c) = self.rotation_rad.sin_cos();
 
-        // Rotate into ring-local space.
-        // (x, y) = R(-rot) * (dx, dy)
+        // Rotate into focus-ring-local space.
         let x = c * dx + s * dy;
         let y = -s * dx + c * dy;
 
@@ -120,24 +125,6 @@ impl EyeRing {
         let ny = y / ry;
 
         nx * nx + ny * ny
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct FocusRings {
-    pub primary: EyeRing,
-    pub secondary: EyeRing,
-}
-
-impl FocusRings {
-    pub fn zone(&self, vp_center: Vec2, p: Vec2) -> RingZone {
-        if self.primary.contains(vp_center, p) {
-            RingZone::Primary
-        } else if self.secondary.contains(vp_center, p) {
-            RingZone::Secondary
-        } else {
-            RingZone::Outside
-        }
     }
 }
 
@@ -167,28 +154,24 @@ mod tests {
     }
 
     #[test]
-    fn eye_ring_contains_axis_aligned() {
-        let ring = EyeRing::new(10.0, 5.0, 0.0);
+    fn focus_ring_contains_axis_aligned() {
+        let ring = FocusRing::new(10.0, 5.0, 0.0);
         let c = Vec2 { x: 0.0, y: 0.0 };
 
         assert!(ring.contains(c, Vec2 { x: 0.0, y: 0.0 }));
-        assert!(ring.contains(c, Vec2 { x: 10.0, y: 0.0 })); // on edge
-        assert!(ring.contains(c, Vec2 { x: 0.0, y: 5.0 })); // on edge
+        assert!(ring.contains(c, Vec2 { x: 10.0, y: 0.0 }));
+        assert!(ring.contains(c, Vec2 { x: 0.0, y: 5.0 }));
 
         assert!(!ring.contains(c, Vec2 { x: 10.01, y: 0.0 }));
         assert!(!ring.contains(c, Vec2 { x: 0.0, y: 5.01 }));
     }
 
     #[test]
-    fn focus_rings_zone_classifies() {
-        let rings = FocusRings {
-            primary: EyeRing::new(10.0, 10.0, 0.0),
-            secondary: EyeRing::new(50.0, 50.0, 0.0),
-        };
+    fn focus_zone_classifies() {
+        let ring = FocusRing::new(10.0, 10.0, 0.0);
         let c = Vec2 { x: 0.0, y: 0.0 };
 
-        assert_eq!(rings.zone(c, Vec2 { x: 0.0, y: 0.0 }), RingZone::Primary);
-        assert_eq!(rings.zone(c, Vec2 { x: 20.0, y: 0.0 }), RingZone::Secondary);
-        assert_eq!(rings.zone(c, Vec2 { x: 100.0, y: 0.0 }), RingZone::Outside);
+        assert_eq!(ring.zone(c, Vec2 { x: 0.0, y: 0.0 }), FocusZone::Inside);
+        assert_eq!(ring.zone(c, Vec2 { x: 20.0, y: 0.0 }), FocusZone::Outside);
     }
 }

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -4,11 +4,11 @@ use std::time::Instant;
 use eventline::{info, warn};
 
 use super::input_utils::{key_matches, key_matches_xkb_only, modifier_active};
-use halley_config::RuntimeTuning;
 use crate::interaction::actions::{minimize_focused_active_node, move_latest_node};
 use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
 use crate::state::HalleyWlState;
+use halley_config::RuntimeTuning;
 
 pub(crate) fn apply_bound_key(
     st: &mut HalleyWlState,
@@ -19,7 +19,9 @@ pub(crate) fn apply_bound_key(
 ) -> bool {
     const STEP_RX: f32 = 24.0;
     const STEP_RY: f32 = 16.0;
+    const STEP_ROT: f32 = 0.05;
     const STEP_NODE: f32 = 80.0;
+
     let kb = st.tuning.keybinds.clone();
     if key_matches(key_code, kb.quit_compositor) {
         if modifier_active(mods, kb.modifier) && (!st.tuning.quit_requires_shift || mods.shift_down)
@@ -31,8 +33,6 @@ pub(crate) fn apply_bound_key(
         return false;
     }
 
-    // Custom launch bindings can define their own modifiers; do not gate these
-    // behind the global keybind modifier.
     for binding in st.tuning.launch_bindings.clone() {
         if key_matches(key_code, binding.key) && modifier_active(mods, binding.modifiers) {
             return spawn_command(binding.command.as_str(), wayland_display, "command");
@@ -47,10 +47,7 @@ pub(crate) fn apply_bound_key(
         let next = RuntimeTuning::load_from_path(config_path);
         st.apply_tuning(next);
         info!("manual config reload from {}", config_path);
-        info!(
-            "resolved keybinds: {}",
-            st.tuning.keybinds_resolved_summary()
-        );
+        info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
         return true;
     }
     if key_matches(key_code, kb.minimize_focused) {
@@ -66,7 +63,6 @@ pub(crate) fn apply_bound_key(
     }
 
     let changed = match key_code {
-        // Keep window movement keys highest priority in dev mode.
         code if key_matches(code, kb.move_left) => {
             move_latest_node(st, -STEP_NODE, 0.0);
             true
@@ -83,36 +79,43 @@ pub(crate) fn apply_bound_key(
             move_latest_node(st, 0.0, -STEP_NODE);
             true
         }
+
+        // Primary dev tuning: ring radii
         code if key_matches(code, kb.primary_left) => {
-            st.tuning.ring_primary_rx -= STEP_RX;
+            st.tuning.focus_ring_rx -= STEP_RX;
             true
         }
         code if key_matches(code, kb.primary_right) => {
-            st.tuning.ring_primary_rx += STEP_RX;
+            st.tuning.focus_ring_rx += STEP_RX;
             true
         }
         code if key_matches(code, kb.primary_up) => {
-            st.tuning.ring_primary_ry += STEP_RY;
+            st.tuning.focus_ring_ry += STEP_RY;
             true
         }
         code if key_matches(code, kb.primary_down) => {
-            st.tuning.ring_primary_ry -= STEP_RY;
+            st.tuning.focus_ring_ry -= STEP_RY;
             true
         }
+
+        // Secondary dev tuning repurposed for single-ring testing:
+        // horizontal = rotation, vertical = uniform scale.
         code if key_matches(code, kb.secondary_left) => {
-            st.tuning.ring_secondary_rx -= STEP_RX;
+            st.tuning.focus_ring_rotation_rad -= STEP_ROT;
             true
         }
         code if key_matches(code, kb.secondary_right) => {
-            st.tuning.ring_secondary_rx += STEP_RX;
+            st.tuning.focus_ring_rotation_rad += STEP_ROT;
             true
         }
         code if key_matches(code, kb.secondary_up) => {
-            st.tuning.ring_secondary_ry += STEP_RY;
+            st.tuning.focus_ring_rx += STEP_RX;
+            st.tuning.focus_ring_ry += STEP_RY;
             true
         }
         code if key_matches(code, kb.secondary_down) => {
-            st.tuning.ring_secondary_ry -= STEP_RY;
+            st.tuning.focus_ring_rx -= STEP_RX;
+            st.tuning.focus_ring_ry -= STEP_RY;
             true
         }
         _ => false,
@@ -121,12 +124,10 @@ pub(crate) fn apply_bound_key(
     if changed {
         st.tuning.enforce_guards();
         info!(
-            "rings primary={:.0}x{:.0} secondary={:.0}x{:.0} rot={:.2}",
-            st.tuning.ring_primary_rx,
-            st.tuning.ring_primary_ry,
-            st.tuning.ring_secondary_rx,
-            st.tuning.ring_secondary_ry,
-            st.tuning.ring_rotation_rad
+            "focus-ring {:.0}x{:.0} rot={:.2}",
+            st.tuning.focus_ring_rx,
+            st.tuning.focus_ring_ry,
+            st.tuning.focus_ring_rotation_rad
         );
     }
 
@@ -134,7 +135,6 @@ pub(crate) fn apply_bound_key(
 }
 
 fn spawn_command(command: &str, wayland_display: &str, label: &str) -> bool {
-    // On-demand xwayland: launcher/spawn activity can request the satellite.
     request_xwayland_start();
     match Command::new("sh")
         .arg("-lc")

--- a/crates/halley-wl/src/interaction/actions.rs
+++ b/crates/halley-wl/src/interaction/actions.rs
@@ -1,6 +1,7 @@
 use crate::state::HalleyWlState;
 use eventline::info;
 use halley_core::decay::DecayLevel;
+use halley_core::viewport::FocusZone;
 use std::time::Instant;
 
 pub(crate) fn promote_node_level(
@@ -24,10 +25,10 @@ pub(crate) fn promote_node_level(
         .dock_partner(node_id)
         .filter(|&pid| st.dock_partner(pid) == Some(node_id));
 
-    let in_primary = st.active_rings().zone(st.viewport.center, target_pos)
-        == halley_core::viewport::RingZone::Primary;
+    let in_focus_ring =
+        st.active_focus_ring().zone(st.viewport.center, target_pos) == FocusZone::Inside;
 
-    if in_primary {
+    if in_focus_ring {
         let _ = st.field.set_decay_level(node_id, DecayLevel::Hot);
         st.mark_active_transition(node_id, now, 360);
 
@@ -47,7 +48,7 @@ pub(crate) fn promote_node_level(
         return true;
     }
 
-    // Out of primary: pan to center. Set restore target to this node so
+    // Out of the focus ring: pan to center. Set restore target to this node so
     // when it arrives both it and its partner will reopen via
     // restore_pan_return_active_focus (which already handles the pair).
     st.set_interaction_focus(Some(node_id), 30_000, now);

--- a/crates/halley-wl/src/render.rs
+++ b/crates/halley-wl/src/render.rs
@@ -1,12 +1,11 @@
 use glam::{Vec2, Vec4};
 use halley_core::field::Field;
-use halley_core::viewport::{FocusRings, RingZone, Viewport};
+use halley_core::viewport::{FocusRing, FocusZone, Viewport};
 
 #[derive(Clone, Copy, Debug)]
 pub struct DebugPalette {
     pub clear: Vec4,
-    pub ring_primary: Vec4,
-    pub ring_secondary: Vec4,
+    pub focus_ring: Vec4,
     pub node_active: Vec4,
     pub node_preview: Vec4,
     pub node_cold: Vec4,
@@ -16,8 +15,7 @@ impl Default for DebugPalette {
     fn default() -> Self {
         Self {
             clear: Vec4::new(0.04, 0.05, 0.06, 1.0),
-            ring_primary: Vec4::new(0.15, 0.85, 0.85, 0.75),
-            ring_secondary: Vec4::new(0.85, 0.65, 0.15, 0.55),
+            focus_ring: Vec4::new(0.15, 0.85, 0.85, 0.75),
             node_active: Vec4::new(0.25, 0.95, 0.35, 1.0),
             node_preview: Vec4::new(0.95, 0.85, 0.25, 0.95),
             node_cold: Vec4::new(0.65, 0.70, 0.78, 0.9),
@@ -35,8 +33,7 @@ pub struct RingDebugGeom {
 
 #[derive(Clone, Debug, Default)]
 pub struct ZoneCounts {
-    pub primary: usize,
-    pub secondary: usize,
+    pub inside: usize,
     pub outside: usize,
 }
 
@@ -44,15 +41,14 @@ pub struct ZoneCounts {
 pub struct DebugScene {
     pub viewport_center: Vec2,
     pub viewport_size: Vec2,
-    pub primary_ring: RingDebugGeom,
-    pub secondary_ring: RingDebugGeom,
+    pub focus_ring: RingDebugGeom,
     pub node_count_visible: usize,
     pub zones: ZoneCounts,
 }
 
 /// Minimal render-facing snapshot for upcoming debug drawing.
 /// This is intentionally independent from smithay backend wiring.
-pub fn build_debug_scene(field: &Field, vp: &Viewport, rings: FocusRings) -> DebugScene {
+pub fn build_debug_scene(field: &Field, vp: &Viewport, focus_ring: FocusRing) -> DebugScene {
     let mut zones = ZoneCounts::default();
     let mut visible = 0usize;
 
@@ -61,27 +57,20 @@ pub fn build_debug_scene(field: &Field, vp: &Viewport, rings: FocusRings) -> Deb
             continue;
         }
         visible += 1;
-        match rings.zone(vp.center, node.pos) {
-            RingZone::Primary => zones.primary += 1,
-            RingZone::Secondary => zones.secondary += 1,
-            RingZone::Outside => zones.outside += 1,
+        match focus_ring.zone(vp.center, node.pos) {
+            FocusZone::Inside => zones.inside += 1,
+            FocusZone::Outside => zones.outside += 1,
         }
     }
 
     DebugScene {
         viewport_center: Vec2::new(vp.center.x, vp.center.y),
         viewport_size: Vec2::new(vp.size.x, vp.size.y),
-        primary_ring: RingDebugGeom {
+        focus_ring: RingDebugGeom {
             center: Vec2::new(vp.center.x, vp.center.y),
-            radius_x: rings.primary.radius_x,
-            radius_y: rings.primary.radius_y,
-            rotation_rad: rings.primary.rotation_rad,
-        },
-        secondary_ring: RingDebugGeom {
-            center: Vec2::new(vp.center.x, vp.center.y),
-            radius_x: rings.secondary.radius_x,
-            radius_y: rings.secondary.radius_y,
-            rotation_rad: rings.secondary.rotation_rad,
+            radius_x: focus_ring.radius_x,
+            radius_y: focus_ring.radius_y,
+            rotation_rad: focus_ring.rotation_rad,
         },
         node_count_visible: visible,
         zones,
@@ -113,10 +102,10 @@ impl Default for GpuBootstrap {
 mod tests {
     use super::*;
     use halley_core::field::{Field, Vec2};
-    use halley_core::viewport::EyeRing;
+    use halley_core::viewport::FocusRing;
 
     #[test]
-    fn scene_counts_visible_nodes_by_ring_zone() {
+    fn scene_counts_visible_nodes_by_focus_zone() {
         let mut f = Field::new();
         let _a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         let _b = f.spawn_surface("B", Vec2 { x: 500.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
@@ -130,15 +119,11 @@ mod tests {
                 y: 1080.0,
             },
         );
-        let rings = FocusRings {
-            primary: EyeRing::new(200.0, 120.0, 0.0),
-            secondary: EyeRing::new(1200.0, 700.0, 0.0),
-        };
+        let focus_ring = FocusRing::new(200.0, 120.0, 0.0);
 
-        let s = build_debug_scene(&f, &vp, rings);
+        let s = build_debug_scene(&f, &vp, focus_ring);
         assert_eq!(s.node_count_visible, 2);
-        assert_eq!(s.zones.primary, 1);
-        assert_eq!(s.zones.secondary, 1);
-        assert_eq!(s.zones.outside, 0);
+        assert_eq!(s.zones.inside, 1);
+        assert_eq!(s.zones.outside, 1);
     }
 }

--- a/crates/halley-wl/src/runtime_render/frame_render.rs
+++ b/crates/halley-wl/src/runtime_render/frame_render.rs
@@ -25,10 +25,6 @@ use super::node_render::{
 };
 use super::render_utils::{draw_outline_rect, draw_rect, draw_ring};
 
-// ---------------------------------------------------------------------------
-// Winit entry point
-// ---------------------------------------------------------------------------
-
 pub(crate) fn draw_debug_frame(
     backend: &mut WinitGraphicsBackend<GlesRenderer>,
     st: &mut HalleyWlState,
@@ -50,18 +46,12 @@ pub(crate) fn draw_debug_frame(
             preview_hover_node,
             None,
             None,
-            // Winit cursor/input coordinates share screen-space with the
-            // framebuffer, so no transform is needed.
             Transform::Normal,
         )?;
     }
     backend.submit(Some(&[damage]))?;
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Backend-agnostic render path
-// ---------------------------------------------------------------------------
 
 pub(crate) fn draw_debug_frame_to_target(
     renderer: &mut GlesRenderer,
@@ -78,13 +68,9 @@ pub(crate) fn draw_debug_frame_to_target(
     let damage = Rectangle::<i32, Physical>::from_size(size);
     let now = Instant::now();
 
-    // Keep animator tracks synced so state transitions interpolate immediately.
     st.tick_animator_frame(now);
     st.begin_render_frame(now);
 
-    // ------------------------------------------------------------------
-    // 1. Collect active Wayland surface elements
-    // ------------------------------------------------------------------
     let (
         active_elements,
         node_surface_map,
@@ -94,9 +80,6 @@ pub(crate) fn draw_debug_frame_to_target(
         overlap_overlay_rects,
     ) = collect_active_surfaces(renderer, st, size, resize_preview, now);
 
-    // ------------------------------------------------------------------
-    // 2. Collect hover-preview elements
-    // ------------------------------------------------------------------
     let hovered_preview_id = preview_hover_node.and_then(|id| {
         st.field.node(id).and_then(|n| {
             (node_in_active_area(st, id)
@@ -117,9 +100,6 @@ pub(crate) fn draw_debug_frame_to_target(
         now,
     );
 
-    // ------------------------------------------------------------------
-    // 3. Collect cursor surface elements
-    // ------------------------------------------------------------------
     let cursor_status = cursor_image
         .cloned()
         .unwrap_or_else(smithay::input::pointer::CursorImageStatus::default_named);
@@ -136,9 +116,6 @@ pub(crate) fn draw_debug_frame_to_target(
             render_elements_from_surface_tree(renderer, &surface, loc, 1.0, 1.0, Kind::Unspecified);
     }
 
-    // ------------------------------------------------------------------
-    // 4. Snapshot node list before the mutable frame borrow
-    // ------------------------------------------------------------------
     let render_nodes: Vec<NodeSnapshot> = st
         .field
         .nodes()
@@ -157,13 +134,9 @@ pub(crate) fn draw_debug_frame_to_target(
         })
         .collect();
 
-    // ------------------------------------------------------------------
-    // 5. Draw
-    // ------------------------------------------------------------------
     let mut frame = renderer.render(framebuffer, size, frame_transform)?;
     frame.clear(Color32F::new(0.04, 0.05, 0.06, 1.0), &[damage])?;
 
-    // Active window borders
     for rect in &border_rects {
         let color = if rect.focused {
             Color32F::new(0.22, 0.82, 0.92, 1.0)
@@ -183,12 +156,10 @@ pub(crate) fn draw_debug_frame_to_target(
         )?;
     }
 
-    // Active windows
     if !active_elements.is_empty() {
         let _ = draw_render_elements(&mut frame, 1.0, &active_elements, &[damage]);
     }
 
-    // Overlap tint for windows behind the resize target
     for (x, y, w, h) in overlap_overlay_rects {
         draw_rect(
             &mut frame,
@@ -210,7 +181,6 @@ pub(crate) fn draw_debug_frame_to_target(
         )?;
     }
 
-    // Dev geometry overlay
     if st.tuning.dev_enabled && st.tuning.dev_show_geometry_overlay {
         for (x, y, w, h, color) in overlay_rects {
             draw_outline_rect(&mut frame, x, y, w, h, color, damage)?;
@@ -220,10 +190,8 @@ pub(crate) fn draw_debug_frame_to_target(
         }
     }
 
-    // Node markers / proxy thumbnails
     draw_node_markers(&mut frame, st, size, &render_nodes, hover_node, damage, now)?;
 
-    // Hover preview window
     if let Some((px, py, pw, ph)) = hover_preview_rect {
         if !hover_preview_elements.is_empty() {
             let dl = damage.loc.x;
@@ -241,25 +209,22 @@ pub(crate) fn draw_debug_frame_to_target(
         }
     }
 
-    // Dock connector lines + dock-preview overlay
     draw_docked_pairs(&mut frame, st, size, damage, now)?;
     draw_dock_preview(&mut frame, st, size, damage, now)?;
 
-    // Focus ring
-    let rings = st.active_rings();
+    let focus_ring = st.active_focus_ring();
     draw_ring(
         &mut frame,
         st,
         size.w,
         size.h,
-        rings.primary.radius_x,
-        rings.primary.radius_y,
-        rings.primary.rotation_rad,
+        focus_ring.radius_x,
+        focus_ring.radius_y,
+        focus_ring.rotation_rad,
         Color32F::new(0.15, 0.85, 0.85, 0.9),
         damage,
     )?;
 
-    // Software cursor (TTY backend has no host cursor)
     if let Some((sx, sy)) = cursor_screen {
         let draw_fallback_arrow = match cursor_status {
             smithay::input::pointer::CursorImageStatus::Hidden => false,
@@ -293,11 +258,6 @@ pub(crate) fn draw_debug_frame_to_target(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Fallback arrow cursor
-// ---------------------------------------------------------------------------
-
-/// Tiny software arrow drawn when the themed cursor fails to load.
 fn draw_fallback_cursor_arrow<F>(
     frame: &mut F,
     sx: f32,

--- a/crates/halley-wl/src/spatial/hit_test.rs
+++ b/crates/halley-wl/src/spatial/hit_test.rs
@@ -8,6 +8,7 @@ use crate::runtime_render::{
     active_surface_render_scale, node_marker_bounds, node_marker_metrics, world_to_screen,
 };
 use crate::state::HalleyWlState;
+use halley_core::viewport::FocusZone;
 
 pub(crate) fn pick_hit_node_at(
     st: &HalleyWlState,
@@ -62,9 +63,6 @@ pub(crate) fn pick_hit_node_at(
                 let (cx, cy) = world_to_screen(st, w, h, p.x, p.y);
                 let sw = rw.round();
                 let sh = rh.round();
-                // Align hit bounds with actual render placement.
-                // Rendering anchors the visible window rect at center - scaled_size/2,
-                // with bbox local offsets applied only to the surface-tree origin.
                 let x = ((cx as f32) - sw * 0.5).round() as i32;
                 let y = ((cy as f32) - sh * 0.5).round() as i32;
                 let ww = sw.max(1.0) as i32;
@@ -116,7 +114,6 @@ pub(crate) fn pick_hit_node_at(
         };
     }
 
-    // Newer ids are treated as visually on top in this prototype.
     active.sort_by_key(|h| std::cmp::Reverse(h.node_id.as_u64()));
     node_dot.sort_by_key(|h| std::cmp::Reverse(h.node_id.as_u64()));
 
@@ -130,9 +127,9 @@ pub(crate) fn node_in_active_area(st: &HalleyWlState, node_id: halley_core::fiel
     let Some(n) = st.field.node(node_id) else {
         return false;
     };
-    let rings = st.active_rings();
+    let focus_ring = st.active_focus_ring();
     matches!(
-        rings.zone(st.viewport.center, n.pos),
-        halley_core::viewport::RingZone::Primary
+        focus_ring.zone(st.viewport.center, n.pos),
+        FocusZone::Inside
     )
 }

--- a/crates/halley-wl/src/state/carry.rs
+++ b/crates/halley-wl/src/state/carry.rs
@@ -1,4 +1,5 @@
 use super::*;
+use halley_core::viewport::{FocusRing, FocusZone};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DockSide {
@@ -336,39 +337,17 @@ impl HalleyWlState {
                 )
             };
 
-            // ------------------------------------------------------------------
-            // Edge-collapse: use the full remembered window size so the trigger
-            // fires at the real content edge, not the shrunken animated footprint.
-            //
-            // Each node is decided independently:
-            //   outward edge exits viewport  → collapse to Node immediately
-            //   outward edge inside viewport → reopen once primary coverage returns
-            //
-            // Only the window going out of bounds collapses; its partner is not
-            // affected by that window's overflow.
-            // ------------------------------------------------------------------
             let a_edge_fp = self.dock_state_eval_footprint(a, sa);
             let b_edge_fp = self.dock_state_eval_footprint(b, sb);
 
             let a_overflow = self.dock_outward_edge_overflow(a_pos, a_edge_fp, link_a.side);
             let b_overflow = self.dock_outward_edge_overflow(b_pos, b_edge_fp, link_b.side);
 
-            // Collapse when the outward edge exits the viewport (overflow > 0).
-            // Do NOT auto-reopen Cold nodes here based on coverage — that
-            // bypasses focus history and causes docked pairs to pop open
-            // whenever they drift into the primary zone, even if a completely
-            // different window was focused last.
-            //
-            // Targeted reopening of the last-focused node (docked or otherwise)
-            // is handled exclusively by restore_pan_return_active_focus.
             let decay_a = if a_overflow > 0.0 {
-                // Outward edge left the viewport — collapse.
                 DecayLevel::Cold
             } else if a_state == halley_core::field::NodeState::Active {
-                // Active and on-screen — keep it.
                 DecayLevel::Hot
             } else {
-                // Cold and on-screen: stay Cold until focus logic reopens it.
                 DecayLevel::Cold
             };
 
@@ -394,16 +373,6 @@ impl HalleyWlState {
                 }
             }
 
-            // ------------------------------------------------------------------
-            // Positional correction — keep the pair centred on their shared
-            // anchor so midpoint doesn't drift when footprints change.
-            //
-            // Use a_edge_fp/b_edge_fp (remembered full sizes) rather than the
-            // live sa/sb.  If we used the animated/shrunken sizes here, sep would
-            // shrink as a node collapses, carry() would move both nodes inward,
-            // the outward edge would re-enter the viewport, and the node would
-            // reopen — producing the oscillating collapse/reopen flicker.
-            // ------------------------------------------------------------------
             let gap = self.non_overlap_gap_world();
             match link_b.side {
                 DockSide::Left | DockSide::Right => {
@@ -445,19 +414,18 @@ impl HalleyWlState {
         }
     }
 
-    fn ring_coverage_fractions(
+    fn focus_ring_coverage_fractions(
         &self,
         pos: Vec2,
         footprint: Vec2,
-        rings: FocusRings,
-    ) -> (f32, f32, f32) {
+        focus_ring: FocusRing,
+    ) -> (f32, f32) {
         let sample_fp = Vec2 {
             x: footprint.x.max(48.0),
             y: footprint.y.max(48.0),
         };
         let samples = 7usize;
-        let mut c_primary = 0usize;
-        let mut c_secondary = 0usize;
+        let mut c_inside = 0usize;
         let mut c_total = 0usize;
         for ix in 0..samples {
             for iy in 0..samples {
@@ -467,58 +435,51 @@ impl HalleyWlState {
                     x: pos.x + fx * sample_fp.x,
                     y: pos.y + fy * sample_fp.y,
                 };
-                match rings.zone(self.viewport.center, sp) {
-                    RingZone::Primary => c_primary += 1,
-                    RingZone::Secondary => c_secondary += 1,
-                    RingZone::Outside => {}
+                match focus_ring.zone(self.viewport.center, sp) {
+                    FocusZone::Inside => c_inside += 1,
+                    FocusZone::Outside => {}
                 }
                 c_total += 1;
             }
         }
         if c_total == 0 {
-            return (0.0, 0.0, 1.0);
+            return (0.0, 1.0);
         }
-        let p_primary = c_primary as f32 / c_total as f32;
-        let p_secondary = c_secondary as f32 / c_total as f32;
-        let p_outside = (1.0 - p_primary - p_secondary).max(0.0);
-        (p_primary, p_secondary, p_outside)
+        let p_inside = c_inside as f32 / c_total as f32;
+        let p_outside = (1.0 - p_inside).max(0.0);
+        (p_inside, p_outside)
     }
 
-    fn zone_for_pos_with_hysteresis(&mut self, id: NodeId, pos: Vec2, footprint: Vec2) -> RingZone {
-        let rings = self.active_rings();
+    fn zone_for_pos_with_hysteresis(&mut self, id: NodeId, pos: Vec2, footprint: Vec2) -> FocusZone {
+        let focus_ring = self.active_focus_ring();
         let footprint = self.zone_eval_footprint_for(id, footprint);
-        let (p_primary, _p_secondary, p_outside) =
-            self.ring_coverage_fractions(pos, footprint, rings);
+        let (p_inside, p_outside) =
+            self.focus_ring_coverage_fractions(pos, footprint, focus_ring);
         let prev = self.carry_zone_hint.get(&id).copied();
 
         const ACTIVE_RETAIN_FRAC: f32 = 0.04;
         const ACTIVE_ENTER_FRAC: f32 = 0.10;
         const OUTSIDE_ENTER_FRAC: f32 = 0.90;
+
         let zone = match prev {
-            Some(RingZone::Primary) => {
-                if p_primary >= ACTIVE_RETAIN_FRAC {
-                    RingZone::Primary
+            Some(FocusZone::Inside) => {
+                if p_inside >= ACTIVE_RETAIN_FRAC {
+                    FocusZone::Inside
                 } else if p_outside >= OUTSIDE_ENTER_FRAC {
-                    RingZone::Outside
+                    FocusZone::Outside
                 } else {
-                    RingZone::Primary
-                }
-            }
-            Some(RingZone::Secondary) => {
-                if p_primary >= ACTIVE_ENTER_FRAC {
-                    RingZone::Primary
-                } else {
-                    RingZone::Outside
+                    FocusZone::Inside
                 }
             }
             _ => {
-                if p_primary >= ACTIVE_ENTER_FRAC {
-                    RingZone::Primary
+                if p_inside >= ACTIVE_ENTER_FRAC {
+                    FocusZone::Inside
                 } else {
-                    RingZone::Outside
+                    FocusZone::Outside
                 }
             }
         };
+
         let now_ms = self.now_ms(Instant::now());
         self.carry_zone_last_change_ms.insert(id, now_ms);
         self.carry_zone_pending.remove(&id);
@@ -532,9 +493,9 @@ impl HalleyWlState {
         if n.kind != halley_core::field::NodeKind::Surface || !self.field.is_visible(id) {
             return;
         }
-        let rings = self.active_rings();
-        let pointer_zone = rings.zone(self.viewport.center, pointer_world);
-        let target = if pointer_zone != RingZone::Primary {
+        let focus_ring = self.active_focus_ring();
+        let pointer_zone = focus_ring.zone(self.viewport.center, pointer_world);
+        let target = if pointer_zone != FocusZone::Inside {
             DecayLevel::Cold
         } else {
             DecayLevel::Hot
@@ -596,7 +557,7 @@ impl HalleyWlState {
         }
         let zone = self.zone_for_pos_with_hysteresis(id, source_pos, footprint);
         let target = match zone {
-            RingZone::Primary if was_active => DecayLevel::Hot,
+            FocusZone::Inside if was_active => DecayLevel::Hot,
             _ => DecayLevel::Cold,
         };
         let _ = self.field.set_decay_level(id, target);

--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -1,5 +1,6 @@
 use super::*;
 use eventline::info;
+use halley_core::viewport::FocusZone;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface};
 use smithay::utils::SERIAL_COUNTER;
@@ -70,15 +71,6 @@ impl HalleyWlState {
         let now_ms = self.now_ms(now);
         self.pan_dominant_until_ms = now_ms.saturating_add(220);
         if self.tuning.restore_last_active_on_pan_return {
-            // Only capture the restore target on the FIRST pan event of each
-            // pan session. Refreshing on every event overwrites the target
-            // with None as soon as the node decays away from Active state,
-            // which permanently breaks restoration for that pan cycle.
-            //
-            // The target is cleared by restore_pan_return_active_focus once
-            // restoration fires, or by set_interaction_focus when the user
-            // explicitly focuses a different window — so successive pan
-            // sessions always start with a fresh capture.
             if self.pan_restore_active_focus.is_none() {
                 self.pan_restore_active_focus = self.last_focused_active_surface_node();
             }
@@ -176,13 +168,12 @@ impl HalleyWlState {
             self.pan_restore_active_focus = None;
             return;
         }
-        let rings = self.active_rings();
-        if rings.zone(self.viewport.center, n.pos) != RingZone::Primary {
+
+        let focus_ring = self.active_focus_ring();
+        if focus_ring.zone(self.viewport.center, n.pos) != FocusZone::Inside {
             return;
         }
 
-        // If the restore target is one half of a docked pair, reopen both —
-        // they were focused together and should return together.
         let partner = self.docked_links.get(&id).and_then(|link| {
             let pid = link.partner;
             self.docked_links
@@ -275,10 +266,6 @@ impl HalleyWlState {
                     n.kind == halley_core::field::NodeKind::Surface && self.field.is_visible(fid)
                 }) {
                     self.last_surface_focus_ms.insert(fid, now_ms);
-
-                    // Update the pan-restore target whenever the user explicitly
-                    // focuses a new Surface window so that panning away from it
-                    // and back will restore it — not the old pre-focus target.
                     if self.tuning.restore_last_active_on_pan_return {
                         self.pan_restore_active_focus = Some(fid);
                     }

--- a/crates/halley-wl/src/state/maintenance.rs
+++ b/crates/halley-wl/src/state/maintenance.rs
@@ -1,27 +1,32 @@
 use std::collections::HashSet;
 
 use super::*;
+use halley_core::viewport::{FocusRing, FocusZone};
 
 impl HalleyWlState {
-    pub(crate) fn enforce_single_primary_active_unit(&mut self, rings: FocusRings) {
-        let mut primary_ids: Vec<NodeId> = self
+    pub(crate) fn enforce_single_primary_active_unit(&mut self, focus_ring: FocusRing) {
+        let mut inside_ids: Vec<NodeId> = self
             .field
             .nodes()
             .iter()
             .filter_map(|(&id, n)| {
                 (self.field.is_visible(id)
                     && n.kind == halley_core::field::NodeKind::Surface
-                    && rings.zone(self.viewport.center, n.pos) == RingZone::Primary)
+                    && focus_ring.zone(self.viewport.center, n.pos) == FocusZone::Inside)
                     .then_some(id)
             })
             .collect();
-        if primary_ids.is_empty() {
+
+        if inside_ids.is_empty() {
             return;
         }
-        primary_ids.sort_by_key(|id| id.as_u64());
+
+        inside_ids.sort_by_key(|id| id.as_u64());
+
         let mut units: Vec<Vec<NodeId>> = Vec::new();
         let mut seen: HashSet<NodeId> = HashSet::new();
-        for id in primary_ids {
+
+        for id in inside_ids {
             if seen.contains(&id) {
                 continue;
             }
@@ -44,6 +49,7 @@ impl HalleyWlState {
             seen.insert(id);
             units.push(unit);
         }
+
         if units.is_empty() {
             return;
         }
@@ -62,6 +68,7 @@ impl HalleyWlState {
                     .then_some(idx)
             })
             .collect();
+
         if active_unit_indices.len() <= 1 {
             return;
         }
@@ -84,6 +91,7 @@ impl HalleyWlState {
             let latest_id = unit.iter().map(|id| id.as_u64()).max().unwrap_or(0);
             (preferred_rank, focus_rank, latest_focus, latest_id)
         });
+
         let Some(selected_idx) = selected_idx else {
             return;
         };
@@ -118,6 +126,7 @@ impl HalleyWlState {
             .iter()
             .filter_map(|(&id, &at)| (now_ms >= at).then_some(id))
             .collect();
+
         for id in due {
             self.pending_spawn_activate_at_ms.remove(&id);
             if !self.field.is_visible(id) {
@@ -134,18 +143,18 @@ impl HalleyWlState {
                 self.last_active_size.insert(id, nn.intrinsic_size);
             }
             self.mark_active_transition(id, now, 620);
-            // New toplevels should remain typeable after map/activation.
             self.set_interaction_focus(Some(id), 30_000, now);
             self.push_neighbors_for_activation(id);
         }
     }
 
     pub(crate) fn enforce_carry_zone_states(&mut self) {
-        let tracked: Vec<(NodeId, RingZone)> = self
+        let tracked: Vec<(NodeId, FocusZone)> = self
             .carry_zone_hint
             .iter()
             .map(|(&id, &z)| (id, z))
             .collect();
+
         for (id, zone) in tracked {
             if !self.field.is_visible(id) {
                 continue;
@@ -157,20 +166,19 @@ impl HalleyWlState {
                 continue;
             }
             let target = match zone {
-                // Dragging a Node into center should not auto-promote it to Active.
-                RingZone::Primary if n.state == halley_core::field::NodeState::Active => {
+                FocusZone::Inside if n.state == halley_core::field::NodeState::Active => {
                     DecayLevel::Hot
                 }
-                RingZone::Primary => DecayLevel::Cold,
-                RingZone::Secondary => DecayLevel::Cold,
-                RingZone::Outside => DecayLevel::Cold,
+                FocusZone::Inside => DecayLevel::Cold,
+                FocusZone::Outside => DecayLevel::Cold,
             };
             let _ = self.field.set_decay_level(id, target);
         }
     }
 
-    pub(crate) fn enforce_pan_dominant_zone_states(&mut self, rings: FocusRings, _now_ms: u64) {
+    pub(crate) fn enforce_pan_dominant_zone_states(&mut self, focus_ring: FocusRing, _now_ms: u64) {
         let ids: Vec<NodeId> = self.field.nodes().keys().copied().collect();
+
         for id in ids {
             if !self.field.is_visible(id) {
                 continue;
@@ -181,6 +189,7 @@ impl HalleyWlState {
             if n.kind != halley_core::field::NodeKind::Surface {
                 continue;
             }
+
             let n_state = n.state.clone();
             let pos = n.pos;
             let fp_raw = self.collision_size_for_node(n);
@@ -192,10 +201,11 @@ impl HalleyWlState {
                     y: fp_raw.y.max(48.0),
                 }
             };
+
             let samples = 7usize;
-            let mut c_primary = 0usize;
-            let mut c_secondary = 0usize;
+            let mut c_inside = 0usize;
             let mut c_total = 0usize;
+
             for ix in 0..samples {
                 for iy in 0..samples {
                     let fx = (ix as f32 / (samples - 1) as f32) - 0.5;
@@ -204,27 +214,24 @@ impl HalleyWlState {
                         x: pos.x + fx * fp.x,
                         y: pos.y + fy * fp.y,
                     };
-                    match rings.zone(self.viewport.center, sp) {
-                        RingZone::Primary => c_primary += 1,
-                        RingZone::Secondary => c_secondary += 1,
-                        RingZone::Outside => {}
+                    match focus_ring.zone(self.viewport.center, sp) {
+                        FocusZone::Inside => c_inside += 1,
+                        FocusZone::Outside => {}
                     }
                     c_total += 1;
                 }
             }
-            let p_primary = if c_total > 0 {
-                c_primary as f32 / c_total as f32
+
+            let p_inside = if c_total > 0 {
+                c_inside as f32 / c_total as f32
             } else {
                 0.0
             };
-            let p_secondary = if c_total > 0 {
-                c_secondary as f32 / c_total as f32
-            } else {
-                0.0
-            };
-            let p_outside = (1.0 - p_primary - p_secondary).max(0.0);
+            let p_outside = (1.0 - p_inside).max(0.0);
+
             let was_active = n_state == halley_core::field::NodeState::Active;
             let pair_gap = self.non_overlap_gap_world();
+
             let overlap_active = self
                 .field
                 .nodes()
@@ -246,22 +253,23 @@ impl HalleyWlState {
                     let dy = (on.pos.y - pos.y).abs();
                     dx < req_x && dy < req_y
                 });
+
             const ACTIVE_RETAIN_FRAC: f32 = 0.04;
             const ACTIVE_OVERLAP_RETAIN_FRAC: f32 = 0.22;
             const OUTSIDE_ENTER_FRAC: f32 = 0.90;
+
             let target = if was_active {
                 let retain_frac = if overlap_active {
                     ACTIVE_OVERLAP_RETAIN_FRAC
                 } else {
                     ACTIVE_RETAIN_FRAC
                 };
-                if p_primary >= retain_frac {
+
+                if p_inside >= retain_frac {
                     DecayLevel::Hot
                 } else if p_outside >= OUTSIDE_ENTER_FRAC {
                     DecayLevel::Cold
                 } else if overlap_active {
-                    // Exception: overlap should not let tiny-in-ring windows
-                    // self-pin to Active indefinitely.
                     DecayLevel::Cold
                 } else {
                     DecayLevel::Hot
@@ -269,6 +277,7 @@ impl HalleyWlState {
             } else {
                 DecayLevel::Cold
             };
+
             let _ = self.field.set_decay_level(id, target);
         }
     }
@@ -306,6 +315,7 @@ impl HalleyWlState {
                 Some((id, n.pos, osize, d2))
             })
             .collect();
+
         others.sort_by(|a, b| a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal));
 
         let mut moved = 0usize;
@@ -344,6 +354,7 @@ impl HalleyWlState {
     pub(crate) fn reconcile_surface_bindings(&mut self) {
         const STALE_SURFACE_GRACE_MS: u64 = 1500;
         let now = Instant::now();
+
         let alive: HashSet<ObjectId> = self
             .xdg_shell_state
             .toplevel_surfaces()
@@ -405,6 +416,7 @@ impl HalleyWlState {
                 let _ = self.field.remove(id);
             }
         }
+
         self.surface_activity.retain(|k, _| alive.contains(k));
     }
 }

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -5,7 +5,7 @@ use halley_core::cluster::{ActiveLayoutMode, ClusterId};
 use halley_core::cluster_policy::{ClusterFormationState, ClusterPolicy, tick_cluster_formation};
 use halley_core::decay::DecayLevel;
 use halley_core::field::{Field, NodeId, Vec2, Visibility};
-use halley_core::viewport::{FocusRings, RingZone, Viewport};
+use halley_core::viewport::{FocusZone, Viewport};
 use halley_config::RuntimeTuning;
 
 use smithay::{
@@ -102,9 +102,9 @@ pub struct HalleyWlState {
     pending_spawn_activate_at_ms: HashMap<NodeId, u64>,
     active_transition_until_ms: HashMap<NodeId, u64>,
     primary_promote_cooldown_until_ms: HashMap<NodeId, u64>,
-    carry_zone_hint: HashMap<NodeId, RingZone>,
+    carry_zone_hint: HashMap<NodeId, FocusZone>,
     carry_zone_last_change_ms: HashMap<NodeId, u64>,
-    carry_zone_pending: HashMap<NodeId, RingZone>,
+    carry_zone_pending: HashMap<NodeId, FocusZone>,
     carry_zone_pending_since_ms: HashMap<NodeId, u64>,
     carry_activation_anim_armed: HashSet<NodeId>,
     docked_links: HashMap<NodeId, DockLink>,
@@ -123,7 +123,7 @@ pub struct HalleyWlState {
     viewport_pan_anim: Option<ViewportPanAnim>,
     pan_dominant_until_ms: u64,
     exit_requested: bool,
-    
+
     pub(crate) bbox_loc: HashMap<NodeId, (f32, f32)>,
 
     spawn_cursor: u32,
@@ -208,9 +208,9 @@ impl HalleyWlState {
             viewport_pan_anim: None,
             pan_dominant_until_ms: 0,
             exit_requested: false,
-            
+
             bbox_loc: HashMap::new(),
-            
+
             spawn_cursor: 0,
             started_at: now,
             last_debug_dump_at: now,
@@ -240,7 +240,7 @@ impl HalleyWlState {
         self.tick_overview_animation(now_ms);
         self.tick_viewport_pan_animation(now_ms);
         if self.overview_mode {
-            // Overview mode is authoritative: don't let decay/rings/resize logic
+            // Overview mode is authoritative: don't let decay/focus-ring/resize logic
             // pull nodes back into Active while in the overview workspace.
             self.animator.observe_field(&self.field, now);
             return;
@@ -252,9 +252,6 @@ impl HalleyWlState {
         }
         if let Some(fid) = self.interaction_focus {
             if now_ms >= self.interaction_focus_until_ms {
-                // Keep keyboard focus sticky while the focused surface still exists/visible.
-                // This mirrors the expected compositor behavior: focus only changes due to
-                // explicit focus operations, not passive timer expiry.
                 let keep = self.field.node(fid).is_some_and(|n| {
                     self.field.is_visible(fid) && n.kind == halley_core::field::NodeKind::Surface
                 });
@@ -308,30 +305,21 @@ impl HalleyWlState {
             self.animator.observe_field(&self.field, now);
             return;
         }
-        let rings = self.active_rings();
+        let focus_ring = self.active_focus_ring();
         let pan_dominant = now_ms < self.pan_dominant_until_ms;
         if !self.suspend_state_checks {
-            // Single source of truth for runtime state transitions.
-            // Avoid mixing ring-decay + promote-center policies, which can
-            // issue contradictory Hot/Cold writes near boundaries.
-            self.enforce_pan_dominant_zone_states(rings, now_ms);
+            self.enforce_pan_dominant_zone_states(focus_ring, now_ms);
             self.enforce_carry_zone_states();
         }
         if let Some(id) = self.resize_active {
             let _ = self.field.touch(id, now_ms);
             let _ = self.field.set_decay_level(id, DecayLevel::Hot);
         }
-        // State updates are handled by a single ring policy path above.
-        // Never run zoom-driven client resize while interactive resize is active
-        // (or in its short static cooldown), otherwise two configure sources
-        // fight and cause visible drift/jitter at some size thresholds.
         if self.resize_active.is_none()
             && !(self.resize_static_node.is_some() && now_ms < self.resize_static_until_ms)
         {
             self.update_zoom_live_surface_sizes();
         }
-        // TEMP safety rollback: keep runtime cluster auto-formation disabled while we
-        // stabilize app-mapping/rendering behavior.
         let _ = tick_cluster_formation(
             &mut self.field,
             now_ms,
@@ -349,7 +337,7 @@ impl HalleyWlState {
         {
             self.enforce_docked_pairs();
         }
-        self.enforce_single_primary_active_unit(rings);
+        self.enforce_single_primary_active_unit(focus_ring);
         if !self.suspend_state_checks
             && self.resize_active.is_none()
             && !(self.resize_static_node.is_some() && now_ms < self.resize_static_until_ms)

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -51,13 +51,12 @@ impl HalleyWlState {
     }
 
     pub(super) fn debug_dump(&self) {
-        let rings = self.active_rings();
+        let focus_ring = self.active_focus_ring();
 
         let mut nodes_total = 0usize;
         let mut visible_total = 0usize;
 
-        let mut zone_primary = 0usize;
-        let mut zone_secondary = 0usize;
+        let mut zone_inside = 0usize;
         let mut zone_outside = 0usize;
 
         let mut state_active = 0usize;
@@ -79,64 +78,66 @@ impl HalleyWlState {
                 _ => state_other += 1,
             }
 
-            match rings.zone(self.viewport.center, node.pos) {
-                RingZone::Primary => zone_primary += 1,
-                RingZone::Secondary => zone_secondary += 1,
-                RingZone::Outside => zone_outside += 1,
+            match focus_ring.zone(self.viewport.center, node.pos) {
+                halley_core::viewport::FocusZone::Inside => zone_inside += 1,
+                halley_core::viewport::FocusZone::Outside => zone_outside += 1,
             }
         }
 
         debug!(
-            "tick-dump nodes={} visible={} state(a/n/c/o)={}/{}/{}/{} zone(p/s/o)={}/{}/{} vp=({:.0},{:.0}) {:.0}x{:.0} rings(pr={:.0}x{:.0} sr={:.0}x{:.0} rot={:.2})",
+            "tick-dump nodes={} visible={} state(a/n/c/o)={}/{}/{}/{} zone(i/o)={}/{} vp=({:.0},{:.0}) {:.0}x{:.0} focus-ring({:.0}x{:.0} rot={:.2})",
             nodes_total,
             visible_total,
             state_active,
             state_node,
             state_core,
             state_other,
-            zone_primary,
-            zone_secondary,
+            zone_inside,
             zone_outside,
             self.viewport.center.x,
             self.viewport.center.y,
             self.viewport.size.x,
             self.viewport.size.y,
-            self.tuning.ring_primary_rx,
-            self.tuning.ring_primary_ry,
-            self.tuning.ring_secondary_rx,
-            self.tuning.ring_secondary_ry,
-            self.tuning.ring_rotation_rad,
+            self.tuning.focus_ring_rx,
+            self.tuning.focus_ring_ry,
+            self.tuning.focus_ring_rotation_rad,
         );
     }
 
     pub fn build_debug_scene_snapshot(&self) -> DebugScene {
-        build_debug_scene(&self.field, &self.viewport, self.active_rings())
+        build_debug_scene(&self.field, &self.viewport, self.active_focus_ring())
     }
 
     pub fn apply_tuning(&mut self, mut tuning: RuntimeTuning) {
         let had_nodes = !self.field.nodes().is_empty();
         let prev_viewport = self.viewport;
         let prev_focus = self.last_input_surface_node();
+
         tuning.enforce_guards();
         tuning.apply_process_env();
+
         if had_nodes {
-            // Config reload should not jump the camera away from the current session.
             self.viewport = prev_viewport;
             tuning.viewport_center = prev_viewport.center;
             tuning.viewport_size = prev_viewport.size;
         } else {
             self.viewport = tuning.viewport();
         }
+
         self.zoom_ref_size = tuning.viewport_size;
+
         self.animator.set_spec(AnimSpec {
             state_change_ms: tuning.dev_anim_state_change_ms,
             bounce: tuning.dev_anim_bounce,
         });
+
         if !tuning.physics_enabled {
             self.active_transition_until_ms.clear();
             self.smoothed_render_pos.clear();
         }
+
         self.tuning = tuning;
+
         if let Some(id) = prev_focus {
             self.set_interaction_focus(Some(id), 30_000, Instant::now());
         }
@@ -151,23 +152,24 @@ impl HalleyWlState {
         if !self.tuning.dev_anim_enabled || !self.tuning.physics_enabled {
             return AnimStyle::default();
         }
+
         let now_ms = self.now_ms(now);
         if self.resize_active == Some(id)
             || (self.resize_static_node == Some(id) && now_ms < self.resize_static_until_ms)
         {
             return AnimStyle::default();
         }
+
         self.animator.style_for(id, state, now)
     }
 
-    pub fn active_rings(&self) -> FocusRings {
-        let mut rings = self.tuning.rings();
+    pub fn active_focus_ring(&self) -> halley_core::viewport::FocusRing {
+        let mut ring = self.tuning.focus_ring();
         let sx = (self.viewport.size.x / self.zoom_ref_size.x.max(1.0)).clamp(0.1, 100.0);
         let sy = (self.viewport.size.y / self.zoom_ref_size.y.max(1.0)).clamp(0.1, 100.0);
-        rings.primary.radius_x *= sx;
-        rings.primary.radius_y *= sy;
-        rings.secondary.radius_x *= sx;
-        rings.secondary.radius_y *= sy;
-        rings
+
+        ring.radius_x *= sx;
+        ring.radius_y *= sy;
+        ring
     }
 }

--- a/todo
+++ b/todo
@@ -1,0 +1,9 @@
+[x] land this config/parser cleanup
+
+[ ] do a small config audit and delete knobs you know you no longer want
+
+[ ] then build basic halley-ipc
+
+[ ] then move core user actions onto IPC
+
+[ ] then return to focus-ring/interactions with cleaner control surfaces


### PR DESCRIPTION
Halley previously used a Primary/Secondary/Outside ring model for
focus and decay decisions. This created conflicting behavior across
docking, carry interactions, and state enforcement, often causing
unstable target selection and flicker during drag operations.

This change removes the secondary ring logic and simplifies the
system to a single focus ring with outside detection.

Benefits:
- Much more stable docking behavior
- Simpler state evaluation during carry/drag
- Fewer zone transitions and hysteresis conflicts
- Reduced complexity in focus, maintenance, and carry logic

The interaction model is now:
  inside focus ring  -> active zone
  outside focus ring -> decay/collapse zone