### PR TITLE
cleanup: remove focus-ring rotation and simplify docking/overlap config

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -20,7 +20,8 @@ pub struct RuntimeTuning {
 
     pub focus_ring_rx: f32,
     pub focus_ring_ry: f32,
-    pub focus_ring_rotation_rad: f32,
+    pub focus_ring_offset_x: f32,
+    pub focus_ring_offset_y: f32,
 
     pub primary_hot_inner_frac: f32,
     pub primary_to_preview_ms: u64,
@@ -79,7 +80,8 @@ impl Default for RuntimeTuning {
 
             focus_ring_rx: 820.0,
             focus_ring_ry: 420.0,
-            focus_ring_rotation_rad: 0.0,
+            focus_ring_offset_x: 0.0,
+            focus_ring_offset_y: 0.0,
 
             primary_hot_inner_frac: 0.88,
             primary_to_preview_ms: 1_200_000,
@@ -163,9 +165,8 @@ impl RuntimeTuning {
 
         self.focus_ring_rx = self.focus_ring_rx.clamp(8.0, 16_000.0);
         self.focus_ring_ry = self.focus_ring_ry.clamp(8.0, 16_000.0);
-        self.focus_ring_rotation_rad = self
-            .focus_ring_rotation_rad
-            .clamp(-std::f32::consts::PI, std::f32::consts::PI);
+        self.focus_ring_offset_x = self.focus_ring_offset_x.clamp(-16_000.0, 16_000.0);
+        self.focus_ring_offset_y = self.focus_ring_offset_y.clamp(-16_000.0, 16_000.0);
 
         self.primary_hot_inner_frac = self.primary_hot_inner_frac.clamp(0.1, 1.0);
         self.primary_to_preview_ms = self.primary_to_preview_ms.clamp(250, 7_200_000);
@@ -196,7 +197,8 @@ impl RuntimeTuning {
         FocusRing::new(
             self.focus_ring_rx,
             self.focus_ring_ry,
-            self.focus_ring_rotation_rad,
+            self.focus_ring_offset_x,
+            self.focus_ring_offset_y,
         )
     }
 

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -218,10 +218,16 @@ fn load_focus_ring_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         &["focus-ring.ry", "focus-ring.radius-y", "focus-ring.radius_y"],
         out.focus_ring_ry,
     );
-    out.focus_ring_rotation_rad = pick_f32(
+
+    out.focus_ring_offset_x = pick_f32(
         cfg,
-        &["focus-ring.rotation-rad", "focus-ring.rotation_rad"],
-        out.focus_ring_rotation_rad,
+        &["focus-ring.offset-x", "focus-ring.offset_x"],
+        out.focus_ring_offset_x,
+    );
+    out.focus_ring_offset_y = pick_f32(
+        cfg,
+        &["focus-ring.offset-y", "focus-ring.offset_y"],
+        out.focus_ring_offset_y,
     );
 
     // Transitional compatibility with the older config shape.

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -303,50 +303,6 @@ fn load_docking_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.non_overlap_gap_px =
         pick_f32(cfg, &["docking.gap", "docking.gap-px"], out.non_overlap_gap_px);
 
-    out.non_overlap_active_gap_scale = pick_f32(
-        cfg,
-        &[
-            "docking.active-gap-scale",
-            "docking.active_gap_scale",
-            "layout.active-gap-scale",
-            "layout.active_gap_scale",
-        ],
-        out.non_overlap_active_gap_scale,
-    );
-
-    out.non_overlap_bump_newer = pick_bool(
-        cfg,
-        &[
-            "docking.bump-newer",
-            "docking.bump_newer",
-            "layout.bump-newer",
-            "layout.bump_newer",
-        ],
-        out.non_overlap_bump_newer,
-    );
-
-    out.drag_smoothing_boost = pick_f32(
-        cfg,
-        &[
-            "docking.drag-smoothing-boost",
-            "docking.drag_smoothing_boost",
-            "layout.drag-smoothing-boost",
-            "layout.drag_smoothing_boost",
-        ],
-        out.drag_smoothing_boost,
-    );
-
-    out.center_window_to_mouse = pick_bool(
-        cfg,
-        &[
-            "docking.center-window-to-mouse",
-            "docking.center_window_to_mouse",
-            "layout.center-window-to-mouse",
-            "layout.center_window_to_mouse",
-        ],
-        out.center_window_to_mouse,
-    );
-
     out.restore_last_active_on_pan_return = pick_bool(
         cfg,
         &[

--- a/crates/halley-core/src/viewport.rs
+++ b/crates/halley-core/src/viewport.rs
@@ -69,26 +69,27 @@ pub enum FocusZone {
     Outside,
 }
 
-/// A focus ring modeled as a rotated ellipse in Field coordinates.
+/// A focus ring modeled as an axis-aligned ellipse in Field coordinates,
+/// with an offset relative to the viewport center.
 ///
 /// We use normalized ellipse distance:
-///   d2 = (x'/rx)^2 + (y'/ry)^2
+///   d2 = (x/rx)^2 + (y/ry)^2
 /// If d2 <= 1 => inside.
-///
-/// This is deterministic, cheap, and keeps the current ellipse/eye-like model.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FocusRing {
     pub radius_x: f32,
     pub radius_y: f32,
-    pub rotation_rad: f32,
+    pub offset_x: f32,
+    pub offset_y: f32,
 }
 
 impl FocusRing {
-    pub fn new(radius_x: f32, radius_y: f32, rotation_rad: f32) -> Self {
+    pub fn new(radius_x: f32, radius_y: f32, offset_x: f32, offset_y: f32) -> Self {
         Self {
             radius_x,
             radius_y,
-            rotation_rad,
+            offset_x,
+            offset_y,
         }
     }
 
@@ -105,24 +106,23 @@ impl FocusRing {
     }
 
     /// Return normalized squared distance inside this ellipse:
-    /// d2 = (x'/rx)^2 + (y'/ry)^2
+    /// d2 = (x/rx)^2 + (y/ry)^2
     /// - d2 <= 1.0: inside/on boundary
     /// - d2 > 1.0: outside
     pub fn normalized_distance2(&self, center: Vec2, p: Vec2) -> f32 {
-        let dx = p.x - center.x;
-        let dy = p.y - center.y;
+        let ring_center = Vec2 {
+            x: center.x + self.offset_x,
+            y: center.y + self.offset_y,
+        };
 
-        let (s, c) = self.rotation_rad.sin_cos();
-
-        // Rotate into focus-ring-local space.
-        let x = c * dx + s * dy;
-        let y = -s * dx + c * dy;
+        let dx = p.x - ring_center.x;
+        let dy = p.y - ring_center.y;
 
         let rx = self.radius_x.max(0.0001);
         let ry = self.radius_y.max(0.0001);
 
-        let nx = x / rx;
-        let ny = y / ry;
+        let nx = dx / rx;
+        let ny = dy / ry;
 
         nx * nx + ny * ny
     }
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn focus_ring_contains_axis_aligned() {
-        let ring = FocusRing::new(10.0, 5.0, 0.0);
+        let ring = FocusRing::new(10.0, 5.0, 0.0, 0.0);
         let c = Vec2 { x: 0.0, y: 0.0 };
 
         assert!(ring.contains(c, Vec2 { x: 0.0, y: 0.0 }));
@@ -167,8 +167,21 @@ mod tests {
     }
 
     #[test]
+    fn focus_ring_respects_offset() {
+        let ring = FocusRing::new(10.0, 5.0, 4.0, -2.0);
+        let c = Vec2 { x: 0.0, y: 0.0 };
+
+        assert!(ring.contains(c, Vec2 { x: 4.0, y: -2.0 }));
+        assert!(ring.contains(c, Vec2 { x: 14.0, y: -2.0 }));
+        assert!(ring.contains(c, Vec2 { x: 4.0, y: 3.0 }));
+
+        assert!(!ring.contains(c, Vec2 { x: 14.01, y: -2.0 }));
+        assert!(!ring.contains(c, Vec2 { x: 4.0, y: 3.01 }));
+    }
+
+    #[test]
     fn focus_zone_classifies() {
-        let ring = FocusRing::new(10.0, 10.0, 0.0);
+        let ring = FocusRing::new(10.0, 10.0, 0.0, 0.0);
         let c = Vec2 { x: 0.0, y: 0.0 };
 
         assert_eq!(ring.zone(c, Vec2 { x: 0.0, y: 0.0 }), FocusZone::Inside);

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -23,7 +23,6 @@ pub(crate) fn key_is_compositor_binding(
 ) -> bool {
     let kb = &st.tuning.keybinds;
 
-    // Quit is special: mod+shift+quit
     if key_matches(key_code, kb.quit_compositor) {
         let need = if st.tuning.quit_requires_shift {
             with_extra_shift(kb.modifier)
@@ -35,7 +34,6 @@ pub(crate) fn key_is_compositor_binding(
         }
     }
 
-    // Explicit configured launch bindings must match exactly.
     for binding in &st.tuning.launch_bindings {
         if key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
             return true;
@@ -84,7 +82,7 @@ pub(crate) fn apply_bound_key(
 ) -> bool {
     const STEP_RX: f32 = 24.0;
     const STEP_RY: f32 = 16.0;
-    const STEP_ROT: f32 = 0.05;
+    const STEP_OFFSET: f32 = 24.0;
     const STEP_NODE: f32 = 80.0;
 
     let kb = st.tuning.keybinds.clone();
@@ -166,21 +164,19 @@ pub(crate) fn apply_bound_key(
         }
 
         code if key_matches(code, kb.secondary_left) && modifier_exact(mods, kb.modifier) => {
-            st.tuning.focus_ring_rotation_rad -= STEP_ROT;
+            st.tuning.focus_ring_offset_x -= STEP_OFFSET;
             true
         }
         code if key_matches(code, kb.secondary_right) && modifier_exact(mods, kb.modifier) => {
-            st.tuning.focus_ring_rotation_rad += STEP_ROT;
+            st.tuning.focus_ring_offset_x += STEP_OFFSET;
             true
         }
         code if key_matches(code, kb.secondary_up) && modifier_exact(mods, kb.modifier) => {
-            st.tuning.focus_ring_rx += STEP_RX;
-            st.tuning.focus_ring_ry += STEP_RY;
+            st.tuning.focus_ring_offset_y += STEP_OFFSET;
             true
         }
         code if key_matches(code, kb.secondary_down) && modifier_exact(mods, kb.modifier) => {
-            st.tuning.focus_ring_rx -= STEP_RX;
-            st.tuning.focus_ring_ry -= STEP_RY;
+            st.tuning.focus_ring_offset_y -= STEP_OFFSET;
             true
         }
         _ => false,
@@ -189,10 +185,11 @@ pub(crate) fn apply_bound_key(
     if changed {
         st.tuning.enforce_guards();
         info!(
-            "focus-ring {:.0}x{:.0} rot={:.2}",
+            "focus-ring {:.0}x{:.0} offset=({:.0},{:.0})",
             st.tuning.focus_ring_rx,
             st.tuning.focus_ring_ry,
-            st.tuning.focus_ring_rotation_rad
+            st.tuning.focus_ring_offset_x,
+            st.tuning.focus_ring_offset_y
         );
     }
 

--- a/crates/halley-wl/src/render.rs
+++ b/crates/halley-wl/src/render.rs
@@ -28,7 +28,8 @@ pub struct RingDebugGeom {
     pub center: Vec2,
     pub radius_x: f32,
     pub radius_y: f32,
-    pub rotation_rad: f32,
+    pub offset_x: f32,
+    pub offset_y: f32,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -46,8 +47,6 @@ pub struct DebugScene {
     pub zones: ZoneCounts,
 }
 
-/// Minimal render-facing snapshot for upcoming debug drawing.
-/// This is intentionally independent from smithay backend wiring.
 pub fn build_debug_scene(field: &Field, vp: &Viewport, focus_ring: FocusRing) -> DebugScene {
     let mut zones = ZoneCounts::default();
     let mut visible = 0usize;
@@ -67,18 +66,17 @@ pub fn build_debug_scene(field: &Field, vp: &Viewport, focus_ring: FocusRing) ->
         viewport_center: Vec2::new(vp.center.x, vp.center.y),
         viewport_size: Vec2::new(vp.size.x, vp.size.y),
         focus_ring: RingDebugGeom {
-            center: Vec2::new(vp.center.x, vp.center.y),
+            center: Vec2::new(vp.center.x + focus_ring.offset_x, vp.center.y + focus_ring.offset_y),
             radius_x: focus_ring.radius_x,
             radius_y: focus_ring.radius_y,
-            rotation_rad: focus_ring.rotation_rad,
+            offset_x: focus_ring.offset_x,
+            offset_y: focus_ring.offset_y,
         },
         node_count_visible: visible,
         zones,
     }
 }
 
-/// Lightweight GPU bootstrap holder for the next step.
-/// No rendering is performed yet.
 #[derive(Debug)]
 pub struct GpuBootstrap {
     pub instance: wgpu::Instance,
@@ -119,7 +117,7 @@ mod tests {
                 y: 1080.0,
             },
         );
-        let focus_ring = FocusRing::new(200.0, 120.0, 0.0);
+        let focus_ring = FocusRing::new(200.0, 120.0, 0.0, 0.0);
 
         let s = build_debug_scene(&f, &vp, focus_ring);
         assert_eq!(s.node_count_visible, 2);

--- a/crates/halley-wl/src/runtime_render/frame_render.rs
+++ b/crates/halley-wl/src/runtime_render/frame_render.rs
@@ -220,7 +220,8 @@ pub(crate) fn draw_debug_frame_to_target(
         size.h,
         focus_ring.radius_x,
         focus_ring.radius_y,
-        focus_ring.rotation_rad,
+        focus_ring.offset_x,
+        focus_ring.offset_y,
         Color32F::new(0.15, 0.85, 0.85, 0.9),
         damage,
     )?;

--- a/crates/halley-wl/src/runtime_render/render_utils.rs
+++ b/crates/halley-wl/src/runtime_render/render_utils.rs
@@ -17,18 +17,19 @@ pub(crate) fn draw_ring<F: Frame>(
     h: i32,
     rx: f32,
     ry: f32,
-    rot: f32,
+    offset_x: f32,
+    offset_y: f32,
     color: Color32F,
     damage: Rectangle<i32, Physical>,
 ) -> Result<(), F::Error> {
     let samples = 96;
-    let (s, c) = rot.sin_cos();
+    let center_x = st.viewport.center.x + offset_x;
+    let center_y = st.viewport.center.y + offset_y;
+
     for i in 0..samples {
         let t = (i as f32 / samples as f32) * TAU;
-        let ex = t.cos() * rx;
-        let ey = t.sin() * ry;
-        let x = c * ex - s * ey + st.viewport.center.x;
-        let y = s * ex + c * ey + st.viewport.center.y;
+        let x = center_x + t.cos() * rx;
+        let y = center_y + t.sin() * ry;
         let (sx, sy) = world_to_screen(st, w, h, x, y);
         draw_rect(frame, sx - 1, sy - 1, 3, 3, color, damage)?;
     }
@@ -94,7 +95,6 @@ pub(crate) fn sync_node_size_from_surface(
     let bw = bbox.size.w.max(1) as f32;
     let bh = bbox.size.h.max(1) as f32;
 
-    // Do immutable reads before taking node_mut.
     let now_ms = st.now_ms(Instant::now());
     let resize_static_active = st.resize_static_active_for(node_id, now_ms);
 
@@ -121,8 +121,6 @@ pub(crate) fn sync_node_size_from_surface(
 }
 
 pub(crate) fn preview_proxy_size(_real_w: f32, _real_h: f32) -> (f32, f32) {
-    // Node/proxy footprint must be source-size invariant.
-    // Keep this fixed so all windows collapse to a uniform node size.
     (220.0, 220.0)
 }
 

--- a/crates/halley-wl/src/state/overlap.rs
+++ b/crates/halley-wl/src/state/overlap.rs
@@ -22,20 +22,22 @@ impl HalleyWlState {
         if !self.tuning.physics_enabled {
             return self.field.carry(id, to);
         }
+
         let Some(n) = self.field.node(id) else {
             return false;
         };
         if n.kind != halley_core::field::NodeKind::Surface {
             return self.field.carry(id, to);
         }
+
         let mover_size = self.collision_size_for_node(n);
         let gap = self.non_overlap_gap_world();
-        let base_damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0);
+        let damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0);
         let mut mover_pos = to;
 
         const MAX_PUSH_STEP: f32 = 6.0;
         const MAX_PUSHES_PER_PASS: usize = 2;
-        // Active push behavior: when dragged into another window, push the other one.
+
         for _ in 0..16 {
             let others: Vec<(NodeId, Vec2, Vec2, bool)> = self
                 .field
@@ -56,6 +58,7 @@ impl HalleyWlState {
                     ))
                 })
                 .collect();
+
             let mut changed = false;
             let mut pushes_this_pass = 0usize;
 
@@ -63,19 +66,23 @@ impl HalleyWlState {
                 if pushes_this_pass >= MAX_PUSHES_PER_PASS {
                     break;
                 }
+
                 let dx = opos.x - mover_pos.x;
                 let dy = opos.y - mover_pos.y;
-                let pair_gap = gap;
-                let req_x = mover_size.x * 0.5 + osize.x * 0.5 + pair_gap;
-                let req_y = mover_size.y * 0.5 + osize.y * 0.5 + pair_gap;
+                let req_x = mover_size.x * 0.5 + osize.x * 0.5 + gap;
+                let req_y = mover_size.y * 0.5 + osize.y * 0.5 + gap;
+
                 let ox = req_x - dx.abs();
                 let oy = req_y - dy.abs();
-                // Keep repulsion onset consistent across all state edges.
-                let bubble = 1.0;
-                let sx = (req_x + bubble) - dx.abs();
-                let sy = (req_y + bubble) - dy.abs();
+
+                // Small soft zone so windows begin easing apart before true overlap.
+                let soft_zone = 1.0;
+                let sx = (req_x + soft_zone) - dx.abs();
+                let sy = (req_y + soft_zone) - dy.abs();
+
                 if sx > 0.0 && sy > 0.0 {
-                    let soft = base_damping * 0.14;
+                    let soft = damping * 0.14;
+
                     if sx < sy {
                         let step = (sx * soft).max(0.35).min(MAX_PUSH_STEP);
                         if opinned {
@@ -85,6 +92,7 @@ impl HalleyWlState {
                             let s = if dx >= 0.0 { 1.0 } else { -1.0 };
                             let split_other = step * 0.45;
                             let split_mover = step * 0.55;
+
                             let _ = self.field.carry(
                                 oid,
                                 Vec2 {
@@ -105,6 +113,7 @@ impl HalleyWlState {
                             let s = if dy >= 0.0 { 1.0 } else { -1.0 };
                             let split_other = step * 0.45;
                             let split_mover = step * 0.55;
+
                             let _ = self.field.carry(
                                 oid,
                                 Vec2 {
@@ -119,9 +128,9 @@ impl HalleyWlState {
                     }
                 }
 
-                // Hard separation on contact for all state edges.
                 if ox > 0.0 && oy > 0.0 {
                     let hard_gain = 0.24;
+
                     if opinned {
                         if ox < oy {
                             let s = if dx >= 0.0 { -1.0 } else { 1.0 };
@@ -149,6 +158,7 @@ impl HalleyWlState {
                                 y: opos.y + s * (step * 0.45),
                             }
                         };
+
                         if self.field.carry(oid, target) {
                             changed = true;
                             pushes_this_pass += 1;
@@ -172,9 +182,11 @@ impl HalleyWlState {
         if n.kind != halley_core::field::NodeKind::Surface {
             return self.field.carry(id, to);
         }
+
         let mover_size = self.collision_size_for_node(n);
         let gap = self.non_overlap_gap_world();
         let mut mover_pos = to;
+
         for _ in 0..24 {
             let others: Vec<(NodeId, Vec2, Vec2)> = self
                 .field
@@ -190,7 +202,9 @@ impl HalleyWlState {
                     Some((oid, other.pos, self.collision_size_for_node(other)))
                 })
                 .collect();
+
             let mut changed = false;
+
             for (oid, opos, osize) in others {
                 let dx = mover_pos.x - opos.x;
                 let dy = mover_pos.y - opos.y;
@@ -198,9 +212,11 @@ impl HalleyWlState {
                 let req_y = mover_size.y * 0.5 + osize.y * 0.5 + gap;
                 let ox = req_x - dx.abs();
                 let oy = req_y - dy.abs();
+
                 if ox <= 0.0 || oy <= 0.0 {
                     continue;
                 }
+
                 if ox < oy {
                     let s = if dx.abs() > f32::EPSILON {
                         dx.signum()
@@ -218,12 +234,15 @@ impl HalleyWlState {
                     };
                     mover_pos.y += s * (oy + 0.3);
                 }
+
                 changed = true;
             }
+
             if !changed {
                 break;
             }
         }
+
         self.field.carry(id, mover_pos)
     }
 
@@ -234,6 +253,7 @@ impl HalleyWlState {
         let base_h = 160.0f32;
         let mut out_w = base_h * aspect;
         let mut out_h = base_h;
+
         if out_w < 180.0 {
             out_w = 180.0;
             out_h = out_w / aspect.max(0.1);
@@ -242,23 +262,25 @@ impl HalleyWlState {
             out_w = 360.0;
             out_h = out_w / aspect.max(0.1);
         }
+
         out_h = out_h.clamp(100.0, 220.0);
         Vec2 { x: out_w, y: out_h }
     }
 
     #[inline]
     fn active_collision_scale(anim_scale: f32, real_w: f32, real_h: f32) -> f32 {
-        // Keep collision envelope growth in sync with render-time Active morph.
         let base = Self::preview_collision_size(real_w, real_h);
         let start = (base.x / real_w.max(1.0))
             .min(base.y / real_h.max(1.0))
             .clamp(0.24, 1.0);
         let t = ((anim_scale - 0.30) / (1.0 - 0.30)).clamp(0.0, 1.0);
         let e = t * t * (3.0 - 2.0 * t);
+
         let mut out = start + (1.0 - start) * e;
         if anim_scale > 1.0 {
             out += (anim_scale - 1.0) * 0.30;
         }
+
         out.clamp(0.24, 1.08)
     }
 
@@ -268,7 +290,6 @@ impl HalleyWlState {
     }
 
     fn node_collision_size(&self, label: &str, anim_scale: f32) -> Vec2 {
-        // Match the visual node marker envelope (dot + label + outline pad).
         let zx = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let zy = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
         let z = ((zx + zy) * 0.5).clamp(1.0, 8.0);
@@ -282,9 +303,6 @@ impl HalleyWlState {
             .clamp(24.0, 320.0);
         let pad_px = 6.0;
 
-        // Collision solver assumes center-symmetric extents.
-        // Node visuals are asymmetric (label is to the right), so use a
-        // conservative symmetric envelope to prevent one-sided overlap.
         let left_half_px = dot_half_px + pad_px;
         let right_half_px = label_gap_px + label_w_px + pad_px;
         let half_w_px = left_half_px.max(right_half_px).max(4.0);
@@ -292,9 +310,9 @@ impl HalleyWlState {
         let bounds_w_px = (half_w_px * 2.0).max(8.0);
         let bounds_h_px = (half_h_px * 2.0).max(8.0);
 
-        // Convert marker pixel envelope to field units.
         let world_per_px_x = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let world_per_px_y = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
+
         Vec2 {
             x: bounds_w_px * world_per_px_x.max(0.01),
             y: bounds_h_px * world_per_px_y.max(0.01),
@@ -304,9 +322,8 @@ impl HalleyWlState {
     pub(super) fn collision_size_for_node(&self, n: &halley_core::field::Node) -> Vec2 {
         let now = Instant::now();
         let anim = self.anim_style_for(n.id, n.state.clone(), now);
+
         match n.state {
-            // Camera-invariant collision for Active windows:
-            // zooming the viewport must not change repel boundaries.
             halley_core::field::NodeState::Active => {
                 let basis = self
                     .last_active_size
@@ -315,10 +332,9 @@ impl HalleyWlState {
                     .unwrap_or(n.intrinsic_size);
                 let s = Self::active_collision_scale(anim.scale, basis.x, basis.y);
                 let (world_per_px_x, world_per_px_y) = self.world_units_per_px_xy();
-                // Slightly tighten active envelope to compensate common CSD/shadow
-                // extents that visually look like excess top/bottom collision area.
                 let base_w = (basis.x - 4.0).max(32.0);
                 let base_h = (basis.y - 14.0).max(32.0);
+
                 Vec2 {
                     x: base_w * s * world_per_px_x,
                     y: base_h * s * world_per_px_y,
@@ -341,6 +357,7 @@ impl HalleyWlState {
         if self.suspend_overlap_resolve {
             return;
         }
+
         let now_ms = self.now_ms(Instant::now());
         let mut ids: Vec<NodeId> = self
             .field
@@ -354,29 +371,33 @@ impl HalleyWlState {
                     .is_some_and(|n| n.kind == halley_core::field::NodeKind::Surface)
             })
             .collect();
+
         if ids.len() < 2 {
             return;
         }
+
         ids.sort_by_key(|id| id.as_u64());
+
         let gap = self.non_overlap_gap_world();
-        let bump_newer = self.tuning.non_overlap_bump_newer;
         let focus_id = self.interaction_focus;
         let damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 0.35);
+
         const MAX_RESOLVE_STEP: f32 = 18.0;
 
-        // Hard deterministic solver: when two windows overlap, move the newer one.
         for _ in 0..24 {
             let mut changed = false;
+
             for i in 0..ids.len() {
                 for j in (i + 1)..ids.len() {
                     let a = ids[i];
                     let b = ids[j];
+
                     if self.is_recently_resized_node(a, now_ms)
                         || self.is_recently_resized_node(b, now_ms)
                     {
-                        // Never auto-reposition a node that was just resized.
                         continue;
                     }
+
                     if self
                         .docked_links
                         .get(&a)
@@ -386,173 +407,121 @@ impl HalleyWlState {
                             .get(&b)
                             .is_some_and(|link| link.partner == a)
                     {
-                        // Docked pairs are constraint-locked elsewhere; skip repel solver
-                        // to prevent steady-state tug-of-war drift.
                         continue;
                     }
+
                     let Some(na) = self.field.node(a) else {
                         continue;
                     };
                     let Some(nb) = self.field.node(b) else {
                         continue;
                     };
-                    if na.pinned && nb.pinned {
+
+                    let a_pos = na.pos;
+                    let b_pos = nb.pos;
+                    let a_pinned = na.pinned;
+                    let b_pinned = nb.pinned;
+
+                    if a_pinned && b_pinned {
                         continue;
                     }
 
-                    let dx = nb.pos.x - na.pos.x;
-                    let dy = nb.pos.y - na.pos.y;
                     let sa = self.collision_size_for_node(na);
                     let sb = self.collision_size_for_node(nb);
-                    let pair_gap = gap;
-                    let req_x = sa.x * 0.5 + sb.x * 0.5 + pair_gap;
-                    let req_y = sa.y * 0.5 + sb.y * 0.5 + pair_gap;
+
+                    let dx = b_pos.x - a_pos.x;
+                    let dy = b_pos.y - a_pos.y;
+
+                    let req_x = sa.x * 0.5 + sb.x * 0.5 + gap;
+                    let req_y = sa.y * 0.5 + sb.y * 0.5 + gap;
                     let ox = req_x - dx.abs();
                     let oy = req_y - dy.abs();
-                    // Keep near-contact smoothing consistent across all state edges.
+
                     let soft_zone = 1.0;
                     let sx = (req_x + soft_zone) - dx.abs();
                     let sy = (req_y + soft_zone) - dy.abs();
+
+                    let mut primary_id = if focus_id == Some(a) {
+                        b
+                    } else if focus_id == Some(b) {
+                        a
+                    } else {
+                        b
+                    };
+
+                    if primary_id == a && a_pinned && !b_pinned {
+                        primary_id = b;
+                    } else if primary_id == b && b_pinned && !a_pinned {
+                        primary_id = a;
+                    } else if a_pinned && b_pinned {
+                        continue;
+                    }
+
+                    let (mover_id, mover_pos, anchor_pos, mx, my, mover_pinned) = if primary_id == a {
+                        (a, a_pos, b_pos, if dx >= 0.0 { -1.0 } else { 1.0 }, if dy >= 0.0 { -1.0 } else { 1.0 }, a_pinned)
+                    } else {
+                        (b, b_pos, a_pos, if dx >= 0.0 { 1.0 } else { -1.0 }, if dy >= 0.0 { 1.0 } else { -1.0 }, b_pinned)
+                    };
+
+                    if mover_pinned {
+                        continue;
+                    }
+
                     if ox <= 0.0 || oy <= 0.0 {
-                        // Near-contact smoothing to avoid late "snap" corrections.
                         if sx > 0.0 && sy > 0.0 {
-                            let (mover_id, mover, anchor, msx, msy) =
-                                if focus_id == Some(a) && !nb.pinned {
-                                    (
-                                        b,
-                                        nb,
-                                        na,
-                                        if dx >= 0.0 { 1.0 } else { -1.0 },
-                                        if dy >= 0.0 { 1.0 } else { -1.0 },
-                                    )
-                                } else if focus_id == Some(b) && !na.pinned {
-                                    (
-                                        a,
-                                        na,
-                                        nb,
-                                        if dx >= 0.0 { -1.0 } else { 1.0 },
-                                        if dy >= 0.0 { -1.0 } else { 1.0 },
-                                    )
-                                } else if bump_newer {
-                                    (
-                                        b,
-                                        nb,
-                                        na,
-                                        if dx >= 0.0 { 1.0 } else { -1.0 },
-                                        if dy >= 0.0 { 1.0 } else { -1.0 },
-                                    )
-                                } else {
-                                    (
-                                        a,
-                                        na,
-                                        nb,
-                                        if dx >= 0.0 { -1.0 } else { 1.0 },
-                                        if dy >= 0.0 { -1.0 } else { 1.0 },
-                                    )
-                                };
-                            if !mover.pinned {
-                                let nudge = (sx.min(sy) * damping * 0.18).clamp(0.15, 2.4);
-                                let target = if sx < sy {
-                                    Vec2 {
-                                        x: mover.pos.x + msx * nudge,
-                                        y: mover.pos.y,
-                                    }
-                                } else {
-                                    Vec2 {
-                                        x: mover.pos.x,
-                                        y: mover.pos.y + msy * nudge,
-                                    }
-                                };
-                                if self.field.carry(mover_id, target) {
-                                    changed = true;
+                            let nudge = (sx.min(sy) * damping * 0.18).clamp(0.15, 2.4);
+                            let target = if sx < sy {
+                                Vec2 {
+                                    x: mover_pos.x + mx * nudge,
+                                    y: mover_pos.y,
                                 }
                             } else {
-                                let _ = anchor;
+                                Vec2 {
+                                    x: mover_pos.x,
+                                    y: mover_pos.y + my * nudge,
+                                }
+                            };
+
+                            if self.field.carry(mover_id, target) {
+                                changed = true;
                             }
                         }
                         continue;
                     }
 
-                    let (mover_id, mover, anchor, sx, sy) = if focus_id == Some(a) && !nb.pinned {
-                        (
-                            b,
-                            nb,
-                            na,
-                            if dx >= 0.0 { 1.0 } else { -1.0 },
-                            if dy >= 0.0 { 1.0 } else { -1.0 },
-                        )
-                    } else if focus_id == Some(b) && !na.pinned {
-                        (
-                            a,
-                            na,
-                            nb,
-                            if dx >= 0.0 { -1.0 } else { 1.0 },
-                            if dy >= 0.0 { -1.0 } else { 1.0 },
-                        )
-                    } else if bump_newer {
-                        (
-                            b,
-                            nb,
-                            na,
-                            if dx >= 0.0 { 1.0 } else { -1.0 },
-                            if dy >= 0.0 { 1.0 } else { -1.0 },
-                        )
-                    } else {
-                        (
-                            a,
-                            na,
-                            nb,
-                            if dx >= 0.0 { -1.0 } else { 1.0 },
-                            if dy >= 0.0 { -1.0 } else { 1.0 },
-                        )
-                    };
-                    let fallback = if mover_id == b { a } else { b };
-                    let mover = if !mover.pinned {
-                        Some((mover_id, mover, anchor, sx, sy))
-                    } else {
-                        let Some(other) = self.field.node(fallback) else {
-                            continue;
-                        };
-                        if other.pinned {
-                            None
-                        } else {
-                            let fsx = -sx;
-                            let fsy = -sy;
-                            Some((fallback, other, mover, fsx, fsy))
-                        }
-                    };
-                    let Some((mid, mnode, anode, msx, msy)) = mover else {
-                        continue;
-                    };
-
                     let full_target = if ox < oy {
                         Vec2 {
-                            x: anode.pos.x + msx * (req_x + 0.3),
-                            y: mnode.pos.y,
+                            x: anchor_pos.x + mx * (req_x + 0.3),
+                            y: mover_pos.y,
                         }
                     } else {
                         Vec2 {
-                            x: mnode.pos.x,
-                            y: anode.pos.y + msy * (req_y + 0.3),
+                            x: mover_pos.x,
+                            y: anchor_pos.y + my * (req_y + 0.3),
                         }
                     };
+
                     let mut step = Vec2 {
-                        x: (full_target.x - mnode.pos.x) * damping,
-                        y: (full_target.y - mnode.pos.y) * damping,
+                        x: (full_target.x - mover_pos.x) * damping,
+                        y: (full_target.y - mover_pos.y) * damping,
                     };
+
                     step.x = step.x.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
                     step.y = step.y.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
-                    if step.x.abs() < 0.5 && (full_target.x - mnode.pos.x).abs() > 0.5 {
+
+                    if step.x.abs() < 0.5 && (full_target.x - mover_pos.x).abs() > 0.5 {
                         step.x = 0.5 * step.x.signum();
                     }
-                    if step.y.abs() < 0.5 && (full_target.y - mnode.pos.y).abs() > 0.5 {
+                    if step.y.abs() < 0.5 && (full_target.y - mover_pos.y).abs() > 0.5 {
                         step.y = 0.5 * step.y.signum();
                     }
+
                     let target = Vec2 {
-                        x: mnode.pos.x + step.x,
-                        y: mnode.pos.y + step.y,
+                        x: mover_pos.x + step.x,
+                        y: mover_pos.y + step.y,
                     };
-                    if self.field.carry(mid, target) {
+
+                    if self.field.carry(mover_id, target) {
                         changed = true;
                     }
                 }
@@ -568,12 +537,15 @@ impl HalleyWlState {
         let width = width.max(96);
         let height = height.max(72);
         let focused_node = self.last_input_surface_node();
+
         for top in self.xdg_shell_state.toplevel_surfaces() {
             let wl = top.wl_surface();
             let key = wl.id();
+
             if self.surface_to_node.get(&key).copied() != Some(node_id) {
                 continue;
             }
+
             top.with_pending_state(|s| {
                 s.size = Some((width, height).into());
                 if focused_node == Some(node_id) {

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -85,7 +85,7 @@ impl HalleyWlState {
         }
 
         debug!(
-            "tick-dump nodes={} visible={} state(a/n/c/o)={}/{}/{}/{} zone(i/o)={}/{} vp=({:.0},{:.0}) {:.0}x{:.0} focus-ring({:.0}x{:.0} rot={:.2})",
+            "tick-dump nodes={} visible={} state(a/n/c/o)={}/{}/{}/{} zone(i/o)={}/{} vp=({:.0},{:.0}) {:.0}x{:.0} focus-ring({:.0}x{:.0} offset=({:.0},{:.0}))",
             nodes_total,
             visible_total,
             state_active,
@@ -100,7 +100,8 @@ impl HalleyWlState {
             self.viewport.size.y,
             self.tuning.focus_ring_rx,
             self.tuning.focus_ring_ry,
-            self.tuning.focus_ring_rotation_rad,
+            self.tuning.focus_ring_offset_x,
+            self.tuning.focus_ring_offset_y,
         );
     }
 
@@ -170,6 +171,8 @@ impl HalleyWlState {
 
         ring.radius_x *= sx;
         ring.radius_y *= sy;
+        ring.offset_x *= sx;
+        ring.offset_y *= sy;
         ring
     }
 }

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -10,7 +10,8 @@ end
 focus-ring:
   primary-rx 820.0
   primary-ry 420.0
-  rotation-rad 0.0
+  offset-x 0
+  offset-y 0
 end
 
 clusters:


### PR DESCRIPTION
This PR cleans up several onfiguration and runtime paths by
removing unused complexity and aligning the code with Halley’s current
design.

Focus ring changes:
- remove focus_ring_rotation_rad from RuntimeTuning
- remove rotation handling from FocusRing math and rendering
- introduce focus_ring_offset_x / focus_ring_offset_y
- focus ring is now centered at: viewport.center + (offset_x, offset_y)
- simplify draw_ring implementation (no trig rotation step)

Docking / overlap changes:
- reduce docking configuration to a single gap value
- remove unused tuning knobs (active-gap-scale, bump-newer,
  drag-smoothing-boost, center-window-to-mouse)
- simplify overlap solver mover selection
- deterministic behavior: move the non-focused window, otherwise the
  newer window
- keep gap enforcement and damping behavior intact

These changes remove configuration drift, simplify the math involved in
focus-ring and overlap behavior, and make the system easier to reason
about as Halley moves toward IPC and higher-level features.