### PR TITLE
refactor(core): move docking into halley-core and remove warm decay state

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -24,8 +24,7 @@ pub struct RuntimeTuning {
     pub focus_ring_offset_y: f32,
 
     pub primary_hot_inner_frac: f32,
-    pub primary_to_preview_ms: u64,
-    pub primary_preview_to_node_ms: u64,
+    pub primary_to_node_ms: u64,
 
     pub dev_enabled: bool,
     pub dev_show_geometry_overlay: bool,
@@ -84,8 +83,7 @@ impl Default for RuntimeTuning {
             focus_ring_offset_y: 0.0,
 
             primary_hot_inner_frac: 0.88,
-            primary_to_preview_ms: 1_200_000,
-            primary_preview_to_node_ms: 60_000,
+            primary_to_node_ms: 1_260_000,
 
             dev_enabled: false,
             dev_show_geometry_overlay: false,
@@ -169,8 +167,7 @@ impl RuntimeTuning {
         self.focus_ring_offset_y = self.focus_ring_offset_y.clamp(-16_000.0, 16_000.0);
 
         self.primary_hot_inner_frac = self.primary_hot_inner_frac.clamp(0.1, 1.0);
-        self.primary_to_preview_ms = self.primary_to_preview_ms.clamp(250, 7_200_000);
-        self.primary_preview_to_node_ms = self.primary_preview_to_node_ms.clamp(250, 7_200_000);
+        self.primary_to_node_ms = self.primary_to_node_ms.clamp(250, 7_200_000);
 
         self.dev_zoom_decay_min_frac = self.dev_zoom_decay_min_frac.clamp(0.005, 0.5);
         self.dev_anim_state_change_ms = self.dev_anim_state_change_ms.clamp(30, 3_000);
@@ -204,8 +201,7 @@ impl RuntimeTuning {
 
     pub fn focus_ring_decay_policy(&self) -> FocusRingDecayPolicy {
         let mut p = FocusRingDecayPolicy::new();
-        p.inside_to_preview_ms = self.primary_to_preview_ms;
-        p.preview_to_node_ms = self.primary_preview_to_node_ms;
+        p.inside_to_node_ms = self.primary_to_node_ms;
         p
     }
 

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -244,7 +244,19 @@ fn load_focus_ring_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 }
 
 fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.primary_to_preview_ms = pick_u64(
+    out.primary_to_node_ms = pick_u64(
+        cfg,
+        &[
+            "nodes.primary-to-node-ms",
+            "nodes.primary_to_node_ms",
+            "nodes.node-delay",
+            "nodes.node_delay",
+        ],
+        out.primary_to_node_ms,
+    );
+
+    // Backward compatibility for old two-stage configs.
+    let legacy_preview = pick_u64(
         cfg,
         &[
             "nodes.primary-to-preview-ms",
@@ -252,10 +264,9 @@ fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
             "nodes.preview-delay",
             "nodes.preview_delay",
         ],
-        out.primary_to_preview_ms,
+        0,
     );
-
-    out.primary_preview_to_node_ms = pick_u64(
+    let legacy_preview_to_node = pick_u64(
         cfg,
         &[
             "nodes.primary-preview-to-node-ms",
@@ -263,8 +274,15 @@ fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
             "nodes.preview-to-node-ms",
             "nodes.preview_to_node_ms",
         ],
-        out.primary_preview_to_node_ms,
+        0,
     );
+
+    if legacy_preview > 0 || legacy_preview_to_node > 0 {
+        let combined = legacy_preview.saturating_add(legacy_preview_to_node);
+        if combined > 0 {
+            out.primary_to_node_ms = combined;
+        }
+    }
 
     out.primary_hot_inner_frac = pick_f32(
         cfg,

--- a/crates/halley-core/src/cluster_policy.rs
+++ b/crates/halley-core/src/cluster_policy.rs
@@ -214,10 +214,6 @@ mod tests {
     use super::*;
     use crate::field::Vec2;
 
-    // NOTE: this helper requires a small addition to Field (see below):
-    // `clusters_iter()` that yields &Cluster.
-    // (Or you can replace it in tests by scanning `field.cluster(..)` if you prefer.)
-
     #[test]
     fn forms_cluster_after_dwell() {
         let mut f = Field::new();
@@ -231,6 +227,7 @@ mod tests {
             dwell_ms: 1_000,
             min_members: 2,
             include_anchored: false,
+            include_active: true,
         };
 
         // t=0: start timer but not mature
@@ -283,6 +280,7 @@ mod tests {
             dwell_ms: 1_000,
             min_members: 2,
             include_anchored: false,
+            include_active: true,
         };
 
         // Start near

--- a/crates/halley-core/src/decay.rs
+++ b/crates/halley-core/src/decay.rs
@@ -7,24 +7,18 @@ use crate::field::NodeState;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DecayLevel {
     Hot,  // Active
-    Warm, // Preview
     Cold, // Node
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DecayPolicy {
-    /// Age >= preview_after_ms => Warm/Preview
-    pub preview_after_ms: u64,
-    /// Age >= node_after_ms => Cold/Node (must be >= preview_after_ms)
+    /// Age >= node_after_ms => Cold/Node
     pub node_after_ms: u64,
 }
 
 impl DecayPolicy {
-    pub fn new(preview_after_ms: u64, node_after_ms: u64) -> Self {
-        Self {
-            preview_after_ms,
-            node_after_ms,
-        }
+    pub fn new(node_after_ms: u64) -> Self {
+        Self { node_after_ms }
     }
 }
 
@@ -33,8 +27,6 @@ impl DecayPolicy {
 /// - `focused` is pinned Hot.
 /// - Core nodes do not decay (they remain handles).
 pub fn tick_decay(field: &mut Field, now_ms: u64, policy: DecayPolicy, focused: Option<NodeId>) {
-    debug_assert!(policy.node_after_ms >= policy.preview_after_ms);
-
     let ids: Vec<NodeId> = field.nodes().keys().copied().collect();
 
     for id in ids {
@@ -45,18 +37,16 @@ pub fn tick_decay(field: &mut Field, now_ms: u64, policy: DecayPolicy, focused: 
         }
 
         if Some(id) == focused {
-            field.set_decay_level(id, DecayLevel::Hot);
+            let _ = field.set_decay_level(id, DecayLevel::Hot);
             continue;
         }
 
         let age = now_ms.saturating_sub(n.last_touch_ms);
 
         if age >= policy.node_after_ms {
-            field.set_decay_level(id, DecayLevel::Cold);
-        } else if age >= policy.preview_after_ms {
-            field.set_decay_level(id, DecayLevel::Warm);
+            let _ = field.set_decay_level(id, DecayLevel::Cold);
         } else {
-            field.set_decay_level(id, DecayLevel::Hot);
+            let _ = field.set_decay_level(id, DecayLevel::Hot);
         }
     }
 }
@@ -64,13 +54,9 @@ pub fn tick_decay(field: &mut Field, now_ms: u64, policy: DecayPolicy, focused: 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FocusRingDecayPolicy {
     /// Inside the focus ring:
-    /// - age < inside_to_preview_ms => Hot/Active
-    /// - age < inside_to_preview_ms + preview_to_node_ms => Warm/Preview
+    /// - age < inside_to_node_ms => Hot/Active
     /// - otherwise => Cold/Node
-    pub inside_to_preview_ms: u64,
-
-    /// Additional time spent in Preview before Node once inside_to_preview_ms is reached.
-    pub preview_to_node_ms: u64,
+    pub inside_to_node_ms: u64,
 
     /// Outside the focus ring:
     /// - if true => immediately Cold/Node
@@ -80,15 +66,14 @@ pub struct FocusRingDecayPolicy {
 impl FocusRingDecayPolicy {
     pub fn new() -> Self {
         Self {
-            inside_to_preview_ms: 1_200_000,
-            preview_to_node_ms: 60_000,
+            inside_to_node_ms: 1_200_000,
             outside_immediate_cold: true,
         }
     }
 }
 
 /// Focus-ring-aware decay:
-/// - Inside focus ring: Hot, then Preview, then Node based on timers
+/// - Inside focus ring: Hot, then Node based on timer
 /// - Outside focus ring: Cold immediately
 /// - Focused node: Hot
 /// - Core nodes do not decay
@@ -113,7 +98,7 @@ pub fn tick_decay_focus_ring(
         }
 
         if Some(id) == focused {
-            field.set_decay_level(id, DecayLevel::Hot);
+            let _ = field.set_decay_level(id, DecayLevel::Hot);
             continue;
         }
 
@@ -122,31 +107,21 @@ pub fn tick_decay_focus_ring(
         match zone {
             FocusZone::Inside => {
                 let age = now_ms.saturating_sub(last_touch_ms);
-                let to_preview = policy.inside_to_preview_ms;
-                let to_node = to_preview.saturating_add(policy.preview_to_node_ms);
-
-                if age >= to_node {
-                    field.set_decay_level(id, DecayLevel::Cold);
-                } else if age >= to_preview {
-                    field.set_decay_level(id, DecayLevel::Warm);
+                if age >= policy.inside_to_node_ms {
+                    let _ = field.set_decay_level(id, DecayLevel::Cold);
                 } else {
-                    field.set_decay_level(id, DecayLevel::Hot);
+                    let _ = field.set_decay_level(id, DecayLevel::Hot);
                 }
             }
             FocusZone::Outside => {
                 if policy.outside_immediate_cold {
-                    field.set_decay_level(id, DecayLevel::Cold);
+                    let _ = field.set_decay_level(id, DecayLevel::Cold);
                 } else {
                     let age = now_ms.saturating_sub(last_touch_ms);
-                    let to_preview = policy.inside_to_preview_ms;
-                    let to_node = to_preview.saturating_add(policy.preview_to_node_ms);
-
-                    if age >= to_node {
-                        field.set_decay_level(id, DecayLevel::Cold);
-                    } else if age >= to_preview {
-                        field.set_decay_level(id, DecayLevel::Warm);
+                    if age >= policy.inside_to_node_ms {
+                        let _ = field.set_decay_level(id, DecayLevel::Cold);
                     } else {
-                        field.set_decay_level(id, DecayLevel::Hot);
+                        let _ = field.set_decay_level(id, DecayLevel::Hot);
                     }
                 }
             }
@@ -160,10 +135,6 @@ fn dominant_focus_zone(
     pos: Vec2,
     footprint: Vec2,
 ) -> FocusZone {
-    // Approximate "where the window mostly is" using a small deterministic sample grid.
-    // Majority semantics:
-    // - >50% inside => Inside
-    // - otherwise => Outside
     let w = footprint.x.abs();
     let h = footprint.y.abs();
 
@@ -209,11 +180,11 @@ mod tests {
     use crate::field::Vec2;
 
     fn default_focus_ring() -> FocusRing {
-        FocusRing::new(50.0, 30.0, 0.0)
+        FocusRing::new(50.0, 30.0, 0.0, 0.0)
     }
 
     #[test]
-    fn decays_hot_to_warm_to_cold() {
+    fn decays_hot_to_cold() {
         let mut f = Field::new();
         let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
 
@@ -221,11 +192,11 @@ mod tests {
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
         assert_eq!(f.node(a).unwrap().state, NodeState::Active);
 
-        let policy = DecayPolicy::new(1000, 5000);
+        let policy = DecayPolicy::new(5000);
 
         tick_decay(&mut f, 1500, policy, None);
-        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Warm);
-        assert_eq!(f.node(a).unwrap().state, NodeState::Preview);
+        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
+        assert_eq!(f.node(a).unwrap().state, NodeState::Active);
 
         tick_decay(&mut f, 6000, policy, None);
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Cold);
@@ -238,7 +209,7 @@ mod tests {
         let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
 
-        let policy = DecayPolicy::new(1000, 5000);
+        let policy = DecayPolicy::new(5000);
 
         tick_decay(&mut f, 6000, policy, Some(a));
         assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
@@ -254,7 +225,7 @@ mod tests {
         let cid = f.create_cluster(vec![a, b]).unwrap();
         let core = f.collapse_cluster(cid).unwrap();
 
-        let policy = DecayPolicy::new(1000, 5000);
+        let policy = DecayPolicy::new(5000);
         tick_decay(&mut f, 999_999, policy, None);
 
         let n = f.node(core).unwrap();
@@ -279,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn inside_focus_ring_can_decay_to_preview() {
+    fn inside_focus_ring_stays_hot_before_threshold() {
         let mut f = Field::new();
         let a = f.spawn_surface("A", Vec2 { x: 49.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
@@ -287,17 +258,16 @@ mod tests {
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
         let ring = default_focus_ring();
         let mut policy = FocusRingDecayPolicy::new();
-        policy.inside_to_preview_ms = 1000;
-        policy.preview_to_node_ms = 5000;
+        policy.inside_to_node_ms = 5000;
 
         tick_decay_focus_ring(&mut f, &vp, 1500, ring, policy, None);
 
-        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Warm);
-        assert_eq!(f.node(a).unwrap().state, NodeState::Preview);
+        assert_eq!(f.node(a).unwrap().decay, DecayLevel::Hot);
+        assert_eq!(f.node(a).unwrap().state, NodeState::Active);
     }
 
     #[test]
-    fn inside_focus_ring_can_decay_to_node() {
+    fn inside_focus_ring_can_decay_to_cold() {
         let mut f = Field::new();
         let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
         assert!(f.touch(a, 0));
@@ -305,8 +275,7 @@ mod tests {
         let vp = Viewport::new(Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 50.0 });
         let ring = default_focus_ring();
         let mut policy = FocusRingDecayPolicy::new();
-        policy.inside_to_preview_ms = 1000;
-        policy.preview_to_node_ms = 5000;
+        policy.inside_to_node_ms = 5000;
 
         tick_decay_focus_ring(&mut f, &vp, 7000, ring, policy, None);
 

--- a/crates/halley-core/src/docking.rs
+++ b/crates/halley-core/src/docking.rs
@@ -1,0 +1,737 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::field::{Field, NodeId, NodeKind, NodeState, Vec2};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DockSide {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+impl DockSide {
+    #[inline]
+    pub fn opposite(self) -> Self {
+        match self {
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
+            Self::Top => Self::Bottom,
+            Self::Bottom => Self::Top,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DockPreview {
+    pub mover_id: NodeId,
+    pub target_id: NodeId,
+    pub side: DockSide,
+    pub snap_pos: Vec2,
+    pub armed: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DockPair {
+    pub a: NodeId,
+    pub b: NodeId,
+    pub a_side: DockSide,
+    pub b_side: DockSide,
+}
+
+#[derive(Debug, Default)]
+pub struct DockingState {
+    preview: Option<DockPreview>,
+    pairs: HashMap<NodeId, DockPair>,
+}
+
+impl DockingState {
+    #[inline]
+    pub fn clear_preview(&mut self) {
+        self.preview = None;
+    }
+
+    #[inline]
+    pub fn preview(&self) -> Option<DockPreview> {
+        self.preview
+    }
+
+    pub fn partner(&self, node_id: NodeId) -> Option<NodeId> {
+        let pair = self.pairs.get(&node_id)?;
+        if pair.a == node_id {
+            Some(pair.b)
+        } else if pair.b == node_id {
+            Some(pair.a)
+        } else {
+            None
+        }
+    }
+
+    pub fn sides_for_pair(&self, a: NodeId, b: NodeId) -> Option<(DockSide, DockSide)> {
+        let pair = self.pairs.get(&a)?;
+        if pair.a == a && pair.b == b {
+            Some((pair.a_side, pair.b_side))
+        } else if pair.a == b && pair.b == a {
+            Some((pair.b_side, pair.a_side))
+        } else {
+            None
+        }
+    }
+
+    pub fn pairs(&self) -> Vec<(NodeId, NodeId)> {
+        let mut out = Vec::new();
+        let mut seen = HashSet::new();
+
+        for (&id, pair) in &self.pairs {
+            let other = if pair.a == id { pair.b } else { pair.a };
+            let lo = id.as_u64().min(other.as_u64());
+            let hi = id.as_u64().max(other.as_u64());
+            if seen.insert((lo, hi)) {
+                out.push((id, other));
+            }
+        }
+
+        out
+    }
+
+    pub fn undock(&mut self, node_id: NodeId) -> bool {
+        let Some(pair) = self.pairs.remove(&node_id) else {
+            return false;
+        };
+
+        self.pairs.remove(&pair.a);
+        self.pairs.remove(&pair.b);
+
+        if self
+            .preview
+            .is_some_and(|p| p.mover_id == node_id || p.target_id == node_id)
+        {
+            self.preview = None;
+        }
+
+        true
+    }
+
+    fn can_participate(field: &Field, node_id: NodeId) -> bool {
+        let Some(node) = field.node(node_id) else {
+            return false;
+        };
+
+        if !field.is_visible(node_id) {
+            return false;
+        }
+
+        if node.kind != NodeKind::Surface {
+            return false;
+        }
+
+        matches!(node.state, NodeState::Active | NodeState::Node | NodeState::Preview)
+    }
+
+    fn node_extent(field: &Field, node_id: NodeId) -> Option<Vec2> {
+        let node = field.node(node_id)?;
+        Some(Vec2 {
+            x: node.footprint.x.max(1.0),
+            y: node.footprint.y.max(1.0),
+        })
+    }
+
+    fn choose_side(delta: Vec2) -> DockSide {
+        if delta.x.abs() >= delta.y.abs() {
+            if delta.x >= 0.0 {
+                DockSide::Right
+            } else {
+                DockSide::Left
+            }
+        } else if delta.y >= 0.0 {
+            DockSide::Top
+        } else {
+            DockSide::Bottom
+        }
+    }
+
+    fn snap_position_for_target(
+        field: &Field,
+        mover_id: NodeId,
+        target_id: NodeId,
+        side: DockSide,
+    ) -> Option<Vec2> {
+        let mover_size = Self::node_extent(field, mover_id)?;
+        let target = field.node(target_id)?;
+        let target_size = Self::node_extent(field, target_id)?;
+
+        let mut snap = target.pos;
+
+        match side {
+            DockSide::Left => {
+                snap.x = target.pos.x - ((target_size.x + mover_size.x) * 0.5);
+                snap.y = target.pos.y;
+            }
+            DockSide::Right => {
+                snap.x = target.pos.x + ((target_size.x + mover_size.x) * 0.5);
+                snap.y = target.pos.y;
+            }
+            DockSide::Top => {
+                snap.x = target.pos.x;
+                snap.y = target.pos.y + ((target_size.y + mover_size.y) * 0.5);
+            }
+            DockSide::Bottom => {
+                snap.x = target.pos.x;
+                snap.y = target.pos.y - ((target_size.y + mover_size.y) * 0.5);
+            }
+        }
+
+        Some(snap)
+    }
+
+    fn is_armed(field: &Field, mover_id: NodeId, target_id: NodeId, side: DockSide) -> bool {
+        let Some(mover) = field.node(mover_id) else {
+            return false;
+        };
+        let Some(target) = field.node(target_id) else {
+            return false;
+        };
+
+        let dx = mover.pos.x - target.pos.x;
+        let dy = mover.pos.y - target.pos.y;
+
+        let mover_size = Self::node_extent(field, mover_id).unwrap_or(Vec2 { x: 1.0, y: 1.0 });
+        let target_size = Self::node_extent(field, target_id).unwrap_or(Vec2 { x: 1.0, y: 1.0 });
+
+        let arm_slack = 140.0_f32;
+
+        match side {
+            DockSide::Left | DockSide::Right => {
+                let desired = (mover_size.x + target_size.x) * 0.5;
+                let axis_ok = (dx.abs() - desired).abs() <= arm_slack;
+                let cross_ok = dy.abs() <= target_size.y.max(mover_size.y);
+                axis_ok && cross_ok
+            }
+            DockSide::Top | DockSide::Bottom => {
+                let desired = (mover_size.y + target_size.y) * 0.5;
+                let axis_ok = (dy.abs() - desired).abs() <= arm_slack;
+                let cross_ok = dx.abs() <= target_size.x.max(mover_size.x);
+                axis_ok && cross_ok
+            }
+        }
+    }
+
+    fn choose_target_for_mover(
+        &self,
+        field: &Field,
+        mover_id: NodeId,
+    ) -> Option<(NodeId, DockSide, Vec2, bool)> {
+        let mover = field.node(mover_id)?;
+
+        let mut best: Option<(NodeId, DockSide, Vec2, bool, f32)> = None;
+
+        for (&candidate_id, candidate) in field.nodes() {
+            if candidate_id == mover_id {
+                continue;
+            }
+            if !Self::can_participate(field, candidate_id) {
+                continue;
+            }
+
+            let delta = Vec2 {
+                x: mover.pos.x - candidate.pos.x,
+                y: mover.pos.y - candidate.pos.y,
+            };
+
+            let side = Self::choose_side(delta);
+            let Some(snap_pos) = Self::snap_position_for_target(field, mover_id, candidate_id, side)
+            else {
+                continue;
+            };
+
+            let dist2 = {
+                let sx = mover.pos.x - snap_pos.x;
+                let sy = mover.pos.y - snap_pos.y;
+                (sx * sx) + (sy * sy)
+            };
+
+            let armed = Self::is_armed(field, mover_id, candidate_id, side);
+
+            match best {
+                None => best = Some((candidate_id, side, snap_pos, armed, dist2)),
+                Some((_, _, _, best_armed, best_dist2)) => {
+                    let prefer =
+                        (armed && !best_armed) || (armed == best_armed && dist2 < best_dist2);
+                    if prefer {
+                        best = Some((candidate_id, side, snap_pos, armed, dist2));
+                    }
+                }
+            }
+        }
+
+        best.map(|(target_id, side, snap_pos, armed, _)| (target_id, side, snap_pos, armed))
+    }
+
+    pub fn update_preview(&mut self, field: &Field, mover_id: NodeId) -> Option<DockPreview> {
+        if !Self::can_participate(field, mover_id) {
+            self.preview = None;
+            return None;
+        }
+
+        let Some((target_id, side, snap_pos, armed)) = self.choose_target_for_mover(field, mover_id)
+        else {
+            self.preview = None;
+            return None;
+        };
+
+        let preview = DockPreview {
+            mover_id,
+            target_id,
+            side,
+            snap_pos,
+            armed,
+        };
+
+        self.preview = Some(preview);
+        Some(preview)
+    }
+
+    pub fn commit_preview(&mut self, field: &mut Field, mover_id: NodeId) -> bool {
+        let Some(preview) = self.preview else {
+            return false;
+        };
+
+        if preview.mover_id != mover_id || !preview.armed {
+            return false;
+        }
+
+        if !Self::can_participate(field, preview.mover_id)
+            || !Self::can_participate(field, preview.target_id)
+        {
+            self.preview = None;
+            return false;
+        }
+
+        self.undock(preview.mover_id);
+        self.undock(preview.target_id);
+
+        if let Some(mover) = field.node_mut(preview.mover_id) {
+            mover.pos = preview.snap_pos;
+        } else {
+            self.preview = None;
+            return false;
+        }
+
+        let pair = DockPair {
+            a: preview.mover_id,
+            b: preview.target_id,
+            a_side: preview.side,
+            b_side: preview.side.opposite(),
+        };
+
+        self.pairs.insert(pair.a, pair);
+        self.pairs.insert(pair.b, pair);
+        self.preview = None;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decay::DecayLevel;
+    use crate::field::{Field, NodeState, Vec2};
+
+    fn spawn_pair() -> (Field, NodeId, NodeId) {
+        let mut f = Field::new();
+        let a = f.spawn_surface(
+            "A",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let b = f.spawn_surface(
+            "B",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        (f, a, b)
+    }
+
+    #[test]
+    fn dock_side_opposite_roundtrips() {
+        assert_eq!(DockSide::Left.opposite(), DockSide::Right);
+        assert_eq!(DockSide::Right.opposite(), DockSide::Left);
+        assert_eq!(DockSide::Top.opposite(), DockSide::Bottom);
+        assert_eq!(DockSide::Bottom.opposite(), DockSide::Top);
+    }
+
+    #[test]
+    fn choose_side_prefers_horizontal_when_dx_dominates() {
+        assert_eq!(
+            DockingState::choose_side(Vec2 { x: 50.0, y: 10.0 }),
+            DockSide::Right
+        );
+        assert_eq!(
+            DockingState::choose_side(Vec2 { x: -50.0, y: 10.0 }),
+            DockSide::Left
+        );
+    }
+
+    #[test]
+    fn choose_side_prefers_vertical_when_dy_dominates() {
+        assert_eq!(
+            DockingState::choose_side(Vec2 { x: 10.0, y: 50.0 }),
+            DockSide::Top
+        );
+        assert_eq!(
+            DockingState::choose_side(Vec2 { x: 10.0, y: -50.0 }),
+            DockSide::Bottom
+        );
+    }
+
+    #[test]
+    fn snap_position_for_left_right_uses_half_width_sum() {
+        let (f, a, b) = spawn_pair();
+
+        let left = DockingState::snap_position_for_target(&f, a, b, DockSide::Left).unwrap();
+        let right = DockingState::snap_position_for_target(&f, a, b, DockSide::Right).unwrap();
+
+        assert_eq!(left, Vec2 { x: 200.0, y: 0.0 });
+        assert_eq!(right, Vec2 { x: 400.0, y: 0.0 });
+    }
+
+    #[test]
+    fn snap_position_for_top_bottom_uses_half_height_sum() {
+        let (mut f, a, b) = spawn_pair();
+        if let Some(n) = f.node_mut(a) {
+            n.intrinsic_size = Vec2 { x: 100.0, y: 60.0 };
+            n.footprint = n.intrinsic_size;
+        }
+        if let Some(n) = f.node_mut(b) {
+            n.intrinsic_size = Vec2 { x: 100.0, y: 80.0 };
+            n.footprint = n.intrinsic_size;
+        }
+
+        let top = DockingState::snap_position_for_target(&f, a, b, DockSide::Top).unwrap();
+        let bottom = DockingState::snap_position_for_target(&f, a, b, DockSide::Bottom).unwrap();
+
+        assert_eq!(top, Vec2 { x: 300.0, y: 70.0 });
+        assert_eq!(bottom, Vec2 { x: 300.0, y: -70.0 });
+    }
+
+    #[test]
+    fn hidden_nodes_cannot_participate() {
+        let (mut f, a, _) = spawn_pair();
+        assert!(DockingState::can_participate(&f, a));
+
+        assert!(f.set_hidden(a, true));
+        assert!(!DockingState::can_participate(&f, a));
+    }
+
+    #[test]
+    fn core_nodes_cannot_participate() {
+        let mut f = Field::new();
+        let a = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+        let b = f.spawn_surface("B", Vec2 { x: 20.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+
+        let cid = f.create_cluster(vec![a, b]).unwrap();
+        let core = f.collapse_cluster(cid).unwrap();
+
+        assert!(!DockingState::can_participate(&f, core));
+    }
+
+    #[test]
+    fn update_preview_selects_target_and_sets_armed_when_close_enough() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+
+        assert_eq!(preview.mover_id, mover);
+        assert_eq!(preview.target_id, target);
+        assert_eq!(preview.side, DockSide::Left);
+        assert!(preview.armed);
+        assert_eq!(preview.snap_pos, Vec2 { x: 200.0, y: 0.0 });
+    }
+
+    #[test]
+    fn update_preview_sets_unarmed_when_far() {
+        let (f, mover, _) = spawn_pair();
+        let mut docking = DockingState::default();
+
+        let preview = docking.update_preview(&f, mover).unwrap();
+        assert!(!preview.armed);
+    }
+
+    #[test]
+    fn commit_preview_creates_bidirectional_pair_and_moves_mover() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+        assert!(preview.armed);
+
+        assert!(docking.commit_preview(&mut f, mover));
+        assert_eq!(docking.partner(mover), Some(target));
+        assert_eq!(docking.partner(target), Some(mover));
+        assert_eq!(
+            docking.sides_for_pair(mover, target),
+            Some((DockSide::Left, DockSide::Right))
+        );
+        assert_eq!(f.node(mover).unwrap().pos, Vec2 { x: 200.0, y: 0.0 });
+        assert!(docking.preview().is_none());
+    }
+
+    #[test]
+    fn commit_preview_rejects_wrong_mover() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let other = f.spawn_surface(
+            "Other",
+            Vec2 { x: 600.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+        assert_eq!(preview.target_id, target);
+
+        assert!(!docking.commit_preview(&mut f, other));
+        assert!(docking.partner(mover).is_none());
+        assert!(docking.partner(target).is_none());
+    }
+
+    #[test]
+    fn commit_preview_rejects_unarmed_preview() {
+        let (mut f, mover, _) = spawn_pair();
+        let mut docking = DockingState::default();
+
+        let preview = docking.update_preview(&f, mover).unwrap();
+        assert!(!preview.armed);
+        assert!(!docking.commit_preview(&mut f, mover));
+    }
+
+    #[test]
+    fn undock_removes_pair_from_both_nodes() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        let mut docking = DockingState::default();
+        let _ = docking.update_preview(&f, mover);
+        assert!(docking.commit_preview(&mut f, mover));
+
+        assert!(docking.undock(mover));
+        assert_eq!(docking.partner(mover), None);
+        assert_eq!(docking.partner(target), None);
+        assert!(docking.pairs().is_empty());
+    }
+
+    #[test]
+    fn committing_new_pair_undocks_old_pair_first() {
+        let mut f = Field::new();
+
+        let a = f.spawn_surface("A", Vec2 { x: 205.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+        let b = f.spawn_surface("B", Vec2 { x: 300.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+        let c = f.spawn_surface("C", Vec2 { x: 505.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+
+        let mut docking = DockingState::default();
+
+        let _ = docking.update_preview(&f, a);
+        assert!(docking.commit_preview(&mut f, a));
+        assert_eq!(docking.partner(a), Some(b));
+
+        if let Some(n) = f.node_mut(a) {
+            n.pos = Vec2 { x: 405.0, y: 0.0 };
+        }
+
+        let _ = docking.update_preview(&f, a);
+        assert!(docking.commit_preview(&mut f, a));
+
+        assert_eq!(docking.partner(a), Some(c));
+        assert_eq!(docking.partner(c), Some(a));
+        assert_eq!(docking.partner(b), None);
+    }
+
+    #[test]
+    fn pairs_returns_each_pair_once() {
+        let mut f = Field::new();
+        let a = f.spawn_surface("A", Vec2 { x: 205.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+        let b = f.spawn_surface("B", Vec2 { x: 300.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
+
+        let mut docking = DockingState::default();
+        let _ = docking.update_preview(&f, a);
+        assert!(docking.commit_preview(&mut f, a));
+
+        let pairs = docking.pairs();
+        assert_eq!(pairs.len(), 1);
+
+        let (x, y) = pairs[0];
+        assert!(
+            (x == a && y == b) || (x == b && y == a),
+            "unexpected pair: ({x}, {y})"
+        );
+    }
+
+    #[test]
+    fn preview_clears_when_node_cannot_participate() {
+        let (mut f, mover, _) = spawn_pair();
+        let mut docking = DockingState::default();
+
+        assert!(docking.update_preview(&f, mover).is_some());
+        assert!(f.set_hidden(mover, true));
+        assert!(docking.update_preview(&f, mover).is_none());
+        assert!(docking.preview().is_none());
+    }
+
+    #[test]
+    fn node_state_preview_is_allowed_to_participate() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        assert!(f.set_state(mover, NodeState::Preview));
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+
+        assert_eq!(preview.target_id, target);
+    }
+
+    #[test]
+    fn field_wrapper_methods_work_for_docking() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        let preview = f.update_dock_preview(mover).unwrap();
+        assert_eq!(preview.target_id, target);
+        assert!(f.dock_preview().is_some());
+
+        assert!(f.finalize_dock_on_drag_release(mover));
+        assert_eq!(f.dock_partner(mover), Some(target));
+        assert_eq!(f.dock_partner(target), Some(mover));
+
+        assert!(f.undock_node(mover));
+        assert_eq!(f.dock_partner(mover), None);
+        assert_eq!(f.dock_partner(target), None);
+    }
+
+    #[test]
+    fn hidden_target_is_not_selected() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let hidden = f.spawn_surface(
+            "Hidden",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let visible = f.spawn_surface(
+            "Visible",
+            Vec2 { x: 300.0, y: 200.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        assert!(f.set_hidden(hidden, true));
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+
+        assert_eq!(preview.target_id, visible);
+    }
+
+    #[test]
+    fn detached_target_is_not_selected() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let detached = f.spawn_surface(
+            "Detached",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        assert!(f.set_detached(detached, true));
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover);
+
+        assert!(preview.is_none());
+    }
+
+    #[test]
+    fn state_node_can_participate_in_docking() {
+        let mut f = Field::new();
+        let mover = f.spawn_surface(
+            "Mover",
+            Vec2 { x: 205.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        let target = f.spawn_surface(
+            "Target",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+
+        assert!(f.set_decay_level(target, DecayLevel::Cold));
+        assert_eq!(f.node(target).unwrap().state, NodeState::Node);
+
+        let mut docking = DockingState::default();
+        let preview = docking.update_preview(&f, mover).unwrap();
+        assert_eq!(preview.target_id, target);
+    }
+}

--- a/crates/halley-core/src/field.rs
+++ b/crates/halley-core/src/field.rs
@@ -1,7 +1,8 @@
 use crate::cluster::{Cluster, ClusterId};
+use crate::docking::{DockPreview, DockSide, DockingState};
 use crate::decay::DecayLevel;
 use crate::viewport::Viewport;
-use crate::visual::{NodeVisual, VisualParams, build_visuals, build_visuals_in_view};
+use crate::visual::{build_visuals, build_visuals_in_view, NodeVisual, VisualParams};
 
 use std::collections::HashMap;
 
@@ -152,6 +153,8 @@ pub struct Field {
 
     next_cluster: u64,
     clusters: HashMap<ClusterId, Cluster>,
+
+    docking: DockingState,
 }
 
 impl Field {
@@ -161,6 +164,7 @@ impl Field {
             nodes: HashMap::new(),
             next_cluster: 1,
             clusters: HashMap::new(),
+            docking: DockingState::default(),
         }
     }
 
@@ -174,6 +178,52 @@ impl Field {
 
     pub fn node_mut(&mut self, id: NodeId) -> Option<&mut Node> {
         self.nodes.get_mut(&id)
+    }
+
+    #[inline]
+    pub fn dock_preview(&self) -> Option<DockPreview> {
+        self.docking.preview()
+    }
+
+    #[inline]
+    pub fn dock_partner(&self, node_id: NodeId) -> Option<NodeId> {
+        self.docking.partner(node_id)
+    }
+
+    #[inline]
+    pub fn dock_sides_for_pair(&self, a: NodeId, b: NodeId) -> Option<(DockSide, DockSide)> {
+        self.docking.sides_for_pair(a, b)
+    }
+
+    #[inline]
+    pub fn docked_pairs(&self) -> Vec<(NodeId, NodeId)> {
+        self.docking.pairs()
+    }
+
+    #[inline]
+    pub fn clear_dock_preview(&mut self) {
+        self.docking.clear_preview();
+    }
+
+    #[inline]
+    pub fn undock_node(&mut self, node_id: NodeId) -> bool {
+        self.docking.undock(node_id)
+    }
+
+    #[inline]
+    pub fn update_dock_preview(&mut self, mover_id: NodeId) -> Option<DockPreview> {
+        let mut docking = std::mem::take(&mut self.docking);
+        let out = docking.update_preview(self, mover_id);
+        self.docking = docking;
+        out
+    }
+
+    #[inline]
+    pub fn finalize_dock_on_drag_release(&mut self, mover_id: NodeId) -> bool {
+        let mut docking = std::mem::take(&mut self.docking);
+        let out = docking.commit_preview(self, mover_id);
+        self.docking = docking;
+        out
     }
 
     /// Spawn a basic Surface node.
@@ -340,7 +390,9 @@ impl Field {
 
     /// Apply a decay level to a node by mapping it to representation state.
     pub fn set_decay_level(&mut self, id: NodeId, level: DecayLevel) -> bool {
-        let Some(n) = self.node(id) else { return false };
+        let Some(n) = self.node(id) else {
+            return false;
+        };
 
         // Core is a handle; it doesn't decay away.
         if n.kind == NodeKind::Core {
@@ -349,8 +401,6 @@ impl Field {
 
         let state = match level {
             DecayLevel::Hot => NodeState::Active,
-            // Two-state runtime model: Warm collapses to Node.
-            DecayLevel::Warm => NodeState::Node,
             DecayLevel::Cold => NodeState::Node,
         };
 
@@ -371,7 +421,6 @@ impl Field {
         n.state = state.clone();
         n.footprint = match state {
             NodeState::Active => n.intrinsic_size,
-            // Two-state runtime model: Preview falls back to node footprint.
             NodeState::Preview => DOT,
             NodeState::Drifting => n.footprint,
             NodeState::Node => DOT,
@@ -739,7 +788,7 @@ mod tests {
         assert_eq!(f.node(id).unwrap().footprint, Vec2 { x: 100.0, y: 50.0 });
 
         assert!(f.set_state(id, NodeState::Preview));
-        assert_eq!(f.node(id).unwrap().footprint, Vec2 { x: 100.0, y: 50.0 });
+        assert_eq!(f.node(id).unwrap().footprint, Vec2 { x: 24.0, y: 24.0 });
     }
 
     #[test]
@@ -762,9 +811,9 @@ mod tests {
         let mut f = Field::new();
         let id = f.spawn_surface("A", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 10.0, y: 10.0 });
 
-        assert!(f.set_decay_level(id, DecayLevel::Warm));
-        assert_eq!(f.node(id).unwrap().decay, DecayLevel::Warm);
-        assert_eq!(f.node(id).unwrap().state, NodeState::Preview);
+        assert!(f.set_decay_level(id, DecayLevel::Hot));
+        assert_eq!(f.node(id).unwrap().decay, DecayLevel::Hot);
+        assert_eq!(f.node(id).unwrap().state, NodeState::Active);
 
         assert!(f.set_decay_level(id, DecayLevel::Cold));
         assert_eq!(f.node(id).unwrap().decay, DecayLevel::Cold);

--- a/crates/halley-core/src/lib.rs
+++ b/crates/halley-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bearings;
 pub mod cluster;
 pub mod cluster_policy;
 pub mod decay;
+pub mod docking;
 pub mod field;
 pub mod focus;
 pub mod tiling;

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -80,8 +80,6 @@ pub(crate) fn handle_pointer_button_input(
     }
     let world_now = screen_to_world(st, ws_w, ws_h, sx, sy);
     ps.world = world_now;
-    // Non-primary buttons are forwarded to clients above; compositor interactions
-    // are only bound to left/right.
     if !left && !right {
         return;
     }
@@ -118,6 +116,7 @@ pub(crate) fn handle_pointer_button_input(
                                 let _ = st.exit_cluster_workspace_if_member(h.node_id, now);
                                 ps.last_title_click = None;
                                 ps.drag = None;
+                                st.field.clear_dock_preview();
                                 ps.resize = None;
                                 ps.panning = false;
                                 backend.request_redraw();
@@ -133,7 +132,6 @@ pub(crate) fn handle_pointer_button_input(
                         return;
                     }
                     let drag_mod_ok = modifier_active(&mods, st.tuning.keybinds.modifier);
-                    // Click-to-focus: latch keyboard routing on ordinary left-clicks.
                     if !drag_mod_ok
                         && st.field.node(h.node_id).is_some_and(|n| {
                             n.kind == halley_core::field::NodeKind::Surface
@@ -186,9 +184,6 @@ pub(crate) fn handle_pointer_button_input(
                         }
                         ps.drag = Some(drag_ctx);
                         st.begin_carry_state_tracking(h.node_id);
-                        // Drag/pan interactions must not steal keyboard focus.
-                        // Keep typing routed to the dragged surface unless the
-                        // user explicitly focuses another window.
                         st.set_interaction_focus(Some(h.node_id), 30_000, Instant::now());
                         let to = halley_core::field::Vec2 {
                             x: world_now.x - drag_ctx.current_offset.x,
@@ -229,6 +224,7 @@ pub(crate) fn handle_pointer_button_input(
             } else if right {
                 if workspace_active {
                     ps.drag = None;
+                    st.field.clear_dock_preview();
                     ps.resize = None;
                     ps.panning = false;
                     return;
@@ -265,6 +261,7 @@ pub(crate) fn handle_pointer_button_input(
                                 (sx, sy),
                             );
                             ps.drag = None;
+                            st.field.clear_dock_preview();
                             ps.panning = false;
                             ps.move_anim.clear();
                             st.begin_resize_interaction(h.node_id, Instant::now());
@@ -386,11 +383,12 @@ pub(crate) fn handle_pointer_button_input(
                     } else {
                         st.update_carry_state_preview_at(d.node_id, world_now, now);
                     }
-                    let _ = st.finalize_dock_on_drag_release(d.node_id, now);
+                    let _ = st.field.finalize_dock_on_drag_release(d.node_id);
                     st.end_carry_state_tracking(d.node_id);
                     ps.preview_block_until = Some(now + Duration::from_millis(360));
                 }
                 ps.drag = None;
+                st.field.clear_dock_preview();
                 ps.panning = false;
                 if ps.resize.is_some() {
                     finalize_resize(st, &mut ps, backend);

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -86,6 +86,9 @@ pub(crate) fn handle_pointer_motion_absolute(
     ps.workspace_size = (ws_w, ws_h);
     if st.has_active_cluster_workspace() {
         ps.hover_node = None;
+        if ps.drag.is_some() {
+            st.field.clear_dock_preview();
+        }
         ps.drag = None;
         ps.resize = None;
         ps.panning = false;
@@ -94,6 +97,7 @@ pub(crate) fn handle_pointer_motion_absolute(
     if let Some(drag) = ps.drag {
         if ps.resize.is_some() || !drag_mod_ok {
             st.end_carry_state_tracking(drag.node_id);
+            st.field.clear_dock_preview();
             ps.drag = None;
         } else {
             let mut next_drag = drag;
@@ -113,7 +117,7 @@ pub(crate) fn handle_pointer_motion_absolute(
                     let _ = st.carry_surface_non_overlap(drag.node_id, centered);
                 }
                 ps.drag = Some(next_drag);
-                st.update_dock_preview(drag.node_id, Instant::now());
+                let _ = st.field.update_dock_preview(drag.node_id);
                 backend.request_redraw();
             }
         }
@@ -173,8 +177,6 @@ pub(crate) fn handle_pointer_motion_absolute(
             .max(min_h)
             .round() as i32;
 
-        // Keep the opposite edge fixed for each handle direction; this avoids
-        // cumulative drift/jitter when repeatedly resizing from left/top.
         let (left, right) = match resize.handle {
             ResizeHandle::Left | ResizeHandle::TopLeft | ResizeHandle::BottomLeft => {
                 let r = resize.start_right_px;
@@ -211,9 +213,6 @@ pub(crate) fn handle_pointer_motion_absolute(
         }
         let center_sx = (left + right) * 0.5;
         let center_sy = (top + bottom) * 0.5;
-        // Freeze screen->world transform to resize press-time dimensions/viewport.
-        // This prevents node center jumps when the backend emits WinitEvent::Resized
-        // while interactive resize is in progress.
         let center_world = screen_to_world_with_view(
             resize.press_view_center,
             resize.press_view_size,

--- a/crates/halley-wl/src/interaction/actions.rs
+++ b/crates/halley-wl/src/interaction/actions.rs
@@ -20,10 +20,10 @@ pub(crate) fn promote_node_level(
     }
     let target_pos = n.pos;
 
-    // If this node is one half of a docked pair, promote both together.
     let partner = st
+        .field
         .dock_partner(node_id)
-        .filter(|&pid| st.dock_partner(pid) == Some(node_id));
+        .filter(|&pid| st.field.dock_partner(pid) == Some(node_id));
 
     let in_focus_ring =
         st.active_focus_ring().zone(st.viewport.center, target_pos) == FocusZone::Inside;
@@ -48,9 +48,6 @@ pub(crate) fn promote_node_level(
         return true;
     }
 
-    // Out of the focus ring: pan to center. Set restore target to this node so
-    // when it arrives both it and its partner will reopen via
-    // restore_pan_return_active_focus (which already handles the pair).
     st.set_interaction_focus(Some(node_id), 30_000, now);
     st.set_pan_restore_focus_target(node_id);
     st.animate_viewport_center_to(target_pos, now)

--- a/crates/halley-wl/src/runtime_render/dock_render.rs
+++ b/crates/halley-wl/src/runtime_render/dock_render.rs
@@ -1,22 +1,18 @@
 use std::error::Error;
 use std::time::Instant;
 
+use halley_core::docking::DockSide;
 use smithay::{
     backend::renderer::{Color32F, Frame},
     utils::{Physical, Rectangle, Size},
 };
 
-use crate::state::{DockSide, HalleyWlState};
+use crate::state::HalleyWlState;
 
 use super::render_utils::{
     draw_outline_rect, draw_rect, node_marker_bounds, node_marker_metrics, world_to_screen,
 };
 
-// ---------------------------------------------------------------------------
-// Geometry helpers
-// ---------------------------------------------------------------------------
-
-/// Return the screen-space anchor point on one side of a rectangle.
 #[inline]
 pub(crate) fn rect_side_anchor(x: i32, y: i32, w: i32, h: i32, side: DockSide) -> (i32, i32) {
     let cx = x + (w / 2);
@@ -29,11 +25,6 @@ pub(crate) fn rect_side_anchor(x: i32, y: i32, w: i32, h: i32, side: DockSide) -
     }
 }
 
-// ---------------------------------------------------------------------------
-// Docked-pair connection lines
-// ---------------------------------------------------------------------------
-
-/// Draw the connector lines (and midpoint dots) between every docked node pair.
 pub(crate) fn draw_docked_pairs<F>(
     frame: &mut F,
     st: &mut HalleyWlState,
@@ -45,7 +36,7 @@ where
     F: Frame,
     F::Error: std::error::Error + 'static,
 {
-    for (a, b) in st.docked_pairs() {
+    for (a, b) in st.field.docked_pairs() {
         let (Some(na), Some(nb)) = (st.field.node(a), st.field.node(b)) else {
             continue;
         };
@@ -92,7 +83,7 @@ where
             let rb_t = rb_y;
             let rb_b = rb_y + rb_h;
 
-            if let Some((a_side, b_side)) = st.dock_sides_for_pair(a, b) {
+            if let Some((a_side, b_side)) = st.field.dock_sides_for_pair(a, b) {
                 (
                     rect_side_anchor(ra_x, ra_y, ra_w, ra_h, a_side),
                     rect_side_anchor(rb_x, rb_y, rb_w, rb_h, b_side),
@@ -129,11 +120,6 @@ where
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Dock-preview overlay
-// ---------------------------------------------------------------------------
-
-/// Draw the dock snap-preview: target highlight, anchor dots, and mover ghost.
 pub(crate) fn draw_dock_preview<F>(
     frame: &mut F,
     st: &mut HalleyWlState,
@@ -145,9 +131,15 @@ where
     F: Frame,
     F::Error: std::error::Error + 'static,
 {
-    let Some((mover_id, target_id, side, snap_pos, armed)) = st.dock_preview(now) else {
+    let Some(preview) = st.field.dock_preview() else {
         return Ok(());
     };
+
+    let mover_id = preview.mover_id;
+    let target_id = preview.target_id;
+    let side = preview.side;
+    let snap_pos = preview.snap_pos;
+    let armed = preview.armed;
 
     let (sx, sy) = world_to_screen(st, size.w, size.h, snap_pos.x, snap_pos.y);
     let marker = if armed {
@@ -159,7 +151,6 @@ where
     draw_outline_rect(frame, sx - 12, sy - 12, 24, 24, marker, damage)?;
     draw_rect(frame, sx - 2, sy - 2, 5, 5, marker, damage)?;
 
-    // Mover ghost bounding box.
     if let Some(m) = st.field.node(mover_id) {
         let (mx, my) = world_to_screen(st, size.w, size.h, m.pos.x, m.pos.y);
         let lx = mx.min(sx);
@@ -177,7 +168,6 @@ where
         )?;
     }
 
-    // Target node highlight with per-side anchor dots.
     if let Some(t) = st.field.node(target_id) {
         let (tx, ty) = world_to_screen(st, size.w, size.h, t.pos.x, t.pos.y);
         let target_is_node = matches!(

--- a/crates/halley-wl/src/state/carry.rs
+++ b/crates/halley-wl/src/state/carry.rs
@@ -1,271 +1,8 @@
 use super::*;
+use halley_core::docking::DockSide;
 use halley_core::viewport::{FocusRing, FocusZone};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum DockSide {
-    Left,
-    Right,
-    Top,
-    Bottom,
-}
-
-impl DockSide {
-    fn opposite(self) -> Self {
-        match self {
-            DockSide::Left => DockSide::Right,
-            DockSide::Right => DockSide::Left,
-            DockSide::Top => DockSide::Bottom,
-            DockSide::Bottom => DockSide::Top,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(super) struct DockLink {
-    pub(super) partner: NodeId,
-    pub(super) side: DockSide,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(super) struct DockPending {
-    pub(super) mover: NodeId,
-    pub(super) target: NodeId,
-    pub(super) side: DockSide,
-    pub(super) snap_pos: Vec2,
-    pub(super) since_ms: u64,
-}
-
 impl HalleyWlState {
-    const DOCK_SNAP_DIST: f32 = 84.0;
-    const DOCK_DWELL_MS: u64 = 360;
-
-    pub(crate) fn dock_partner(&self, id: NodeId) -> Option<NodeId> {
-        self.docked_links.get(&id).map(|l| l.partner)
-    }
-
-    fn dock_link(&self, id: NodeId) -> Option<DockLink> {
-        self.docked_links.get(&id).copied()
-    }
-
-    pub(crate) fn dock_sides_for_pair(&self, a: NodeId, b: NodeId) -> Option<(DockSide, DockSide)> {
-        let a_link = self.docked_links.get(&a).copied()?;
-        let b_link = self.docked_links.get(&b).copied()?;
-        if a_link.partner == b && b_link.partner == a {
-            Some((a_link.side, b_link.side))
-        } else {
-            None
-        }
-    }
-
-    fn dock_side_snap_pos(&self, mover: NodeId, target: NodeId, side: DockSide) -> Option<Vec2> {
-        let mover_n = self.field.node(mover)?;
-        let target_n = self.field.node(target)?;
-        let mover_size = self.collision_size_for_node(mover_n);
-        let target_size = self.collision_size_for_node(target_n);
-        let gap = self.non_overlap_gap_world();
-        let half_x = mover_size.x * 0.5 + target_size.x * 0.5 + gap;
-        let half_y = mover_size.y * 0.5 + target_size.y * 0.5 + gap;
-        let p = match side {
-            DockSide::Left => Vec2 {
-                x: target_n.pos.x - half_x,
-                y: target_n.pos.y,
-            },
-            DockSide::Right => Vec2 {
-                x: target_n.pos.x + half_x,
-                y: target_n.pos.y,
-            },
-            DockSide::Top => Vec2 {
-                x: target_n.pos.x,
-                y: target_n.pos.y + half_y,
-            },
-            DockSide::Bottom => Vec2 {
-                x: target_n.pos.x,
-                y: target_n.pos.y - half_y,
-            },
-        };
-        Some(p)
-    }
-
-    fn best_dock_candidate(&self, mover: NodeId) -> Option<(NodeId, DockSide, Vec2, f32)> {
-        let mover_n = self.field.node(mover)?;
-        if mover_n.kind != halley_core::field::NodeKind::Surface || !self.field.is_visible(mover) {
-            return None;
-        }
-        if self.dock_partner(mover).is_some() {
-            return None;
-        }
-        let mover_pos = mover_n.pos;
-        let mut best: Option<(NodeId, DockSide, Vec2, f32)> = None;
-        for (&id, n) in self.field.nodes() {
-            if id == mover || !self.field.is_visible(id) {
-                continue;
-            }
-            if n.kind != halley_core::field::NodeKind::Surface {
-                continue;
-            }
-            if self.dock_partner(id).is_some() {
-                continue;
-            }
-            for side in [
-                DockSide::Left,
-                DockSide::Right,
-                DockSide::Top,
-                DockSide::Bottom,
-            ] {
-                let Some(snap_pos) = self.dock_side_snap_pos(mover, id, side) else {
-                    continue;
-                };
-                let dx = mover_pos.x - snap_pos.x;
-                let dy = mover_pos.y - snap_pos.y;
-                let d = (dx * dx + dy * dy).sqrt();
-                if best.is_none_or(|(_, _, _, bd)| d < bd) {
-                    best = Some((id, side, snap_pos, d));
-                }
-            }
-        }
-        best
-    }
-
-    pub fn update_dock_preview(&mut self, mover: NodeId, now: Instant) {
-        let now_ms = self.now_ms(now);
-        let next = self
-            .best_dock_candidate(mover)
-            .and_then(|(target, side, snap_pos, dist)| {
-                (dist <= Self::DOCK_SNAP_DIST).then_some(DockPending {
-                    mover,
-                    target,
-                    side,
-                    snap_pos,
-                    since_ms: now_ms,
-                })
-            });
-        match (self.dock_pending, next) {
-            (Some(cur), Some(mut n))
-                if cur.mover == n.mover && cur.target == n.target && cur.side == n.side =>
-            {
-                n.since_ms = cur.since_ms;
-                self.dock_pending = Some(n);
-            }
-            (_, n) => {
-                self.dock_pending = n;
-            }
-        }
-    }
-
-    pub(crate) fn dock_preview(
-        &self,
-        now: Instant,
-    ) -> Option<(NodeId, NodeId, DockSide, Vec2, bool)> {
-        let p = self.dock_pending?;
-        let armed = self.now_ms(now).saturating_sub(p.since_ms) >= Self::DOCK_DWELL_MS;
-        Some((p.mover, p.target, p.side, p.snap_pos, armed))
-    }
-
-    fn insert_dock_pair(&mut self, a: NodeId, b: NodeId) {
-        let side_a = self.dock_pending.map(|p| p.side).unwrap_or(DockSide::Left);
-        let side_b = side_a.opposite();
-        self.docked_links.insert(
-            a,
-            DockLink {
-                partner: b,
-                side: side_a,
-            },
-        );
-        self.docked_links.insert(
-            b,
-            DockLink {
-                partner: a,
-                side: side_b,
-            },
-        );
-    }
-
-    pub fn clear_docking_for_node(&mut self, id: NodeId) {
-        if let Some(link) = self.docked_links.remove(&id) {
-            self.docked_links.remove(&link.partner);
-        }
-        if self
-            .dock_pending
-            .is_some_and(|p| p.mover == id || p.target == id)
-        {
-            self.dock_pending = None;
-        }
-    }
-
-    fn undock_for_drag(&mut self, id: NodeId) {
-        if let Some(partner) = self.dock_partner(id) {
-            self.docked_links.remove(&id);
-            self.docked_links.remove(&partner);
-        }
-        if self
-            .dock_pending
-            .is_some_and(|p| p.mover == id || p.target == id)
-        {
-            self.dock_pending = None;
-        }
-    }
-
-    pub fn finalize_dock_on_drag_release(&mut self, mover: NodeId, now: Instant) -> bool {
-        let now_ms = self.now_ms(now);
-        let Some(pending) = self.dock_pending else {
-            return false;
-        };
-        if pending.mover != mover || now_ms.saturating_sub(pending.since_ms) < Self::DOCK_DWELL_MS {
-            return false;
-        }
-        let mover_ok = self.field.node(pending.mover).is_some_and(|n| {
-            n.kind == halley_core::field::NodeKind::Surface && self.field.is_visible(pending.mover)
-        });
-        let target_ok = self.field.node(pending.target).is_some_and(|n| {
-            n.kind == halley_core::field::NodeKind::Surface && self.field.is_visible(pending.target)
-        });
-        if !mover_ok || !target_ok {
-            self.dock_pending = None;
-            return false;
-        }
-        if self.dock_partner(pending.mover).is_some() || self.dock_partner(pending.target).is_some()
-        {
-            self.dock_pending = None;
-            return false;
-        }
-        let either_active = self
-            .field
-            .node(pending.mover)
-            .is_some_and(|n| n.state == halley_core::field::NodeState::Active)
-            || self
-                .field
-                .node(pending.target)
-                .is_some_and(|n| n.state == halley_core::field::NodeState::Active);
-        let _ = self.field.carry(pending.mover, pending.snap_pos);
-        self.insert_dock_pair(pending.mover, pending.target);
-        if either_active {
-            let _ = self.field.set_decay_level(pending.mover, DecayLevel::Hot);
-            let _ = self.field.set_decay_level(pending.target, DecayLevel::Hot);
-            self.mark_active_transition(pending.mover, now, 280);
-            self.mark_active_transition(pending.target, now, 280);
-            if let Some(n) = self.field.node(pending.mover) {
-                self.last_active_size
-                    .insert(pending.mover, n.intrinsic_size);
-            }
-            if let Some(n) = self.field.node(pending.target) {
-                self.last_active_size
-                    .insert(pending.target, n.intrinsic_size);
-            }
-        }
-        self.set_interaction_focus(Some(pending.target), 700, now);
-        self.dock_pending = None;
-        true
-    }
-
-    pub fn docked_pairs(&self) -> Vec<(NodeId, NodeId)> {
-        self.docked_links
-            .iter()
-            .filter_map(|(&id, link)| {
-                (id.as_u64() < link.partner.as_u64()).then_some((id, link.partner))
-            })
-            .collect()
-    }
-
     #[inline]
     fn dock_outward_edge_overflow(
         &self,
@@ -298,11 +35,12 @@ impl HalleyWlState {
     }
 
     pub fn enforce_docked_pairs(&mut self) {
-        if self.docked_links.is_empty() {
+        let pairs = self.field.docked_pairs();
+        if pairs.is_empty() {
             return;
         }
+
         let now_ms = self.now_ms(Instant::now());
-        let pairs = self.docked_pairs();
 
         for (a, b) in pairs {
             if !self.field.is_visible(a) || !self.field.is_visible(b) {
@@ -312,12 +50,10 @@ impl HalleyWlState {
             {
                 continue;
             }
-            let (Some(link_a), Some(link_b)) = (self.dock_link(a), self.dock_link(b)) else {
+
+            let Some((link_a_side, link_b_side)) = self.field.dock_sides_for_pair(a, b) else {
                 continue;
             };
-            if link_a.partner != b || link_b.partner != a {
-                continue;
-            }
 
             let (mid, sa, sb, a_state, b_state, a_pos, b_pos) = {
                 let (Some(na), Some(nb)) = (self.field.node(a), self.field.node(b)) else {
@@ -340,8 +76,8 @@ impl HalleyWlState {
             let a_edge_fp = self.dock_state_eval_footprint(a, sa);
             let b_edge_fp = self.dock_state_eval_footprint(b, sb);
 
-            let a_overflow = self.dock_outward_edge_overflow(a_pos, a_edge_fp, link_a.side);
-            let b_overflow = self.dock_outward_edge_overflow(b_pos, b_edge_fp, link_b.side);
+            let a_overflow = self.dock_outward_edge_overflow(a_pos, a_edge_fp, link_a_side);
+            let b_overflow = self.dock_outward_edge_overflow(b_pos, b_edge_fp, link_b_side);
 
             let decay_a = if a_overflow > 0.0 {
                 DecayLevel::Cold
@@ -374,11 +110,11 @@ impl HalleyWlState {
             }
 
             let gap = self.non_overlap_gap_world();
-            match link_b.side {
+            match link_b_side {
                 DockSide::Left | DockSide::Right => {
                     let sep = (a_edge_fp.x * 0.5 + b_edge_fp.x * 0.5 + gap).max(0.0);
                     let half_sep = sep * 0.5;
-                    let (ax, bx) = if link_b.side == DockSide::Right {
+                    let (ax, bx) = if link_b_side == DockSide::Right {
                         (mid.x - half_sep, mid.x + half_sep)
                     } else {
                         (mid.x + half_sep, mid.x - half_sep)
@@ -389,7 +125,7 @@ impl HalleyWlState {
                 DockSide::Top | DockSide::Bottom => {
                     let sep = (a_edge_fp.y * 0.5 + b_edge_fp.y * 0.5 + gap).max(0.0);
                     let half_sep = sep * 0.5;
-                    let (ay, by) = if link_b.side == DockSide::Top {
+                    let (ay, by) = if link_b_side == DockSide::Top {
                         (mid.y - half_sep, mid.y + half_sep)
                     } else {
                         (mid.y + half_sep, mid.y - half_sep)
@@ -489,7 +225,9 @@ impl HalleyWlState {
     }
 
     pub fn finalize_mouse_drag_state(&mut self, id: NodeId, pointer_world: Vec2, _now: Instant) {
-        let Some(n) = self.field.node(id) else { return };
+        let Some(n) = self.field.node(id) else {
+            return;
+        };
         if n.kind != halley_core::field::NodeKind::Surface || !self.field.is_visible(id) {
             return;
         }
@@ -511,7 +249,9 @@ impl HalleyWlState {
         }
         self.suspend_overlap_resolve = true;
         self.suspend_state_checks = true;
-        self.undock_for_drag(id);
+        let _ = self.field.undock_node(id);
+        self.field.clear_dock_preview();
+
         if let Some(n) = self.field.node(id) {
             let fp = self.collision_size_for_node(n);
             let z = self.zone_for_pos_with_hysteresis(id, n.pos, fp);
@@ -530,12 +270,7 @@ impl HalleyWlState {
         self.carry_zone_pending.remove(&id);
         self.carry_zone_pending_since_ms.remove(&id);
         self.carry_activation_anim_armed.remove(&id);
-        if self
-            .dock_pending
-            .is_some_and(|p| p.mover == id || p.target == id)
-        {
-            self.dock_pending = None;
-        }
+        self.field.clear_dock_preview();
         self.suspend_overlap_resolve = false;
         self.suspend_state_checks = false;
         self.enforce_docked_pairs();
@@ -543,12 +278,16 @@ impl HalleyWlState {
     }
 
     pub fn update_carry_state_preview(&mut self, id: NodeId, now: Instant) {
-        let Some(n) = self.field.node(id) else { return };
+        let Some(n) = self.field.node(id) else {
+            return;
+        };
         self.update_carry_state_preview_at(id, n.pos, now);
     }
 
     pub fn update_carry_state_preview_at(&mut self, id: NodeId, source_pos: Vec2, now: Instant) {
-        let Some(n) = self.field.node(id) else { return };
+        let Some(n) = self.field.node(id) else {
+            return;
+        };
         let n_kind = n.kind.clone();
         let was_active = n.state == halley_core::field::NodeState::Active;
         let footprint = self.zone_eval_footprint_for(id, self.collision_size_for_node(n));

--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -2,7 +2,7 @@ use super::*;
 use eventline::info;
 use halley_core::viewport::FocusZone;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
-use smithay::reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface};
+use smithay::reexports::wayland_server::{protocol::wl_surface::WlSurface, Resource};
 use smithay::utils::SERIAL_COUNTER;
 use smithay::wayland::selection::data_device::set_data_device_focus;
 use smithay::wayland::selection::primary_selection::set_primary_focus;
@@ -181,13 +181,10 @@ impl HalleyWlState {
             return;
         }
 
-        let partner = self.docked_links.get(&id).and_then(|link| {
-            let pid = link.partner;
-            self.docked_links
-                .get(&pid)
-                .is_some_and(|back| back.partner == id)
-                .then_some(pid)
-        });
+        let partner = self
+            .field
+            .dock_partner(id)
+            .filter(|&pid| self.field.dock_partner(pid) == Some(id));
 
         let _ = self.field.set_decay_level(id, DecayLevel::Hot);
         self.mark_active_transition(id, now, 280);
@@ -350,12 +347,11 @@ impl HalleyWlState {
 
     pub fn toggle_last_focused_surface_node(&mut self, now: Instant) -> Option<NodeId> {
         let id = self.last_focused_surface_node()?;
-        let partner = self.docked_links.get(&id).and_then(|link| {
-            self.docked_links
-                .get(&link.partner)
-                .is_some_and(|back| back.partner == id)
-                .then_some(link.partner)
-        });
+        let partner = self
+            .field
+            .dock_partner(id)
+            .filter(|&pid| self.field.dock_partner(pid) == Some(id));
+
         let state = self.field.node(id)?.state.clone();
         match state {
             halley_core::field::NodeState::Active => {

--- a/crates/halley-wl/src/state/maintenance.rs
+++ b/crates/halley-wl/src/state/maintenance.rs
@@ -31,17 +31,15 @@ impl HalleyWlState {
                 continue;
             }
             let mut unit = vec![id];
-            if let Some(link) = self.docked_links.get(&id) {
-                let partner = link.partner;
-                if self
-                    .docked_links
-                    .get(&partner)
-                    .is_some_and(|back| back.partner == id)
-                    && self.field.node(partner).is_some_and(|pn| {
-                        self.field.is_visible(partner)
-                            && pn.kind == halley_core::field::NodeKind::Surface
-                    })
-                {
+            if let Some(partner) = self
+                .field
+                .dock_partner(id)
+                .filter(|&pid| self.field.dock_partner(pid) == Some(id))
+            {
+                if self.field.node(partner).is_some_and(|pn| {
+                    self.field.is_visible(partner)
+                        && pn.kind == halley_core::field::NodeKind::Surface
+                }) {
                     unit.push(partner);
                     seen.insert(partner);
                 }
@@ -382,7 +380,8 @@ impl HalleyWlState {
                 if self.pan_restore_active_focus == Some(id) {
                     self.pan_restore_active_focus = None;
                 }
-                self.clear_docking_for_node(id);
+                let _ = self.field.undock_node(id);
+                self.field.clear_dock_preview();
                 self.zoom_nominal_size.remove(&id);
                 self.zoom_resize_fallback.remove(&id);
                 self.zoom_resize_reject_streak.remove(&id);

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -48,8 +48,6 @@ mod surface_lifecycle;
 mod wayland_handlers;
 mod workspace;
 mod zoom;
-pub(crate) use carry::DockSide;
-use carry::{DockLink, DockPending};
 pub use client::ClientState;
 use focus::ViewportPanAnim;
 
@@ -96,8 +94,6 @@ pub struct HalleyWlState {
     carry_zone_pending: HashMap<NodeId, FocusZone>,
     carry_zone_pending_since_ms: HashMap<NodeId, u64>,
     carry_activation_anim_armed: HashSet<NodeId>,
-    docked_links: HashMap<NodeId, DockLink>,
-    dock_pending: Option<DockPending>,
     resize_active: Option<NodeId>,
     resize_static_node: Option<NodeId>,
     resize_static_lock_pos: Option<Vec2>,
@@ -177,8 +173,6 @@ impl HalleyWlState {
             carry_zone_pending: HashMap::new(),
             carry_zone_pending_since_ms: HashMap::new(),
             carry_activation_anim_armed: HashSet::new(),
-            docked_links: HashMap::new(),
-            dock_pending: None,
             resize_active: None,
             resize_static_node: None,
             resize_static_lock_pos: None,

--- a/crates/halley-wl/src/state/overlap.rs
+++ b/crates/halley-wl/src/state/overlap.rs
@@ -75,7 +75,6 @@ impl HalleyWlState {
                 let ox = req_x - dx.abs();
                 let oy = req_y - dy.abs();
 
-                // Small soft zone so windows begin easing apart before true overlap.
                 let soft_zone = 1.0;
                 let sx = (req_x + soft_zone) - dx.abs();
                 let sy = (req_y + soft_zone) - dy.abs();
@@ -398,15 +397,7 @@ impl HalleyWlState {
                         continue;
                     }
 
-                    if self
-                        .docked_links
-                        .get(&a)
-                        .is_some_and(|link| link.partner == b)
-                        || self
-                            .docked_links
-                            .get(&b)
-                            .is_some_and(|link| link.partner == a)
-                    {
+                    if self.field.dock_partner(a) == Some(b) || self.field.dock_partner(b) == Some(a) {
                         continue;
                     }
 
@@ -458,9 +449,23 @@ impl HalleyWlState {
                     }
 
                     let (mover_id, mover_pos, anchor_pos, mx, my, mover_pinned) = if primary_id == a {
-                        (a, a_pos, b_pos, if dx >= 0.0 { -1.0 } else { 1.0 }, if dy >= 0.0 { -1.0 } else { 1.0 }, a_pinned)
+                        (
+                            a,
+                            a_pos,
+                            b_pos,
+                            if dx >= 0.0 { -1.0 } else { 1.0 },
+                            if dy >= 0.0 { -1.0 } else { 1.0 },
+                            a_pinned,
+                        )
                     } else {
-                        (b, b_pos, a_pos, if dx >= 0.0 { 1.0 } else { -1.0 }, if dy >= 0.0 { 1.0 } else { -1.0 }, b_pinned)
+                        (
+                            b,
+                            b_pos,
+                            a_pos,
+                            if dx >= 0.0 { 1.0 } else { -1.0 },
+                            if dy >= 0.0 { 1.0 } else { -1.0 },
+                            b_pinned,
+                        )
                     };
 
                     if mover_pinned {

--- a/crates/halley-wl/src/state/surface_lifecycle.rs
+++ b/crates/halley-wl/src/state/surface_lifecycle.rs
@@ -26,7 +26,6 @@ impl HalleyWlState {
             return id;
         }
 
-        // Spawn around the current viewport center so new windows are discoverable.
         let n = self.spawn_cursor;
         self.spawn_cursor += 1;
         let size = Vec2 {
@@ -115,7 +114,6 @@ impl HalleyWlState {
                 {
                     pos = p;
                 } else {
-                    // Fallback: ring search around viewport center.
                     for i in 0..24u32 {
                         let ring = 200.0 + ((i / 8) as f32) * 120.0;
                         let theta = (i % 8) as f32 * std::f32::consts::TAU / 8.0;
@@ -133,7 +131,6 @@ impl HalleyWlState {
         }
 
         let id = self.field.spawn_surface(label.to_string(), pos, size);
-        // Two-state model: new windows start Active.
         let _ = self
             .field
             .set_state(id, halley_core::field::NodeState::Active);
@@ -186,7 +183,8 @@ impl HalleyWlState {
             if self.pan_restore_active_focus == Some(id) {
                 self.pan_restore_active_focus = None;
             }
-            self.clear_docking_for_node(id);
+            let _ = self.field.undock_node(id);
+            self.field.clear_dock_preview();
             self.zoom_nominal_size.remove(&id);
             self.zoom_resize_fallback.remove(&id);
             self.zoom_resize_reject_streak.remove(&id);


### PR DESCRIPTION
- move docking state and pairing logic into halley-core
- switch decay model from hot/warm/cold to hot/cold
- simplify runtime tuning and config parsing for two-state decay
- remove stale wl-side docking state and helpers
- update and expand tests for docking and decay behavior