### PR TITLE
render/resize: restore overlap overlay, enforce resized window top ordering, and resolve overlaps immediately on release

### DIFF
--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -353,6 +353,10 @@ pub(crate) fn handle_pointer_button_input(
                                     false,
                                 );
                             }
+                            st.set_recent_top_node(
+                                resize.node_id,
+                                now + Duration::from_millis(600),
+                            );
                             st.end_resize_interaction(now);
                             backend.request_redraw();
                             return;
@@ -372,7 +376,12 @@ pub(crate) fn handle_pointer_button_input(
                                 y: final_h as f32,
                             },
                         );
-                        st.end_resize_interaction(Instant::now());
+                        st.set_recent_top_node(
+                            resize.node_id,
+                            now + Duration::from_millis(600),
+                        );
+                        st.end_resize_interaction(now);
+                        backend.request_redraw();
                     }
                 };
             if left {

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -55,7 +55,8 @@ pub(crate) fn handle_pointer_button_input(
     ps.workspace_size = (ws_w, ws_h);
     if let Some(pointer) = st.seat.get_pointer() {
         let resize_preview = ps.resize;
-        let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, Instant::now(), resize_preview);
+        let focus =
+            pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, Instant::now(), resize_preview);
         let motion_serial = SERIAL_COUNTER.next_serial();
         let button_serial = SERIAL_COUNTER.next_serial();
         pointer.motion(
@@ -240,22 +241,29 @@ pub(crate) fn handle_pointer_button_input(
                             let fallback_size = n.intrinsic_size;
                             let fallback_pos = n.pos;
                             let (start_left, start_top, start_right, start_bottom) =
-                                active_node_screen_rect(st, ws_w, ws_h, h.node_id, Instant::now(), None)
-                                    .unwrap_or_else(|| {
-                                        let center_scr = world_to_screen(
-                                            st,
-                                            ws_w,
-                                            ws_h,
-                                            fallback_pos.x,
-                                            fallback_pos.y,
-                                        );
-                                        (
-                                            (center_scr.0 as f32) - fallback_size.x * 0.5,
-                                            (center_scr.1 as f32) - fallback_size.y * 0.5,
-                                            (center_scr.0 as f32) + fallback_size.x * 0.5,
-                                            (center_scr.1 as f32) + fallback_size.y * 0.5,
-                                        )
-                                    });
+                                active_node_screen_rect(
+                                    st,
+                                    ws_w,
+                                    ws_h,
+                                    h.node_id,
+                                    Instant::now(),
+                                    None,
+                                )
+                                .unwrap_or_else(|| {
+                                    let center_scr = world_to_screen(
+                                        st,
+                                        ws_w,
+                                        ws_h,
+                                        fallback_pos.x,
+                                        fallback_pos.y,
+                                    );
+                                    (
+                                        (center_scr.0 as f32) - fallback_size.x * 0.5,
+                                        (center_scr.1 as f32) - fallback_size.y * 0.5,
+                                        (center_scr.0 as f32) + fallback_size.x * 0.5,
+                                        (center_scr.1 as f32) + fallback_size.y * 0.5,
+                                    )
+                                });
                             let handle = pick_resize_handle_from_screen(
                                 (start_left, start_top, start_right, start_bottom),
                                 (sx, sy),
@@ -358,6 +366,7 @@ pub(crate) fn handle_pointer_button_input(
                                 now + Duration::from_millis(600),
                             );
                             st.end_resize_interaction(now);
+                            st.resolve_overlap_now();
                             backend.request_redraw();
                             return;
                         }
@@ -381,6 +390,7 @@ pub(crate) fn handle_pointer_button_input(
                             now + Duration::from_millis(600),
                         );
                         st.end_resize_interaction(now);
+                        st.resolve_overlap_now();
                         backend.request_redraw();
                     }
                 };

--- a/crates/halley-wl/src/run/drm.rs
+++ b/crates/halley-wl/src/run/drm.rs
@@ -9,6 +9,8 @@ pub(super) struct TtyDrmProbe {
     pub(super) renderer: Rc<RefCell<GlesRenderer>>,
 }
 
+use crate::interaction::types::ResizeCtx;
+
 pub(super) fn probe_tty_drm_device(
     seat: &str,
     tuning: &RuntimeTuning,
@@ -435,6 +437,7 @@ pub(super) fn queue_tty_drm_frame(
     gbm_surface: &Rc<RefCell<GbmBufferedSurface<GbmAllocator<DeviceFd>, ()>>>,
     renderer: &Rc<RefCell<GlesRenderer>>,
     st: &mut HalleyWlState,
+    resize_preview: Option<ResizeCtx>,
     cursor_screen: Option<(f32, f32)>,
     cursor_image: Option<&smithay::input::pointer::CursorImageStatus>,
 ) -> Result<(), Box<dyn Error>> {
@@ -447,12 +450,13 @@ pub(super) fn queue_tty_drm_frame(
         let mut target = renderer.bind(&mut dmabuf).map_err(|err| {
             io::Error::other(format!("failed to bind renderer to drm buffer: {}", err))
         })?;
+
         draw_debug_frame_to_target(
             &mut renderer,
             &mut target,
             (w as i32, h as i32).into(),
             st,
-            None,
+            resize_preview,
             None,
             None,
             cursor_screen,

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -261,10 +261,12 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
 
             let initial_cursor = Some(pointer_state.borrow().screen);
             let initial_cursor_image = state.cursor_image_status.clone();
+            let initial_resize_preview = pointer_state.borrow().resize;
             if let Err(err) = queue_tty_drm_frame(
                 &drm_probe.gbm_surface,
                 &drm_probe.renderer,
                 &mut state,
+                initial_resize_preview,
                 initial_cursor,
                 Some(&initial_cursor_image),
             ) {
@@ -445,12 +447,17 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     info!("reloaded config from {}", config_path_for_timer.as_str());
                     info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                 }
-                let cursor_screen = Some(pointer_state_for_timer.borrow().screen);
+                let ps = pointer_state_for_timer.borrow();
+                let resize_preview = ps.resize;
+                let cursor_screen = Some(ps.screen);
+                drop(ps);
+
                 let cursor_image = st.cursor_image_status.clone();
                 if let Err(err) = queue_tty_drm_frame(
                     &gbm_surface_for_timer,
                     &renderer_for_timer,
                     st,
+                    resize_preview,
                     cursor_screen,
                     Some(&cursor_image),
                 ) {

--- a/crates/halley-wl/src/runtime_render/frame_render.rs
+++ b/crates/halley-wl/src/runtime_render/frame_render.rs
@@ -73,6 +73,7 @@ pub(crate) fn draw_debug_frame_to_target(
 
     let (
         active_elements,
+        resized_active_elements,
         node_surface_map,
         border_rects,
         overlay_rects,
@@ -179,6 +180,10 @@ pub(crate) fn draw_debug_frame_to_target(
             Color32F::new(0.72, 0.72, 0.72, 0.78),
             damage,
         )?;
+    }
+
+    if !resized_active_elements.is_empty() {
+        let _ = draw_render_elements(&mut frame, 1.0, &resized_active_elements, &[damage]);
     }
 
     if st.tuning.dev_enabled && st.tuning.dev_show_geometry_overlay {

--- a/crates/halley-wl/src/runtime_render/node_render.rs
+++ b/crates/halley-wl/src/runtime_render/node_render.rs
@@ -55,7 +55,8 @@ pub(crate) struct ActiveBorderRect {
 /// geometry/debug overlays that belong to this pass.
 ///
 /// Returns:
-/// - Wayland surface render elements in draw order
+/// - Wayland surface render elements in draw order excluding the actively resized window
+/// - Wayland surface render elements for the actively resized window only
 /// - `node_surface_map` for later use by hover-preview and cursor collection
 /// - active border rects
 /// - geometry overlay rects/points (only populated with `dev_show_geometry_overlay`)
@@ -68,6 +69,7 @@ pub(crate) fn collect_active_surfaces(
     now: Instant,
 ) -> (
     Vec<smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement<GlesRenderer>>,
+    Vec<smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement<GlesRenderer>>,
     HashMap<
         halley_core::field::NodeId,
         smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
@@ -78,11 +80,14 @@ pub(crate) fn collect_active_surfaces(
     Vec<(i32, i32, i32, i32)>,           // overlap_overlay_rects
 ) {
     let mut active_elements = Vec::new();
+    let mut resized_active_elements = Vec::new();
     let mut node_surface_map = HashMap::new();
     let mut border_rects: Vec<ActiveBorderRect> = Vec::new();
     let mut overlay_rects: Vec<(i32, i32, i32, i32, Color32F)> = Vec::new();
     let mut overlay_points: Vec<(i32, i32, Color32F)> = Vec::new();
     let mut overlap_overlay_rects: Vec<(i32, i32, i32, i32)> = Vec::new();
+
+    let recent_top_node = st.recent_top_node_active(now);
 
     let resize_rect_px = resize_preview.map(|rz| {
         (
@@ -135,8 +140,9 @@ pub(crate) fn collect_active_surfaces(
         let transition_alpha = st.active_transition_alpha(node_id, now);
         let anim = st.anim_style_for(node_id, node_state, now);
         let resizing_this_node = resize_preview.is_some_and(|rz| rz.node_id == node_id);
+        let draw_top_this_node = resizing_this_node || recent_top_node == Some(node_id);
 
-        let (scale, live_ramp) = if resizing_this_node {
+        let (scale, live_ramp) = if draw_top_this_node {
             (1.0f32, 1.0f32)
         } else {
             let s = active_surface_render_scale(
@@ -242,18 +248,25 @@ pub(crate) fn collect_active_surfaces(
             }
         }
 
-        active_elements.extend(render_elements_from_surface_tree(
+        let elems = render_elements_from_surface_tree(
             renderer,
             &wl,
             (sx, sy),
             scale as f64,
             (anim.alpha * live_ramp).clamp(0.0, 1.0),
             Kind::Unspecified,
-        ));
+        );
+
+        if draw_top_this_node {
+            resized_active_elements.extend(elems);
+        } else {
+            active_elements.extend(elems);
+        }
     }
 
     (
         active_elements,
+        resized_active_elements,
         node_surface_map,
         border_rects,
         overlay_rects,
@@ -417,7 +430,6 @@ where
         let marker_mix = ease_in_out_cubic(marker_mix_lin);
         let proxy_mix = 1.0 - marker_mix;
 
-        // Blend toward logical position as marker appears to reduce tail lag.
         let p = halley_core::field::Vec2 {
             x: p_smooth.x + (node_pos.x - p_smooth.x) * marker_mix,
             y: p_smooth.y + (node_pos.y - p_smooth.y) * marker_mix,
@@ -448,7 +460,6 @@ where
         let label_w_px = label_w;
         let label_h_px = visual_h;
 
-        // ---- Proxy thumbnail (fades into marker) ---------------------------
         if proxy_mix > 0.01 {
             let proxy_t = ((anim.scale - 0.30) / (0.62 - 0.30)).clamp(0.0, 1.0);
             let proxy_alpha = (anim.alpha * proxy_t * proxy_t * proxy_mix * proxy_mix * proxy_mix)
@@ -503,7 +514,6 @@ where
             )?;
         }
 
-        // ---- Marker + label ------------------------------------------------
         let dot_alpha = (anim.alpha * marker_mix).clamp(0.0, 1.0);
         if dot_alpha <= 0.01 {
             continue;

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -110,6 +110,8 @@ pub struct HalleyWlState {
     exit_requested: bool,
 
     pub(crate) bbox_loc: HashMap<NodeId, (f32, f32)>,
+    pub(crate) recent_top_node: Option<NodeId>,
+    pub(crate) recent_top_until: Option<Instant>,
 
     spawn_cursor: u32,
     started_at: Instant,
@@ -189,6 +191,8 @@ impl HalleyWlState {
             exit_requested: false,
 
             bbox_loc: HashMap::new(),
+            recent_top_node: None,
+            recent_top_until: None,
 
             spawn_cursor: 0,
             started_at: now,
@@ -199,6 +203,20 @@ impl HalleyWlState {
             bounce: out.tuning.dev_anim_bounce,
         });
         out
+    }
+
+    pub fn set_recent_top_node(&mut self, node_id: NodeId, until: Instant) {
+        self.recent_top_node = Some(node_id);
+        self.recent_top_until = Some(until);
+    }
+
+    pub fn recent_top_node_active(&mut self, now: Instant) -> Option<NodeId> {
+        if self.recent_top_until.is_some_and(|until| now >= until) {
+            self.recent_top_node = None;
+            self.recent_top_until = None;
+            return None;
+        }
+        self.recent_top_node
     }
 
     pub fn request_exit(&mut self) {
@@ -216,6 +234,7 @@ impl HalleyWlState {
         }
         self.reconcile_surface_bindings();
         let now_ms = now.duration_since(self.started_at).as_millis() as u64;
+        let _ = self.recent_top_node_active(now);
         self.tick_viewport_pan_animation(now_ms);
         if self.active_cluster_workspace.is_some() {
             self.layout_active_cluster_workspace(now_ms);

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -292,10 +292,6 @@ impl HalleyWlState {
             self.resize_static_lock_pos = None;
             self.resize_static_until_ms = 0;
         }
-        if resize_settling {
-            self.animator.observe_field(&self.field, now);
-            return;
-        }
         let focus_ring = self.active_focus_ring();
         let pan_dominant = now_ms < self.pan_dominant_until_ms;
         if !self.suspend_state_checks {
@@ -329,10 +325,7 @@ impl HalleyWlState {
             self.enforce_docked_pairs();
         }
         self.enforce_single_primary_active_unit(focus_ring);
-        if !self.suspend_state_checks
-            && self.resize_active.is_none()
-            && !(self.resize_static_node.is_some() && now_ms < self.resize_static_until_ms)
-        {
+        if !self.suspend_state_checks && self.resize_active.is_none() {
             self.resolve_surface_overlap();
         }
         if !self.suspend_state_checks && !pan_dominant {

--- a/crates/halley-wl/src/state/overlap.rs
+++ b/crates/halley-wl/src/state/overlap.rs
@@ -357,7 +357,6 @@ impl HalleyWlState {
             return;
         }
 
-        let now_ms = self.now_ms(Instant::now());
         let mut ids: Vec<NodeId> = self
             .field
             .nodes()
@@ -379,7 +378,7 @@ impl HalleyWlState {
 
         let gap = self.non_overlap_gap_world();
         let focus_id = self.interaction_focus;
-        let damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 0.35);
+        let damping = self.tuning.non_overlap_bump_damping.clamp(0.25, 1.0);
 
         const MAX_RESOLVE_STEP: f32 = 18.0;
 
@@ -390,12 +389,6 @@ impl HalleyWlState {
                 for j in (i + 1)..ids.len() {
                     let a = ids[i];
                     let b = ids[j];
-
-                    if self.is_recently_resized_node(a, now_ms)
-                        || self.is_recently_resized_node(b, now_ms)
-                    {
-                        continue;
-                    }
 
                     if self.field.dock_partner(a) == Some(b) || self.field.dock_partner(b) == Some(a) {
                         continue;
@@ -410,8 +403,8 @@ impl HalleyWlState {
 
                     let a_pos = na.pos;
                     let b_pos = nb.pos;
-                    let a_pinned = na.pinned;
-                    let b_pinned = nb.pinned;
+                    let a_pinned = na.pinned || self.resize_static_node == Some(a);
+                    let b_pinned = nb.pinned || self.resize_static_node == Some(b);
 
                     if a_pinned && b_pinned {
                         continue;
@@ -506,25 +499,7 @@ impl HalleyWlState {
                         }
                     };
 
-                    let mut step = Vec2 {
-                        x: (full_target.x - mover_pos.x) * damping,
-                        y: (full_target.y - mover_pos.y) * damping,
-                    };
-
-                    step.x = step.x.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
-                    step.y = step.y.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
-
-                    if step.x.abs() < 0.5 && (full_target.x - mover_pos.x).abs() > 0.5 {
-                        step.x = 0.5 * step.x.signum();
-                    }
-                    if step.y.abs() < 0.5 && (full_target.y - mover_pos.y).abs() > 0.5 {
-                        step.y = 0.5 * step.y.signum();
-                    }
-
-                    let target = Vec2 {
-                        x: mover_pos.x + step.x,
-                        y: mover_pos.y + step.y,
-                    };
+                    let target = full_target;
 
                     if self.field.carry(mover_id, target) {
                         changed = true;


### PR DESCRIPTION
render: restore resize overlap overlay + enforce resized window top ordering

Bring back the visual overlap overlay during window resize to indicate
which windows will be displaced. Rendering order was adjusted so the
actively resized window always draws above overlapped windows.

Adds a short `recent_top_node` grace period after resize release so the
resized window remains above others while overlap resolution and layout
animations settle.

Overlap resolution is now triggered immediately on resize release instead
of waiting for the maintenance tick, eliminating the delay before windows
begin separating.