### PR TITLE
Reworked Halley’s window decay and docking behavior to make interaction

### DIFF
--- a/crates/halley-wl/src/state/carry.rs
+++ b/crates/halley-wl/src/state/carry.rs
@@ -4,26 +4,6 @@ use halley_core::viewport::{FocusRing, FocusZone};
 
 impl HalleyWlState {
     #[inline]
-    fn dock_outward_edge_overflow(
-        &self,
-        pos: Vec2,
-        footprint: Vec2,
-        outward_side: DockSide,
-    ) -> f32 {
-        let vp = self.viewport.rect();
-        let half = Vec2 {
-            x: footprint.x * 0.5,
-            y: footprint.y * 0.5,
-        };
-        match outward_side {
-            DockSide::Left => vp.min.x - (pos.x - half.x),
-            DockSide::Right => (pos.x + half.x) - vp.max.x,
-            DockSide::Top => (pos.y + half.y) - vp.max.y,
-            DockSide::Bottom => vp.min.y - (pos.y - half.y),
-        }
-    }
-
-    #[inline]
     fn dock_state_eval_footprint(&self, id: NodeId, live: Vec2) -> Vec2 {
         match self.last_active_size.get(&id).copied() {
             Some(last) => Vec2 {
@@ -46,16 +26,15 @@ impl HalleyWlState {
             if !self.field.is_visible(a) || !self.field.is_visible(b) {
                 continue;
             }
-            if self.is_recently_resized_node(a, now_ms) || self.is_recently_resized_node(b, now_ms)
-            {
+            if self.is_recently_resized_node(a, now_ms) || self.is_recently_resized_node(b, now_ms) {
                 continue;
             }
 
-            let Some((link_a_side, link_b_side)) = self.field.dock_sides_for_pair(a, b) else {
+            let Some((_, link_b_side)) = self.field.dock_sides_for_pair(a, b) else {
                 continue;
             };
 
-            let (mid, sa, sb, a_state, b_state, a_pos, b_pos) = {
+            let (mid, sa, sb) = {
                 let (Some(na), Some(nb)) = (self.field.node(a), self.field.node(b)) else {
                     continue;
                 };
@@ -66,45 +45,24 @@ impl HalleyWlState {
                     },
                     self.collision_size_for_node(na),
                     self.collision_size_for_node(nb),
-                    na.state.clone(),
-                    nb.state.clone(),
-                    na.pos,
-                    nb.pos,
                 )
             };
 
             let a_edge_fp = self.dock_state_eval_footprint(a, sa);
             let b_edge_fp = self.dock_state_eval_footprint(b, sb);
 
-            let a_overflow = self.dock_outward_edge_overflow(a_pos, a_edge_fp, link_a_side);
-            let b_overflow = self.dock_outward_edge_overflow(b_pos, b_edge_fp, link_b_side);
+            // Docked-pair geometry should not decide decay anymore.
+            // Maintenance owns docked-pair decay policy now.
+            let _ = self.field.set_decay_level(a, DecayLevel::Hot);
+            let _ = self.field.set_decay_level(b, DecayLevel::Hot);
 
-            let decay_a = if a_overflow > 0.0 {
-                DecayLevel::Cold
-            } else if a_state == halley_core::field::NodeState::Active {
-                DecayLevel::Hot
-            } else {
-                DecayLevel::Cold
-            };
-
-            let decay_b = if b_overflow > 0.0 {
-                DecayLevel::Cold
-            } else if b_state == halley_core::field::NodeState::Active {
-                DecayLevel::Hot
-            } else {
-                DecayLevel::Cold
-            };
-
-            let _ = self.field.set_decay_level(a, decay_a);
-            let _ = self.field.set_decay_level(b, decay_b);
-
-            if decay_a == DecayLevel::Hot {
-                if let Some(n) = self.field.node(a) {
+            if let Some(n) = self.field.node(a) {
+                if n.state == halley_core::field::NodeState::Active {
                     self.last_active_size.insert(a, n.intrinsic_size);
                 }
             }
-            if decay_b == DecayLevel::Hot {
-                if let Some(n) = self.field.node(b) {
+            if let Some(n) = self.field.node(b) {
+                if n.state == halley_core::field::NodeState::Active {
                     self.last_active_size.insert(b, n.intrinsic_size);
                 }
             }

--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -248,12 +248,16 @@ impl HalleyWlState {
 
     pub fn set_interaction_focus(&mut self, id: Option<NodeId>, hold_ms: u64, now: Instant) {
         let prev = self.interaction_focus;
+        let now_ms = self.now_ms(now);
+
         if prev == id {
-            if id.is_some() {
-                let now_ms = self.now_ms(now);
+            if let Some(fid) = id {
                 let requested_until = now_ms.saturating_add(hold_ms.max(1));
                 self.interaction_focus_until_ms =
                     self.interaction_focus_until_ms.max(requested_until);
+                let _ = self.field.touch(fid, now_ms);
+                let _ = self.field.set_decay_level(fid, DecayLevel::Hot);
+                self.last_surface_focus_ms.insert(fid, now_ms);
                 self.reassert_wayland_keyboard_focus_if_drifted(id);
             } else {
                 self.interaction_focus_until_ms = 0;
@@ -261,23 +265,24 @@ impl HalleyWlState {
             }
             return;
         }
+
         self.interaction_focus = id;
-        if id.is_some() {
-            let now_ms = self.now_ms(now);
+        if let Some(fid) = id {
             self.interaction_focus_until_ms = now_ms.saturating_add(hold_ms.max(1));
-            if let Some(fid) = id {
-                if self.field.node(fid).is_some_and(|n| {
-                    n.kind == halley_core::field::NodeKind::Surface && self.field.is_visible(fid)
-                }) {
-                    self.last_surface_focus_ms.insert(fid, now_ms);
-                    if self.tuning.restore_last_active_on_pan_return {
-                        self.pan_restore_active_focus = Some(fid);
-                    }
+            if self.field.node(fid).is_some_and(|n| {
+                n.kind == halley_core::field::NodeKind::Surface && self.field.is_visible(fid)
+            }) {
+                let _ = self.field.touch(fid, now_ms);
+                let _ = self.field.set_decay_level(fid, DecayLevel::Hot);
+                self.last_surface_focus_ms.insert(fid, now_ms);
+                if self.tuning.restore_last_active_on_pan_return {
+                    self.pan_restore_active_focus = Some(fid);
                 }
             }
         } else {
             self.interaction_focus_until_ms = 0;
         }
+
         if prev != id {
             info!(
                 "interaction focus changed: {:?} -> {:?} (hold_ms={})",

--- a/crates/halley-wl/src/state/maintenance.rs
+++ b/crates/halley-wl/src/state/maintenance.rs
@@ -5,116 +5,140 @@ use halley_core::viewport::{FocusRing, FocusZone};
 
 impl HalleyWlState {
     pub(crate) fn enforce_single_primary_active_unit(&mut self, focus_ring: FocusRing) {
-        let mut inside_ids: Vec<NodeId> = self
+        let now_ms = self.now_ms(Instant::now());
+        let companion = self.companion_surface_node(now_ms);
+        let preferred_surface = self.last_input_surface_node();
+
+        let active_ids: Vec<NodeId> = self
             .field
             .nodes()
             .iter()
             .filter_map(|(&id, n)| {
                 (self.field.is_visible(id)
                     && n.kind == halley_core::field::NodeKind::Surface
-                    && focus_ring.zone(self.viewport.center, n.pos) == FocusZone::Inside)
+                    && n.state == halley_core::field::NodeState::Active)
                     .then_some(id)
             })
             .collect();
 
-        if inside_ids.is_empty() {
+        if active_ids.len() <= 2 {
             return;
         }
 
-        inside_ids.sort_by_key(|id| id.as_u64());
+        // Special exception:
+        // allow exactly one mutually-docked active pair to remain active
+        // alongside one focused, non-docked active surface.
+        let focused_breakout = self.interaction_focus.filter(|&fid| {
+            self.field.node(fid).is_some_and(|n| {
+                self.field.is_visible(fid)
+                    && n.kind == halley_core::field::NodeKind::Surface
+                    && n.state == halley_core::field::NodeState::Active
+            }) && self.field
+                .dock_partner(fid)
+                .filter(|&pid| self.field.dock_partner(pid) == Some(fid))
+                .is_none()
+        });
 
-        let mut units: Vec<Vec<NodeId>> = Vec::new();
-        let mut seen: HashSet<NodeId> = HashSet::new();
+        let mut docked_pairs: Vec<(NodeId, NodeId, u64)> = Vec::new();
+        let mut seen_pair_roots: HashSet<NodeId> = HashSet::new();
 
-        for id in inside_ids {
-            if seen.contains(&id) {
-                continue;
-            }
-            let mut unit = vec![id];
-            if let Some(partner) = self
+        for &id in &active_ids {
+            let Some(pid) = self
                 .field
                 .dock_partner(id)
                 .filter(|&pid| self.field.dock_partner(pid) == Some(id))
-            {
-                if self.field.node(partner).is_some_and(|pn| {
-                    self.field.is_visible(partner)
-                        && pn.kind == halley_core::field::NodeKind::Surface
-                }) {
-                    unit.push(partner);
-                    seen.insert(partner);
-                }
+            else {
+                continue;
+            };
+
+            let a = if id.as_u64() <= pid.as_u64() { id } else { pid };
+            let b = if a == id { pid } else { id };
+            if !seen_pair_roots.insert(a) {
+                continue;
             }
-            seen.insert(id);
-            units.push(unit);
-        }
 
-        if units.is_empty() {
-            return;
-        }
+            let pair_active = [a, b].iter().all(|nid| {
+                self.field.node(*nid).is_some_and(|n| {
+                    self.field.is_visible(*nid)
+                        && n.kind == halley_core::field::NodeKind::Surface
+                        && n.state == halley_core::field::NodeState::Active
+                })
+            });
 
-        let active_unit_indices: Vec<usize> = units
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, unit)| {
-                unit.iter()
-                    .any(|id| {
-                        self.field.node(*id).is_some_and(|n| {
-                            n.kind == halley_core::field::NodeKind::Surface
-                                && n.state == halley_core::field::NodeState::Active
-                        })
-                    })
-                    .then_some(idx)
-            })
-            .collect();
+            if !pair_active {
+                continue;
+            }
 
-        if active_unit_indices.len() <= 1 {
-            return;
-        }
-
-        let preferred_surface = self.last_input_surface_node();
-        let selected_idx = active_unit_indices.iter().copied().max_by_key(|idx| {
-            let unit = &units[*idx];
-            let preferred_rank = u8::from(
-                preferred_surface.is_some_and(|preferred| unit.iter().any(|id| *id == preferred)),
-            );
-            let focused = self
-                .interaction_focus
-                .is_some_and(|fid| unit.iter().any(|id| *id == fid));
-            let focus_rank = u8::from(focused);
-            let latest_focus = unit
+            let latest_focus = [a, b]
                 .iter()
-                .filter_map(|id| self.last_surface_focus_ms.get(id).copied())
+                .filter_map(|nid| self.last_surface_focus_ms.get(nid).copied())
                 .max()
                 .unwrap_or(0);
-            let latest_id = unit.iter().map(|id| id.as_u64()).max().unwrap_or(0);
-            (preferred_rank, focus_rank, latest_focus, latest_id)
-        });
 
-        let Some(selected_idx) = selected_idx else {
-            return;
-        };
+            docked_pairs.push((a, b, latest_focus));
+        }
 
-        let mut losing_ids: HashSet<NodeId> = HashSet::new();
-        for idx in active_unit_indices {
-            if idx == selected_idx {
-                continue;
-            }
-            let unit = &units[idx];
-            for id in unit {
-                losing_ids.insert(*id);
+        let mut keep_set: HashSet<NodeId> = HashSet::new();
+
+        if let Some(fid) = focused_breakout {
+            docked_pairs.sort_by_key(|(a, b, latest_focus)| {
+                let contains_companion =
+                    companion.is_some_and(|cid| cid == *a || cid == *b);
+                let contains_preferred =
+                    preferred_surface.is_some_and(|pid| pid == *a || pid == *b);
+                let any_inside = [*a, *b].iter().any(|nid| {
+                    self.field.node(*nid).is_some_and(|n| {
+                        focus_ring.zone(self.viewport.center, n.pos) == FocusZone::Inside
+                    })
+                });
+                (
+                    u8::from(contains_companion),
+                    u8::from(contains_preferred),
+                    u8::from(any_inside),
+                    *latest_focus,
+                    b.as_u64(),
+                )
+            });
+
+            if let Some((a, b, _)) = docked_pairs.last().copied() {
+                keep_set.insert(fid);
+                keep_set.insert(a);
+                keep_set.insert(b);
             }
         }
 
-        for id in losing_ids {
-            if !self.field.is_visible(id) {
+        if keep_set.is_empty() {
+            let mut ranked = active_ids.clone();
+            ranked.sort_by_key(|id| {
+                let pos = self
+                    .field
+                    .node(*id)
+                    .map(|n| n.pos)
+                    .unwrap_or(self.viewport.center);
+                let preferred_rank = u8::from(preferred_surface == Some(*id));
+                let focus_rank = u8::from(self.interaction_focus == Some(*id));
+                let companion_rank = u8::from(companion == Some(*id));
+                let inside_rank =
+                    u8::from(focus_ring.zone(self.viewport.center, pos) == FocusZone::Inside);
+                let latest_focus = self.last_surface_focus_ms.get(id).copied().unwrap_or(0);
+                (
+                    preferred_rank,
+                    focus_rank,
+                    companion_rank,
+                    inside_rank,
+                    latest_focus,
+                    id.as_u64(),
+                )
+            });
+
+            keep_set.extend(ranked.iter().rev().take(2).copied());
+        }
+
+        for id in active_ids {
+            if keep_set.contains(&id) {
                 continue;
             }
-            if self.field.node(id).is_some_and(|n| {
-                n.kind == halley_core::field::NodeKind::Surface
-                    && n.state == halley_core::field::NodeState::Active
-            }) {
-                let _ = self.field.set_decay_level(id, DecayLevel::Cold);
-            }
+            let _ = self.field.set_decay_level(id, DecayLevel::Cold);
         }
     }
 
@@ -174,110 +198,195 @@ impl HalleyWlState {
         }
     }
 
-    pub(crate) fn enforce_pan_dominant_zone_states(&mut self, focus_ring: FocusRing, _now_ms: u64) {
+    pub(crate) fn enforce_pan_dominant_zone_states(
+        &mut self,
+        focus_ring: FocusRing,
+        now_ms: u64,
+    ) {
+        const PRIMARY_OUTSIDE_RING_DELAY_MS: u64 = 120_000;
+        const SECONDARY_OUTSIDE_RING_DELAY_MS: u64 = 30_000;
+        const DOCKED_OFFSCREEN_DELAY_MS: u64 = 300_000;
+
         let ids: Vec<NodeId> = self.field.nodes().keys().copied().collect();
 
         for id in ids {
             if !self.field.is_visible(id) {
+                self.dock_decay_offscreen_since_ms.remove(&id);
                 continue;
             }
             let Some(n) = self.field.node(id) else {
+                self.dock_decay_offscreen_since_ms.remove(&id);
                 continue;
             };
             if n.kind != halley_core::field::NodeKind::Surface {
+                self.dock_decay_offscreen_since_ms.remove(&id);
                 continue;
             }
 
-            let n_state = n.state.clone();
-            let pos = n.pos;
-            let fp_raw = self.collision_size_for_node(n);
-            let fp = if n.state == halley_core::field::NodeState::Active {
-                Vec2 { x: 64.0, y: 64.0 }
-            } else {
-                Vec2 {
-                    x: fp_raw.x.max(48.0),
-                    y: fp_raw.y.max(48.0),
+            if let Some(partner) = self
+                .field
+                .dock_partner(id)
+                .filter(|&pid| self.field.dock_partner(pid) == Some(id))
+            {
+                if id.as_u64() < partner.as_u64() {
+                    self.apply_docked_pair_decay_policy(
+                        id,
+                        partner,
+                        now_ms,
+                        DOCKED_OFFSCREEN_DELAY_MS,
+                    );
                 }
-            };
-
-            let samples = 7usize;
-            let mut c_inside = 0usize;
-            let mut c_total = 0usize;
-
-            for ix in 0..samples {
-                for iy in 0..samples {
-                    let fx = (ix as f32 / (samples - 1) as f32) - 0.5;
-                    let fy = (iy as f32 / (samples - 1) as f32) - 0.5;
-                    let sp = Vec2 {
-                        x: pos.x + fx * fp.x,
-                        y: pos.y + fy * fp.y,
-                    };
-                    match focus_ring.zone(self.viewport.center, sp) {
-                        FocusZone::Inside => c_inside += 1,
-                        FocusZone::Outside => {}
-                    }
-                    c_total += 1;
-                }
+                continue;
             }
 
-            let p_inside = if c_total > 0 {
-                c_inside as f32 / c_total as f32
-            } else {
-                0.0
-            };
-            let p_outside = (1.0 - p_inside).max(0.0);
-
-            let was_active = n_state == halley_core::field::NodeState::Active;
-            let pair_gap = self.non_overlap_gap_world();
-
-            let overlap_active = self
-                .field
-                .nodes()
-                .iter()
-                .filter_map(|(&oid, on)| {
-                    if oid == id
-                        || !self.field.is_visible(oid)
-                        || on.kind != halley_core::field::NodeKind::Surface
-                    {
-                        return None;
-                    }
-                    Some((oid, on))
-                })
-                .any(|(_, on)| {
-                    let os = self.collision_size_for_node(on);
-                    let req_x = fp_raw.x * 0.5 + os.x * 0.5 + pair_gap;
-                    let req_y = fp_raw.y * 0.5 + os.y * 0.5 + pair_gap;
-                    let dx = (on.pos.x - pos.x).abs();
-                    let dy = (on.pos.y - pos.y).abs();
-                    dx < req_x && dy < req_y
-                });
-
-            const ACTIVE_RETAIN_FRAC: f32 = 0.04;
-            const ACTIVE_OVERLAP_RETAIN_FRAC: f32 = 0.22;
-            const OUTSIDE_ENTER_FRAC: f32 = 0.90;
-
-            let target = if was_active {
-                let retain_frac = if overlap_active {
-                    ACTIVE_OVERLAP_RETAIN_FRAC
-                } else {
-                    ACTIVE_RETAIN_FRAC
-                };
-
-                if p_inside >= retain_frac {
-                    DecayLevel::Hot
-                } else if p_outside >= OUTSIDE_ENTER_FRAC {
-                    DecayLevel::Cold
-                } else if overlap_active {
-                    DecayLevel::Cold
-                } else {
-                    DecayLevel::Hot
-                }
-            } else {
-                DecayLevel::Cold
-            };
-
-            let _ = self.field.set_decay_level(id, target);
+            self.apply_single_surface_decay_policy(
+                id,
+                focus_ring,
+                now_ms,
+                PRIMARY_OUTSIDE_RING_DELAY_MS,
+                SECONDARY_OUTSIDE_RING_DELAY_MS,
+            );
         }
+
+        self.dock_decay_offscreen_since_ms.retain(|id, _| {
+            self.field.node(*id).is_some_and(|n| {
+                self.field.is_visible(*id)
+                    && n.kind == halley_core::field::NodeKind::Surface
+            })
+        });
+    }
+
+    fn apply_single_surface_decay_policy(
+        &mut self,
+        id: NodeId,
+        focus_ring: FocusRing,
+        now_ms: u64,
+        primary_delay_ms: u64,
+        secondary_delay_ms: u64,
+    ) {
+        let Some(n) = self.field.node(id) else {
+            self.dock_decay_offscreen_since_ms.remove(&id);
+            return;
+        };
+        if !self.field.is_visible(id) || n.kind != halley_core::field::NodeKind::Surface {
+            self.dock_decay_offscreen_since_ms.remove(&id);
+            return;
+        }
+
+        if self.is_hard_decay_protected(id, now_ms) {
+            self.dock_decay_offscreen_since_ms.remove(&id);
+            let _ = self.field.set_decay_level(id, DecayLevel::Hot);
+            return;
+        }
+
+        let outside_ring = focus_ring.zone(self.viewport.center, n.pos) == FocusZone::Outside;
+        if !outside_ring {
+            self.dock_decay_offscreen_since_ms.remove(&id);
+            let _ = self.field.set_decay_level(id, DecayLevel::Hot);
+            return;
+        }
+
+        let is_primary = self.interaction_focus == Some(id);
+        let is_secondary = self.companion_surface_node(now_ms) == Some(id);
+        let delay_ms = if is_primary {
+            primary_delay_ms
+        } else if is_secondary {
+            secondary_delay_ms
+        } else {
+            secondary_delay_ms
+        };
+
+        let since = self
+            .dock_decay_offscreen_since_ms
+            .get(&id)
+            .copied()
+            .unwrap_or(now_ms);
+
+        self.dock_decay_offscreen_since_ms.insert(id, since);
+
+        if now_ms.saturating_sub(since) >= delay_ms {
+            let _ = self.field.set_decay_level(id, DecayLevel::Cold);
+        } else {
+            let _ = self.field.set_decay_level(id, DecayLevel::Hot);
+        }
+    }
+
+    fn apply_docked_pair_decay_policy(
+        &mut self,
+        a: NodeId,
+        b: NodeId,
+        now_ms: u64,
+        delay_ms: u64,
+    ) {
+        let a_visible = self.surface_intersects_viewport(a);
+        let b_visible = self.surface_intersects_viewport(b);
+
+        if self.is_hard_decay_protected(a, now_ms) || self.is_hard_decay_protected(b, now_ms) {
+            self.dock_decay_offscreen_since_ms.remove(&a);
+            self.dock_decay_offscreen_since_ms.remove(&b);
+            let _ = self.field.set_decay_level(a, DecayLevel::Hot);
+            let _ = self.field.set_decay_level(b, DecayLevel::Hot);
+            return;
+        }
+
+        if a_visible || b_visible {
+            self.dock_decay_offscreen_since_ms.remove(&a);
+            self.dock_decay_offscreen_since_ms.remove(&b);
+            let _ = self.field.set_decay_level(a, DecayLevel::Hot);
+            let _ = self.field.set_decay_level(b, DecayLevel::Hot);
+            return;
+        }
+
+        let since_a = self.dock_decay_offscreen_since_ms.get(&a).copied();
+        let since_b = self.dock_decay_offscreen_since_ms.get(&b).copied();
+        let since = since_a.or(since_b).unwrap_or(now_ms);
+
+        self.dock_decay_offscreen_since_ms.insert(a, since);
+        self.dock_decay_offscreen_since_ms.insert(b, since);
+
+        if now_ms.saturating_sub(since) >= delay_ms {
+            let _ = self.field.set_decay_level(a, DecayLevel::Cold);
+            let _ = self.field.set_decay_level(b, DecayLevel::Cold);
+        } else {
+            let _ = self.field.set_decay_level(a, DecayLevel::Hot);
+            let _ = self.field.set_decay_level(b, DecayLevel::Hot);
+        }
+    }
+
+    fn is_hard_decay_protected(&self, id: NodeId, now_ms: u64) -> bool {
+        self.interaction_focus == Some(id)
+            || self.resize_active == Some(id)
+            || self.is_recently_resized_node(id, now_ms)
+            || self.carry_zone_hint.contains_key(&id)
+            || self.active_transition_until_ms.contains_key(&id)
+    }
+
+    fn surface_intersects_viewport(&self, id: NodeId) -> bool {
+        let Some(n) = self.field.node(id) else {
+            return false;
+        };
+        if n.kind != halley_core::field::NodeKind::Surface || !self.field.is_visible(id) {
+            return false;
+        }
+
+        let size = self.collision_size_for_node(n);
+        let half_vw = self.viewport.size.x * 0.5;
+        let half_vh = self.viewport.size.y * 0.5;
+
+        let view_left = self.viewport.center.x - half_vw;
+        let view_right = self.viewport.center.x + half_vw;
+        let view_top = self.viewport.center.y - half_vh;
+        let view_bottom = self.viewport.center.y + half_vh;
+
+        let node_left = n.pos.x - size.x * 0.5;
+        let node_right = n.pos.x + size.x * 0.5;
+        let node_top = n.pos.y - size.y * 0.5;
+        let node_bottom = n.pos.y + size.y * 0.5;
+
+        node_right > view_left
+            && node_left < view_right
+            && node_bottom > view_top
+            && node_top < view_bottom
     }
 
     pub(crate) fn push_neighbors_for_activation(&mut self, activated: NodeId) {
@@ -392,6 +501,7 @@ impl HalleyWlState {
                 self.active_transition_until_ms.remove(&id);
                 self.primary_promote_cooldown_until_ms.remove(&id);
                 self.last_surface_focus_ms.remove(&id);
+                self.dock_decay_offscreen_since_ms.remove(&id);
                 self.carry_zone_hint.remove(&id);
                 self.carry_zone_last_change_ms.remove(&id);
                 self.carry_zone_pending.remove(&id);

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -89,6 +89,8 @@ pub struct HalleyWlState {
     pending_spawn_activate_at_ms: HashMap<NodeId, u64>,
     active_transition_until_ms: HashMap<NodeId, u64>,
     primary_promote_cooldown_until_ms: HashMap<NodeId, u64>,
+
+    dock_decay_offscreen_since_ms: HashMap<NodeId, u64>,
     carry_zone_hint: HashMap<NodeId, FocusZone>,
     carry_zone_last_change_ms: HashMap<NodeId, u64>,
     carry_zone_pending: HashMap<NodeId, FocusZone>,
@@ -170,6 +172,7 @@ impl HalleyWlState {
             pending_spawn_activate_at_ms: HashMap::new(),
             active_transition_until_ms: HashMap::new(),
             primary_promote_cooldown_until_ms: HashMap::new(),
+            dock_decay_offscreen_since_ms: HashMap::new(),
             carry_zone_hint: HashMap::new(),
             carry_zone_last_change_ms: HashMap::new(),
             carry_zone_pending: HashMap::new(),

--- a/crates/halley-wl/src/state/render_state.rs
+++ b/crates/halley-wl/src/state/render_state.rs
@@ -29,7 +29,10 @@ impl HalleyWlState {
             self.smoothed_render_pos.insert(id, logical);
             return logical;
         }
-        if self.interaction_focus == Some(id) {
+        if self.interaction_focus == Some(id)
+            || self.companion_surface_node(now_ms) == Some(id)
+            || self.is_recently_interacted_surface(id, now_ms)
+        {
             self.smoothed_render_pos.insert(id, logical);
             return logical;
         }
@@ -40,7 +43,6 @@ impl HalleyWlState {
         let mut alpha = (dt * 18.0).clamp(0.10, 0.42);
         let mut max_step = (dt * 1800.0).clamp(6.0, 70.0);
         if self.carry_zone_hint.contains_key(&id) {
-            // During pointer drag, reduce visual lag by boosting follow response.
             let boost = self.tuning.drag_smoothing_boost.clamp(0.1, 20.0);
             alpha = (alpha * boost).clamp(0.10, 1.0);
             max_step = (max_step * boost).clamp(6.0, 420.0);
@@ -72,6 +74,8 @@ impl HalleyWlState {
         if self.resize_active == Some(id)
             || (self.resize_static_node == Some(id) && now_ms < self.resize_static_until_ms)
             || self.interaction_focus == Some(id)
+            || self.companion_surface_node(now_ms) == Some(id)
+            || self.is_recently_interacted_surface(id, now_ms)
         {
             return logical;
         }

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -8,6 +8,9 @@ use crate::anim::{AnimSpec, AnimStyle};
 use crate::render::{DebugScene, build_debug_scene};
 
 impl HalleyWlState {
+    const RECENT_INTERACTION_PROTECT_MS: u64 = 7_500;
+    const COMPANION_PROTECT_MS: u64 = 12_000;
+
     pub fn now_ms(&self, now: Instant) -> u64 {
         now.duration_since(self.started_at).as_millis() as u64
     }
@@ -15,6 +18,32 @@ impl HalleyWlState {
     #[inline]
     pub(crate) fn is_recently_resized_node(&self, id: NodeId, now_ms: u64) -> bool {
         self.resize_static_node == Some(id) && now_ms < self.resize_static_until_ms
+    }
+
+    pub(crate) fn companion_surface_node(&self, now_ms: u64) -> Option<NodeId> {
+        let focused = self.interaction_focus;
+        self.last_surface_focus_ms
+            .iter()
+            .filter_map(|(&id, &at)| {
+                if Some(id) == focused {
+                    return None;
+                }
+                if now_ms.saturating_sub(at) > Self::COMPANION_PROTECT_MS {
+                    return None;
+                }
+                self.field.node(id).and_then(|n| {
+                    (self.field.is_visible(id) && n.kind == halley_core::field::NodeKind::Surface)
+                        .then_some((id, at))
+                })
+            })
+            .max_by_key(|(id, at)| (*at, id.as_u64()))
+            .map(|(id, _)| id)
+    }
+
+    pub(crate) fn is_recently_interacted_surface(&self, id: NodeId, now_ms: u64) -> bool {
+        self.last_surface_focus_ms
+            .get(&id)
+            .is_some_and(|&at| now_ms.saturating_sub(at) <= Self::RECENT_INTERACTION_PROTECT_MS)
     }
 
     pub fn mark_active_transition(&mut self, id: NodeId, now: Instant, duration_ms: u64) {

--- a/examples/halley-finale.rune
+++ b/examples/halley-finale.rune
@@ -146,6 +146,11 @@ nodes:
   border-colour-inactive "use-window-inactive"
 end
 
+decay:
+  off-screen-delay 300
+  outside-focus-ring-delay 30
+end
+
 # Device and input behavior
 input:
 end


### PR DESCRIPTION
intentional and predictable.

Previously, docked pairs could collapse immediately when one member began crossing the viewport edge. This happened because carry.rs (enforce_docked_pairs) was applying decay decisions based on outward viewport overflow.

This conflicted with the newer maintenance-based decay model and caused docked windows to collapse prematurely during panning or resizing.

Key changes:

• Removed overflow-driven decay logic from enforce_docked_pairs()
  - Docked geometry code now maintains spatial pairing only
  - Decay policy is no longer determined during docking enforcement

• Centralized collapse policy in maintenance.rs
  - Docked pairs now only become eligible for collapse when BOTH windows are fully offscreen
  - Collapse happens after the shared offscreen delay

• Introduced intentional active-window semantics
  - Up to two active windows may coexist without docking
  - Recently focused windows are protected from immediate decay

• Improved focus/interaction protections
  - Added soft protections for recently interacted surfaces
  - Companion window logic prevents premature collapse during workflows
  - Resize and interaction states temporarily suspend decay

• Corrected decay hierarchy
  Interaction intent
    > Docking relationships
    > Focus state
    > Maintenance decay timers
    > Heuristic decay (zoom etc.)

Result:

• Docked windows remain stable during pan and resize • Decay behavior matches user intent rather than viewport heuristics • Window interaction now feels significantly more predictable • Halley behaves much closer to a viable spatial compositor model

This change removes the last major source of unintended window collapse during navigation and layout manipulation.