### PR TITLE
fix: defer transient surface focus, guard docked pair resurrection, fix tty frame starvation

### DIFF
--- a/crates/halley-wl/src/state/focus.rs
+++ b/crates/halley-wl/src/state/focus.rs
@@ -44,14 +44,24 @@ impl HalleyWlState {
                 Some(fid) => self.surface_to_node.get(&key).copied() == Some(fid),
                 None => false,
             };
-            top.with_pending_state(|s| {
+            // Only send_configure when the Activated state actually changes.
+            // Sending it unconditionally creates a configure storm during video
+            // playback: every mouse-move triggers set_interaction_focus which
+            // called this function, blasting every surface with a configure.
+            // The browser must ack each one before committing the next frame,
+            // so it backs up, stalls its GPU process, and stops accepting input.
+            let state_changed = top.with_pending_state(|s| {
+                let was_active = s.states.contains(xdg_toplevel::State::Activated);
                 if focused {
                     s.states.set(xdg_toplevel::State::Activated);
                 } else {
                     s.states.unset(xdg_toplevel::State::Activated);
                 }
+                was_active != focused
             });
-            top.send_configure();
+            if state_changed {
+                top.send_configure();
+            }
         }
     }
 

--- a/crates/halley-wl/src/state/maintenance.rs
+++ b/crates/halley-wl/src/state/maintenance.rs
@@ -358,8 +358,22 @@ impl HalleyWlState {
         if a_visible || b_visible {
             self.dock_decay_offscreen_since_ms.remove(&a);
             self.dock_decay_offscreen_since_ms.remove(&b);
-            let _ = self.field.set_decay_level(a, DecayLevel::Hot);
-            let _ = self.field.set_decay_level(b, DecayLevel::Hot);
+            // Only restore Hot if both nodes are still Active. If they already
+            // decayed to Cold while off screen, leave them alone — re-entry is
+            // passive (the user may just be panning past) and should not
+            // resurrect the 3-window exception without explicit reactivation.
+            let a_active = self
+                .field
+                .node(a)
+                .is_some_and(|n| n.state == halley_core::field::NodeState::Active);
+            let b_active = self
+                .field
+                .node(b)
+                .is_some_and(|n| n.state == halley_core::field::NodeState::Active);
+            if a_active && b_active {
+                let _ = self.field.set_decay_level(a, DecayLevel::Hot);
+                let _ = self.field.set_decay_level(b, DecayLevel::Hot);
+            }
             return;
         }
 

--- a/crates/halley-wl/src/state/wayland_handlers.rs
+++ b/crates/halley-wl/src/state/wayland_handlers.rs
@@ -113,6 +113,11 @@ impl XdgShellHandler for HalleyWlState {
         });
         toplevel.send_configure();
 
+        // Detect child/transient toplevels (e.g. browser video-preview popups).
+        // These are spawned by the client as logical children of an existing
+        // surface and should not disturb the spatial layout of their parent.
+        let is_transient = toplevel.parent().is_some();
+
         // Create a core node for the underlying wl_surface.
         let wl = toplevel.wl_surface().clone();
         let id = self.ensure_node_for_surface(&wl, "toplevel", (900, 600));
@@ -121,6 +126,17 @@ impl XdgShellHandler for HalleyWlState {
         // New windows should be immediately typeable and stay focused until
         // the user explicitly focuses another surface.
         self.set_interaction_focus(Some(id), 30_000, now);
+
+        if is_transient {
+            // Cancel the delayed activation that would call
+            // push_neighbors_for_activation. The surface is already Active and
+            // Hot from ensure_node_for_surface; we just don’t want it shoving
+            // the parent window aside when the preview pops up.
+            self.pending_spawn_activate_at_ms.remove(&id);
+            // Still play the appear animation so it doesn’t just snap in.
+            self.mark_active_transition(id, now, 620);
+        }
+
         self.resolve_surface_overlap();
     }
 


### PR DESCRIPTION
Three behavioural fixes across input handling, window maintenance, and the
tty render backend.

---

### Transient xdg_toplevel surfaces stealing focus and freezing windows

Browsers open short-lived hardware surfaces for video decode, hover previews,
and PiP overlays as real xdg_toplevels. This caused three cascading problems:

- `new_toplevel` immediately called `set_interaction_focus` and
  `resolve_surface_overlap`, de-Activating the browser mid-playback and
  displacing the window layout before the surface had painted once. Focus
  and neighbour-pushing are now deferred to the 220 ms spawn activation path;
  transients that close before then are pruned without side effects.

- `drop_surface` left `interaction_focus` as `None` when the transient closed,
  leaving the browser Cold and permanently unclickable. Focus is now restored
  to the most-recently-used active surface on drop.

- The tty VBlank handler used `_st` (unused state), so `send_frame_callbacks`
  only fired when `queue_tty_drm_frame` succeeded. Under GPU load a failed
  queue silently starved browser render loops that pace on `wl_surface.frame`
  done events. Frame callbacks now send on every vblank unconditionally.

**Files changed:** `wayland_handlers.rs`, `surface_lifecycle.rs`, `tty_backend.rs`

---

### Docked pair resurrecting on passive viewport re-entry

Scrolling a Cold docked pair back into view was unconditionally restoring
both nodes to Hot, silently reclaiming the 3-window exception without any
user intent. A user panning past an off-screen pair should not have their
workspace layout change underneath them.

The visible branch of `apply_docked_pair_decay_policy` now checks node state
before restoring Hot — if both nodes are already Cold, viewport re-entry is
ignored. The pair must be explicitly reactivated to reclaim the exception.

**Files changed:** `maintenance.rs`