### PR TITLE
input: only intercept explicit compositor keybinds and normalize modifier handling

### DIFF
--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -11,8 +11,8 @@ use crate::interaction::types::{ModState, PointerState};
 use crate::spatial::screen_to_world;
 use crate::state::HalleyWlState;
 
-use super::input_utils::{modifier_active, update_mod_state};
-use super::key_actions::apply_bound_key;
+use super::input_utils::update_mod_state;
+use super::key_actions::{apply_bound_key, key_is_compositor_binding};
 use super::pointer_focus::pointer_focus_for_screen;
 use super::pointer_map_debug_enabled;
 use smithay::backend::input::{Axis, AxisSource, ButtonState, KeyState};
@@ -34,17 +34,17 @@ fn now_millis_u32() -> u32 {
 fn is_modifier_keycode(code: u32) -> bool {
     matches!(
         code,
-        29  // Left Ctrl
-        | 97  // Right Ctrl
-        | 42  // Left Shift
-        | 54  // Right Shift
-        | 56  // Left Alt
-        | 100 // Right Alt / AltGr
-        | 125 // Left Super / Meta
-        | 126 // Right Super / Meta
-        | 58  // Caps Lock
-        | 69  // Num Lock
-        | 70 // Scroll Lock
+        29  | 37  // Left Ctrl
+        | 97  | 105 // Right Ctrl
+        | 42  | 50  // Left Shift
+        | 54  | 62  // Right Shift
+        | 56  | 64  // Left Alt
+        | 100 | 108 // Right Alt / AltGr
+        | 125 | 133 // Left Super / Meta
+        | 126 | 134 // Right Super / Meta
+        | 58        // Caps Lock
+        | 69        // Num Lock
+        | 70        // Scroll Lock
     )
 }
 
@@ -86,27 +86,22 @@ pub(crate) fn handle_keyboard_input(
         }
     }
 
-    // ------------------------------------------------------------------
-    // Decide whether this key event should be intercepted before it
-    // reaches any client.
-    //
-    // Rule:
-    //   - Modifier keys (Super, Alt, Ctrl, Shift, Lock) are ALWAYS
-    //     forwarded so clients can track modifier state correctly.
-    //   - While the compositor modifier is held, all non-modifier
-    //     presses are intercepted.
-    //   - A release event is intercepted if and only if its matching
-    //     press was intercepted, preventing stuck-key artefacts in
-    //     clients.
-    // ------------------------------------------------------------------
     let mods = mod_state.borrow().clone();
-    let modifier_held = modifier_active(&mods, st.tuning.keybinds.modifier);
     let is_mod_key = is_modifier_keycode(code);
 
+    // Pure detection only. Do not execute the action yet.
+    let matched_binding = if pressed && !is_mod_key {
+        key_is_compositor_binding(st, code, &mods)
+    } else {
+        false
+    };
+
+    // Only intercept explicit compositor bindings.
+    // Releases are intercepted only if the matching press was intercepted.
     let intercept = if is_mod_key {
         false
     } else if pressed {
-        if modifier_held {
+        if matched_binding {
             mod_state.borrow_mut().intercepted_keys.insert(code);
             true
         } else {
@@ -123,6 +118,7 @@ pub(crate) fn handle_keyboard_input(
         } else {
             KeyState::Released
         };
+
         keyboard.input::<(), _>(
             st,
             code.into(),
@@ -139,13 +135,10 @@ pub(crate) fn handle_keyboard_input(
         );
     }
 
-    // Apply compositor bindings after the client filter so that the
-    // intercept decision above is the single authoritative gate.
-    // Modifier key events and releases are never compositor actions.
-    if pressed && !is_mod_key {
+    // Execute compositor action only after the filter path above.
+    if pressed && matched_binding {
         if apply_bound_key(st, code, &mods, config_path, wayland_display) {
             backend.request_redraw();
-            return;
         }
     }
 }

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -30,21 +30,26 @@ fn now_millis_u32() -> u32 {
 ///
 /// These are always forwarded to clients so clients can track modifier state
 /// correctly — intercepting them would break client-side keymaps and IMEs.
+///
+/// All codes are XKB (evdev + 8), matching the raw codes delivered by the
+/// input backend. The old list included bare evdev codes alongside the XKB
+/// codes. That caused collisions: evdev 54 (Right Shift) == XKB 54 (letter C),
+/// so Ctrl+Shift+C was being misidentified as a modifier keypress.
 #[inline]
 fn is_modifier_keycode(code: u32) -> bool {
     matches!(
         code,
-        29  | 37  // Left Ctrl
-        | 97  | 105 // Right Ctrl
-        | 42  | 50  // Left Shift
-        | 54  | 62  // Right Shift
-        | 56  | 64  // Left Alt
-        | 100 | 108 // Right Alt / AltGr
-        | 125 | 133 // Left Super / Meta
-        | 126 | 134 // Right Super / Meta
-        | 58        // Caps Lock
-        | 69        // Num Lock
-        | 70        // Scroll Lock
+        37        // Left Ctrl   (evdev 29 + 8)
+        | 105     // Right Ctrl  (evdev 97 + 8)
+        | 50      // Left Shift  (evdev 42 + 8)
+        | 62      // Right Shift (evdev 54 + 8)
+        | 64      // Left Alt    (evdev 56 + 8)
+        | 108     // Right Alt / AltGr (evdev 100 + 8)
+        | 133     // Left Super  (evdev 125 + 8)
+        | 134     // Right Super (evdev 126 + 8)
+        | 66      // Caps Lock   (evdev 58 + 8)
+        | 77      // Num Lock    (evdev 69 + 8)
+        | 78      // Scroll Lock (evdev 70 + 8)
     )
 }
 

--- a/crates/halley-wl/src/input/input_utils.rs
+++ b/crates/halley-wl/src/input/input_utils.rs
@@ -1,37 +1,59 @@
 use crate::interaction::types::ModState;
 use halley_config::KeyModifiers;
 
+/// Match an incoming XKB keycode against a stored evdev keycode.
+/// Incoming codes from libinput/the backend are always XKB (evdev + 8).
+/// Config and keybind tables store evdev codes, so we normalise here.
 pub(crate) fn key_matches(actual: u32, evdev_code: u32) -> bool {
-    actual == evdev_code || actual == evdev_code + 8
-}
-
-pub(crate) fn key_matches_xkb_only(actual: u32, evdev_code: u32) -> bool {
     actual == evdev_code + 8
 }
 
+/// Identical to key_matches; kept so call-sites that were already explicit
+/// about wanting XKB-only matching continue to compile without changes.
+#[inline(always)]
+pub(crate) fn key_matches_xkb_only(actual: u32, evdev_code: u32) -> bool {
+    key_matches(actual, evdev_code)
+}
+
+/// Update modifier bookkeeping from a raw XKB keycode.
+///
+/// Each branch uses only the XKB code (evdev + 8). The old code had both the
+/// evdev code and the XKB code in every branch (e.g. `29 || 37` for Left
+/// Ctrl). That meant an ordinary key whose XKB code happened to equal some
+/// modifier's *evdev* code would silently flip a modifier flag — most
+/// visibly, XKB 54 (the letter C) was being treated as Right Shift's evdev
+/// code 54, corrupting `right_shift_down` on every Ctrl+Shift+C press.
 pub(crate) fn update_mod_state(mods: &mut ModState, code: u32, pressed: bool) {
-    if code == 125 || code == 133 {
+    if code == 133 {
+        // Left Super  (evdev 125 + 8)
         mods.left_super_down = pressed;
         mods.super_down = mods.left_super_down || mods.right_super_down;
-    } else if code == 126 || code == 134 {
+    } else if code == 134 {
+        // Right Super  (evdev 126 + 8)
         mods.right_super_down = pressed;
         mods.super_down = mods.left_super_down || mods.right_super_down;
-    } else if code == 56 || code == 64 {
+    } else if code == 64 {
+        // Left Alt  (evdev 56 + 8)
         mods.left_alt_down = pressed;
         mods.alt_down = mods.left_alt_down || mods.right_alt_down;
-    } else if code == 100 || code == 108 {
+    } else if code == 108 {
+        // Right Alt / AltGr  (evdev 100 + 8)
         mods.right_alt_down = pressed;
         mods.alt_down = mods.left_alt_down || mods.right_alt_down;
-    } else if code == 29 || code == 37 {
+    } else if code == 37 {
+        // Left Ctrl  (evdev 29 + 8)
         mods.left_ctrl_down = pressed;
         mods.ctrl_down = mods.left_ctrl_down || mods.right_ctrl_down;
-    } else if code == 97 || code == 105 {
+    } else if code == 105 {
+        // Right Ctrl  (evdev 97 + 8)
         mods.right_ctrl_down = pressed;
         mods.ctrl_down = mods.left_ctrl_down || mods.right_ctrl_down;
-    } else if code == 42 || code == 50 {
+    } else if code == 50 {
+        // Left Shift  (evdev 42 + 8)
         mods.left_shift_down = pressed;
         mods.shift_down = mods.left_shift_down || mods.right_shift_down;
-    } else if code == 54 || code == 62 {
+    } else if code == 62 {
+        // Right Shift  (evdev 54 + 8)
         mods.right_shift_down = pressed;
         mods.shift_down = mods.left_shift_down || mods.right_shift_down;
     }

--- a/crates/halley-wl/src/input/input_utils.rs
+++ b/crates/halley-wl/src/input/input_utils.rs
@@ -1,5 +1,5 @@
-use halley_config::KeyModifiers;
 use crate::interaction::types::ModState;
+use halley_config::KeyModifiers;
 
 pub(crate) fn key_matches(actual: u32, evdev_code: u32) -> bool {
     actual == evdev_code || actual == evdev_code + 8
@@ -50,4 +50,71 @@ pub(crate) fn modifier_active(mods: &ModState, need: KeyModifiers) -> bool {
         && (!need.shift || mods.shift_down)
         && (!need.left_shift || mods.left_shift_down)
         && (!need.right_shift || mods.right_shift_down)
+}
+
+fn family_exact(
+    any_down: bool,
+    left_down: bool,
+    right_down: bool,
+    want_any: bool,
+    want_left: bool,
+    want_right: bool,
+) -> bool {
+    // No modifier from this family wanted -> none may be down.
+    if !want_any && !want_left && !want_right {
+        return !any_down && !left_down && !right_down;
+    }
+
+    // Specific sides requested must be down.
+    if want_left && !left_down {
+        return false;
+    }
+    if want_right && !right_down {
+        return false;
+    }
+
+    // If no generic family bit is set, reject extra sides.
+    if !want_any {
+        if !want_left && left_down {
+            return false;
+        }
+        if !want_right && right_down {
+            return false;
+        }
+    }
+
+    // Some modifier in this family must be down.
+    any_down
+}
+
+pub(crate) fn modifier_exact(mods: &ModState, need: KeyModifiers) -> bool {
+    family_exact(
+        mods.super_down,
+        mods.left_super_down,
+        mods.right_super_down,
+        need.super_key,
+        need.left_super,
+        need.right_super,
+    ) && family_exact(
+        mods.alt_down,
+        mods.left_alt_down,
+        mods.right_alt_down,
+        need.alt,
+        need.left_alt,
+        need.right_alt,
+    ) && family_exact(
+        mods.ctrl_down,
+        mods.left_ctrl_down,
+        mods.right_ctrl_down,
+        need.ctrl,
+        need.left_ctrl,
+        need.right_ctrl,
+    ) && family_exact(
+        mods.shift_down,
+        mods.left_shift_down,
+        mods.right_shift_down,
+        need.shift,
+        need.left_shift,
+        need.right_shift,
+    )
 }

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -3,12 +3,77 @@ use std::time::Instant;
 
 use eventline::{info, warn};
 
-use super::input_utils::{key_matches, key_matches_xkb_only, modifier_active};
+use super::input_utils::{key_matches, key_matches_xkb_only, modifier_exact};
 use crate::interaction::actions::{minimize_focused_active_node, move_latest_node};
 use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
 use crate::state::HalleyWlState;
-use halley_config::RuntimeTuning;
+use halley_config::{KeyModifiers, RuntimeTuning};
+
+fn with_extra_shift(base: KeyModifiers) -> KeyModifiers {
+    let mut out = base;
+    out.shift = true;
+    out
+}
+
+pub(crate) fn key_is_compositor_binding(
+    st: &HalleyWlState,
+    key_code: u32,
+    mods: &ModState,
+) -> bool {
+    let kb = &st.tuning.keybinds;
+
+    // Quit is special: mod+shift+quit
+    if key_matches(key_code, kb.quit_compositor) {
+        let need = if st.tuning.quit_requires_shift {
+            with_extra_shift(kb.modifier)
+        } else {
+            kb.modifier
+        };
+        if modifier_exact(mods, need) {
+            return true;
+        }
+    }
+
+    // Explicit configured launch bindings must match exactly.
+    for binding in &st.tuning.launch_bindings {
+        if key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
+            return true;
+        }
+    }
+
+    if key_matches(key_code, kb.reload_config) && modifier_exact(mods, kb.modifier) {
+        return true;
+    }
+
+    if key_matches(key_code, kb.minimize_focused) && modifier_exact(mods, kb.modifier) {
+        return true;
+    }
+
+    if !st.tuning.dev_enabled {
+        return false;
+    }
+
+    if key_matches_xkb_only(key_code, kb.overview_toggle) && modifier_exact(mods, kb.modifier) {
+        return true;
+    }
+
+    matches!(
+        key_code,
+        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.move_right) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.move_up) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.move_down) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.primary_left) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.primary_right) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.primary_up) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.primary_down) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.secondary_left) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.secondary_right) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.secondary_up) && modifier_exact(mods, kb.modifier)
+            || key_matches(code, kb.secondary_down) && modifier_exact(mods, kb.modifier)
+    )
+}
 
 pub(crate) fn apply_bound_key(
     st: &mut HalleyWlState,
@@ -23,9 +88,14 @@ pub(crate) fn apply_bound_key(
     const STEP_NODE: f32 = 80.0;
 
     let kb = st.tuning.keybinds.clone();
+
     if key_matches(key_code, kb.quit_compositor) {
-        if modifier_active(mods, kb.modifier) && (!st.tuning.quit_requires_shift || mods.shift_down)
-        {
+        let need = if st.tuning.quit_requires_shift {
+            with_extra_shift(kb.modifier)
+        } else {
+            kb.modifier
+        };
+        if modifier_exact(mods, need) {
             st.request_exit();
             info!("quit requested via keybind");
             return true;
@@ -34,86 +104,81 @@ pub(crate) fn apply_bound_key(
     }
 
     for binding in st.tuning.launch_bindings.clone() {
-        if key_matches(key_code, binding.key) && modifier_active(mods, binding.modifiers) {
+        if key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
             return spawn_command(binding.command.as_str(), wayland_display, "command");
         }
     }
 
-    if !modifier_active(mods, kb.modifier) {
-        return false;
-    }
-
-    if key_matches(key_code, kb.reload_config) {
+    if key_matches(key_code, kb.reload_config) && modifier_exact(mods, kb.modifier) {
         let next = RuntimeTuning::load_from_path(config_path);
         st.apply_tuning(next);
         info!("manual config reload from {}", config_path);
         info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
         return true;
     }
-    if key_matches(key_code, kb.minimize_focused) {
+
+    if key_matches(key_code, kb.minimize_focused) && modifier_exact(mods, kb.modifier) {
         return minimize_focused_active_node(st);
     }
 
     if !st.tuning.dev_enabled {
         return false;
     }
-    if key_matches_xkb_only(key_code, kb.overview_toggle) {
+
+    if key_matches_xkb_only(key_code, kb.overview_toggle) && modifier_exact(mods, kb.modifier) {
         st.toggle_overview_mode(Instant::now());
         return true;
     }
 
     let changed = match key_code {
-        code if key_matches(code, kb.move_left) => {
+        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.modifier) => {
             move_latest_node(st, -STEP_NODE, 0.0);
             true
         }
-        code if key_matches(code, kb.move_right) => {
+        code if key_matches(code, kb.move_right) && modifier_exact(mods, kb.modifier) => {
             move_latest_node(st, STEP_NODE, 0.0);
             true
         }
-        code if key_matches(code, kb.move_up) => {
+        code if key_matches(code, kb.move_up) && modifier_exact(mods, kb.modifier) => {
             move_latest_node(st, 0.0, STEP_NODE);
             true
         }
-        code if key_matches(code, kb.move_down) => {
+        code if key_matches(code, kb.move_down) && modifier_exact(mods, kb.modifier) => {
             move_latest_node(st, 0.0, -STEP_NODE);
             true
         }
 
-        // Primary dev tuning: ring radii
-        code if key_matches(code, kb.primary_left) => {
+        code if key_matches(code, kb.primary_left) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rx -= STEP_RX;
             true
         }
-        code if key_matches(code, kb.primary_right) => {
+        code if key_matches(code, kb.primary_right) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rx += STEP_RX;
             true
         }
-        code if key_matches(code, kb.primary_up) => {
+        code if key_matches(code, kb.primary_up) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_ry += STEP_RY;
             true
         }
-        code if key_matches(code, kb.primary_down) => {
+        code if key_matches(code, kb.primary_down) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_ry -= STEP_RY;
             true
         }
 
-        // Secondary dev tuning repurposed for single-ring testing:
-        // horizontal = rotation, vertical = uniform scale.
-        code if key_matches(code, kb.secondary_left) => {
+        code if key_matches(code, kb.secondary_left) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rotation_rad -= STEP_ROT;
             true
         }
-        code if key_matches(code, kb.secondary_right) => {
+        code if key_matches(code, kb.secondary_right) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rotation_rad += STEP_ROT;
             true
         }
-        code if key_matches(code, kb.secondary_up) => {
+        code if key_matches(code, kb.secondary_up) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rx += STEP_RX;
             st.tuning.focus_ring_ry += STEP_RY;
             true
         }
-        code if key_matches(code, kb.secondary_down) => {
+        code if key_matches(code, kb.secondary_down) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rx -= STEP_RX;
             st.tuning.focus_ring_ry -= STEP_RY;
             true

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -1,82 +1,74 @@
-halley:
-  runtime:
-    tick_ms 200
-  end
-
-  viewport:
-    # Configure outputs explicitly in tty mode.
-    # Unconfigured connected outputs are disabled at startup.
-    DP-1:
-      offset_x 0
-      offset_y 0
-      width 2560
-      height 1440
-    end
-  end
-
-  ring:
-    primary_rx 820.0
-    primary_ry 420.0
-    rotation_rad 0.0
-  end
-
-  clusters:
-    distance_px 280.0
-    dwell_ms 900
-  end
-
-  layout:
-    # If false, disables overlap/bump physics and render smoothing (old choppy mode).
-    physics_enabled true
-
-    # If true, windows snap their center to cursor in Preview/Node and beyond while dragging.
-    # Default false keeps classic "grab point stays under cursor".
-    center_window_to_mouse false
-    
-    # Render follow boost while dragging with mouse; higher = less visual lag.
-    drag_smoothing_boost 6.0
-    
-    # If true, new windows spawn centered and active, previous active windows are moved aside
-    # and demoted to nodes. If false, old windows keep their state and new windows spawn out of the way.
-    new_window_on_top true
-    
-    # Non-overlap spacing in world units.
-    non_overlap_gap_px 20.0
-
-    non_overlap:
-      # Scale only Active<->Active spacing. Lower means windows can sit closer.
-      active_gap_scale 0.22
-    
-      # If true, newer window is displaced; if false, existing one is displaced.
-      bump_newer false
-    
-      # 0.05..1.0, lower = softer / more damped bump animation.
-      bump_damping 0.35
-    end
-  end
-
-  env:
-    XCURSOR_THEME "Adwaita"
-    XCURSOR_SIZE "24"
+viewport:
+  DP-1:
+    offset-x 0
+    offset-y 0
+    width 2560
+    height 1440
   end
 end
 
+focus-ring:
+  primary-rx 820.0
+  primary-ry 420.0
+  rotation-rad 0.0
+end
+
+clusters:
+  distance-px 280.0
+  dwell-ms 900
+end
+
+tile:
+  new-on-top true
+end
+
+docking:
+  gap 20.0
+  active-gap-scale 0.22
+  bump-newer false
+  drag-smoothing-boost 6.0
+  center-window-to-mouse false
+end
+
+physics:
+  enabled true
+  damping 0.35
+end
+
+env:
+  XCURSOR_THEME "Adwaita"
+  XCURSOR_SIZE "24"
+end
+
 keybinds:
-  mod "LSuper"
+  mod "lsuper"
+
+  # Basic compositor controls
   "$var.mod+r" "reload_config"
   "$var.mod+n" "minimize_focused"
   "$var.mod+o" "overview_toggle"
-  "$var.mod+Shift+q" "quit_halley"
-  "$var.mod+Return" "kitty"
+  
+  # Quit Halley
+  "$var.mod+shift+q" "quit_halley"
+  
+  # Applications
+  "$var.mod+return" "kitty"
+  "$var.mod+p" "pavucontrol"
+  "$var.mod+d" "fuzzel"
 end
 
 dev:
   enabled true
-  show_geometry_overlay true
+  show_geometry_overlay false
   debug_tick_dump false
   debug_dump_every_ms 1000
   zoom_decay_enabled true
   zoom_decay_min_frac 0.07
+
+  runtime:
+    tick-ms 200
+  end
+
   anim:
     enabled true
     state_change_ms 360

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,63 @@
+[13.960] Move x: 99.5 y: 142.8 grabbed: 0
+[13.964] Move x: 98.5 y: 142.8 grabbed: 0
+[13.965] Move x: 98.5 y: 141.6 grabbed: 0
+[13.971] Move x: 97.3 y: 141.6 grabbed: 0
+[13.972] Move x: 97.3 y: 140.6 grabbed: 0
+[13.973] Move x: 95.9 y: 140.6 grabbed: 0
+[13.976] Move x: 95.9 y: 139.2 grabbed: 0
+[13.978] Move x: 94.9 y: 139.2 grabbed: 0
+[13.979] Move x: 94.9 y: 137.9 grabbed: 0
+[13.985] Move x: 94.9 y: 136.6 grabbed: 0
+[13.985] Move x: 93.6 y: 136.6 grabbed: 0
+[13.987] Move x: 92.2 y: 136.6 grabbed: 0
+[13.988] Move x: 92.2 y: 135.2 grabbed: 0
+[13.990] Move x: 90.8 y: 135.2 grabbed: 0
+[13.993] Move x: 90.8 y: 134.1 grabbed: 0
+[13.994] Move x: 89.5 y: 134.1 grabbed: 0
+[13.995] Move x: 89.5 y: 132.7 grabbed: 0
+[13.997] Move x: 88.2 y: 131.5 grabbed: 0
+[14.000] Move x: 87.0 y: 131.5 grabbed: 0
+[14.000] Move x: 87.0 y: 130.1 grabbed: 0
+[14.001] Move x: 85.3 y: 130.1 grabbed: 0
+[14.003] Move x: 85.3 y: 128.7 grabbed: 0
+[14.004] Move x: 84.0 y: 128.7 grabbed: 0
+[14.005] Move x: 84.0 y: 127.1 grabbed: 0
+[14.007] Move x: 82.6 y: 127.1 grabbed: 0
+[14.008] Move x: 82.6 y: 125.7 grabbed: 0
+[14.011] Move x: 81.2 y: 125.7 grabbed: 0
+[14.011] Move x: 79.6 y: 124.1 grabbed: 0
+[14.014] Move x: 78.0 y: 122.5 grabbed: 0
+[14.019] Move x: 78.0 y: 121.5 grabbed: 0
+[14.019] Move x: 76.8 y: 121.5 grabbed: 0
+[14.021] Move x: 76.8 y: 120.1 grabbed: 0
+[14.022] Move x: 75.4 y: 120.1 grabbed: 0
+[14.026] Move x: 74.1 y: 120.1 grabbed: 0
+[14.028] Move x: 74.1 y: 118.9 grabbed: 0
+[14.030] Move x: 72.8 y: 118.9 grabbed: 0
+[14.033] Move x: 72.8 y: 117.8 grabbed: 0
+[14.251] MouseEvent matched action: mouse_handle_click
+[14.251] on_mouse_input: click button: left mods: none grabbed: 0 handled_in_kitty: 1
+[14.299] Press xkb_keycode: 0x2a clean_sym: Shift_L composed_sym: Shift_L mods: none glfw_key: 57441 (LEFT_SHIFT) xkb_key: 65505 (Shift_L)
+[14.299] on_key_input: glfw key: 0xe061 native_code: 0xffe1 action: PRESS mods: shift text: '' state: 0 ignoring as keyboard mode does not support encoding this event
+[14.348] Press xkb_keycode: 0x1d clean_sym: Control_L composed_sym: Control_L mods: shift glfw_key: 57442 (LEFT_CONTROL) xkb_key: 65507 (Control_L)
+[14.348] on_key_input: glfw key: 0xe062 native_code: 0xffe3 action: PRESS mods: ctrl+shift text: '' state: 0 ignoring as keyboard mode does not support encoding this event
+[14.619] Press xkb_keycode: 0x2f clean_sym: v composed_sym: V mods: ctrl+shift glfw_key: 118 (v) xkb_key: 118 (v) shifted_key: 86 (V)
+[14.619] on_key_input: glfw key: 0x76 native_code: 0x76 action: PRESS mods: ctrl+shift text: '' state: 0
+KeyPress matched action: paste_from_clipboard, handled as shortcut
+[14.625] Press xkb_keycode: 0x2e clean_sym: c composed_sym: C mods: ctrl+shift glfw_key: 99 (c) xkb_key: 99 (c) shifted_key: 67 (C)
+[14.625] on_key_input: glfw key: 0x63 native_code: 0x63 action: PRESS mods: ctrl+shift text: '' state: 0
+KeyPress matched action: copy_to_clipboard, handled as shortcut
+[14.671] Release xkb_keycode: 0x2f clean_sym: v mods: ctrl+shift glfw_key: 118 (v) xkb_key: 118 (v) shifted_key: 86 (V)
+[14.671] on_key_input: glfw key: 0x76 native_code: 0x76 action: RELEASE mods: ctrl+shift text: '' state: 0 ignoring as keyboard mode does not support encoding this event
+[14.671] Release xkb_keycode: 0x2e clean_sym: c mods: ctrl+shift glfw_key: 99 (c) xkb_key: 99 (c) shifted_key: 67 (C)
+[14.671] on_key_input: glfw key: 0x63 native_code: 0x63 action: RELEASE mods: ctrl+shift text: '' state: 0 ignoring release event for previous press thatwas handled as shortcut
+[14.891] Press xkb_keycode: 0x2f clean_sym: v composed_sym: V mods: ctrl+shift glfw_key: 118 (v) xkb_key: 118 (v) shifted_key: 86 (V)
+[14.891] on_key_input: glfw key: 0x76 native_code: 0x76 action: PRESS mods: ctrl+shift text: '' state: 0
+KeyPress matched action: paste_from_clipboard, handled as shortcut
+[14.972] Move x: 72.8 y: 118.7 grabbed: 0
+[14.987] Release xkb_keycode: 0x2f clean_sym: v mods: ctrl+shift glfw_key: 118 (v) xkb_key: 118 (v) shifted_key: 86 (V)
+[14.987] on_key_input: glfw key: 0x76 native_code: 0x76 action: RELEASE mods: ctrl+shift text: '' state: 0 ignoring release event for previous press thatwas handled as shortcut
+[15.120] Release xkb_keycode: 0x1d clean_sym: Control_L mods: ctrl+shift glfw_key: 57442 (LEFT_CONTROL) xkb_key: 65507 (Control_L)
+[15.120] on_key_input: glfw key: 0xe062 native_code: 0xffe3 action: RELEASE mods: shift text: '' state: 0 ignoring as keyboard mode does not support encoding this event
+[15.125] Release xkb_keycode: 0x2a clean_sym: Shift_L mods: shift glfw_key: 57441 (LEFT_SHIFT) xkb_key: 65505 (Shift_L)
+[15.125] on_key_input: glfw key: 0xe061 native_code: 0xffe1 action: RELEASE mods: none text: '' state: 0 ignoring as keyboard mode does not support encoding this event


### PR DESCRIPTION
Rework keyboard input interception so Halley only captures keys that
actually match configured compositor bindings.

Changes:
- intercept only explicit compositor keybinds instead of all keys while
  the compositor modifier is held
- separate binding detection from action execution to avoid pre-filter
  side effects
- always forward physical modifier keys (Ctrl/Shift/Alt/Super) so
  clients maintain correct modifier state
- track intercepted press keys so releases are handled correctly
- normalize modifier matching so generic modifiers (shift/ctrl/alt/super)
  represent their full key family instead of requiring side-specific keys
- normalize key handling to XKB codes only (evdev + 8)
- remove mixed evdev/XKB comparisons that caused collisions (e.g. XKB 54
  being interpreted as Right Shift's evdev code), which broke bindings
  like Ctrl+Shift+C

This prevents client shortcuts from being swallowed unintentionally,
fixes modifier state corruption caused by evdev/XKB code collisions,
and makes the input pipeline more deterministic and compositor-safe.