### PR TITLE
wayland: fix clipboard paste by propagating selection focus with seat focus

### DIFF
--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -4,6 +4,8 @@ use halley_core::viewport::FocusZone;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface};
 use smithay::utils::SERIAL_COUNTER;
+use smithay::wayland::selection::data_device::set_data_device_focus;
+use smithay::wayland::selection::primary_selection::set_primary_focus;
 
 pub(super) struct ViewportPanAnim {
     pub(super) start_ms: u64,
@@ -23,11 +25,18 @@ impl HalleyWlState {
         None
     }
 
+    fn update_selection_focus_from_surface(&self, surface: Option<&WlSurface>) {
+        let client = surface.and_then(|wl| wl.client());
+        set_data_device_focus(&self.display_handle, &self.seat, client.clone());
+        set_primary_focus(&self.display_handle, &self.seat, client);
+    }
+
     fn apply_wayland_focus_state(&mut self, id: Option<NodeId>) {
         let focus_surface = id.and_then(|fid| self.wl_surface_for_node(fid));
         if let Some(keyboard) = self.seat.get_keyboard() {
             keyboard.set_focus(self, focus_surface.clone(), SERIAL_COUNTER.next_serial());
         }
+        self.update_selection_focus_from_surface(focus_surface.as_ref());
 
         for top in self.xdg_shell_state.toplevel_surfaces() {
             let key = top.wl_surface().id();
@@ -61,7 +70,8 @@ impl HalleyWlState {
                     desired_focus.as_ref().map(|wl| format!("{:?}", wl.id())),
                     current_focus.as_ref().map(|wl| format!("{:?}", wl.id()))
                 );
-                keyboard.set_focus(self, desired_focus, SERIAL_COUNTER.next_serial());
+                keyboard.set_focus(self, desired_focus.clone(), SERIAL_COUNTER.next_serial());
+                self.update_selection_focus_from_surface(desired_focus.as_ref());
             }
         }
     }

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -13,7 +13,9 @@ use smithay::{
     delegate_compositor, delegate_data_control, delegate_data_device, delegate_primary_selection,
     delegate_seat, delegate_shm, delegate_xdg_shell,
     input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus},
-    reexports::wayland_server::{Client, Resource, backend::ObjectId, protocol::wl_seat},
+    reexports::wayland_server::{
+        DisplayHandle, Resource, backend::ObjectId, protocol::wl_seat,
+    },
     utils::Serial,
     wayland::{
         buffer::BufferHandler,
@@ -54,6 +56,7 @@ use focus::ViewportPanAnim;
 use overview::OverviewAnim;
 
 pub struct HalleyWlState {
+    pub display_handle: DisplayHandle,
     pub compositor_state: CompositorState,
     pub xdg_shell_state: XdgShellState,
     pub shm_state: ShmState,
@@ -146,6 +149,7 @@ impl HalleyWlState {
             |_| true,
         );
         let mut out = Self {
+            display_handle: dh.clone(),
             compositor_state: CompositorState::new::<HalleyWlState>(dh),
             xdg_shell_state: XdgShellState::new::<HalleyWlState>(dh),
             shm_state: ShmState::new::<HalleyWlState>(dh, vec![]),
@@ -240,8 +244,6 @@ impl HalleyWlState {
         self.tick_overview_animation(now_ms);
         self.tick_viewport_pan_animation(now_ms);
         if self.overview_mode {
-            // Overview mode is authoritative: don't let decay/focus-ring/resize logic
-            // pull nodes back into Active while in the overview workspace.
             self.animator.observe_field(&self.field, now);
             return;
         }

--- a/crates/halley-wl/src/state/wayland_handlers.rs
+++ b/crates/halley-wl/src/state/wayland_handlers.rs
@@ -1,9 +1,16 @@
 use super::*;
-use smithay::wayland::selection::primary_selection::{PrimarySelectionHandler, PrimarySelectionState};
-use smithay::wayland::selection::wlr_data_control::DataControlState;
 use eventline::info;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
-use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::{Client, Resource, protocol::wl_surface::WlSurface};
+use smithay::wayland::selection::data_device::set_data_device_focus;
+use smithay::wayland::selection::primary_selection::{
+    PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
+};
+use smithay::wayland::selection::wlr_data_control::DataControlState;
+
+fn client_for_surface(surface: Option<&WlSurface>) -> Option<Client> {
+    surface.and_then(|wl| wl.client())
+}
 
 impl SeatHandler for HalleyWlState {
     type KeyboardFocus = WlSurface;
@@ -14,11 +21,15 @@ impl SeatHandler for HalleyWlState {
         &mut self.seat_state
     }
 
-    fn focus_changed(&mut self, _seat: &Seat<Self>, focused: Option<&WlSurface>) {
+    fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) {
         info!(
             "seat focus_changed -> {:?}",
             focused.map(|wl| format!("{:?}", wl.id()))
         );
+
+        let client = client_for_surface(focused);
+        set_data_device_focus(&self.display_handle, seat, client.clone());
+        set_primary_focus(&self.display_handle, seat, client);
     }
 
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
@@ -41,7 +52,13 @@ impl DataDeviceHandler for HalleyWlState {
 impl ClientDndGrabHandler for HalleyWlState {}
 
 impl ServerDndGrabHandler for HalleyWlState {
-    fn send(&mut self, _mime_type: String, _fd: std::os::unix::io::OwnedFd, _seat: Seat<Self>) {}
+    fn send(
+        &mut self,
+        _mime_type: String,
+        _fd: std::os::unix::io::OwnedFd,
+        _seat: Seat<Self>,
+    ) {
+    }
 }
 
 delegate_data_device!(HalleyWlState);
@@ -111,7 +128,12 @@ impl XdgShellHandler for HalleyWlState {
         let _ = popup.send_configure();
     }
 
-    fn move_request(&mut self, _surface: ToplevelSurface, _seat: wl_seat::WlSeat, _serial: Serial) {
+    fn move_request(
+        &mut self,
+        _surface: ToplevelSurface,
+        _seat: wl_seat::WlSeat,
+        _serial: Serial,
+    ) {
         // Interactive move is compositor-driven (configured modifier + drag), not
         // client-request driven.
     }


### PR DESCRIPTION
Wire clipboard selection focus into Halley's Wayland focus path so wl-paste can retrieve data from the active client.

Changes:
- add DisplayHandle to HalleyWlState for selection focus updates
- propagate wl_data_device focus on seat focus changes
- propagate primary selection focus on seat focus changes
- mirror selection focus updates in the compositor's explicit keyboard focus path for reliability
- convert focused WlSurface to the owning Client before updating selection state

This fixes clipboard paste in Halley by ensuring selection ownership and retrieval follow the currently focused client instead of only updating keyboard focus.