### PR TITLE
fix(overlap): resolve docked partner displacement immediately after resize

### DIFF
--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -223,7 +223,7 @@ impl HalleyWlState {
         if let Some(id) = ended {
             self.resize_static_node = Some(id);
             self.resize_static_lock_pos = self.field.node(id).map(|n| n.pos);
-            self.resize_static_until_ms = self.now_ms(now).saturating_add(1_200);
+            self.resize_static_until_ms = self.now_ms(now).saturating_add(120);
             self.set_interaction_focus(Some(id), 30_000, now);
         } else {
             self.resize_static_lock_pos = None;

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -318,10 +318,7 @@ impl HalleyWlState {
             },
             &mut self.cluster_form_state,
         );
-        if !self.suspend_state_checks
-            && self.resize_active.is_none()
-            && !(self.resize_static_node.is_some() && now_ms < self.resize_static_until_ms)
-        {
+       if !self.suspend_state_checks && self.resize_active.is_none() {
             self.enforce_docked_pairs();
         }
         self.enforce_single_primary_active_unit(focus_ring);


### PR DESCRIPTION
The settle window after a resize interaction was blocking both enforce_docked_pairs and resolve_surface_overlap for 1200ms via an early-return in tick_maintenance and explicit guards on each call site. This caused the partner window in a docked pair to visibly lag by ~1.2s after a resize that created overlap.

Changes:
- Remove early-return from resize_settling block in tick_maintenance so overlap and dock enforcement run during the settle window
- Remove resize_static settle guard from resolve_surface_overlap call site in tick_maintenance
- Remove resize_static settle guard from enforce_docked_pairs call site in tick_maintenance (enforce_docked_pairs already skips the resized node itself via is_recently_resized_node)
- Reduce resize_static_until_ms from 1200ms to 120ms in end_resize_interaction — enough to survive client configure ack round-trips without blocking layout enforcement