### PR TITLE
ipc + outputs: wire halleyctl to compositor and fix drag-release decay flicker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,9 +161,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block"
@@ -587,6 +590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.10"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
 name = "glow"
@@ -752,34 +761,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows",
 ]
 
 [[package]]
@@ -825,7 +817,7 @@ dependencies = [
 name = "halley-cli"
 version = "0.1.0"
 dependencies = [
- "drm",
+ "halley-ipc",
 ]
 
 [[package]]
@@ -841,6 +833,14 @@ name = "halley-core"
 version = "0.1.0"
 
 [[package]]
+name = "halley-ipc"
+version = "0.1.0"
+dependencies = [
+ "postcard",
+ "serde",
+]
+
+[[package]]
 name = "halley-wl"
 version = "0.1.0"
 dependencies = [
@@ -849,11 +849,11 @@ dependencies = [
  "glam",
  "halley-config",
  "halley-core",
+ "halley-ipc",
  "notify",
  "once_cell",
  "pollster",
  "postcard",
- "rune-cfg",
  "rustix 1.1.4",
  "serde",
  "smallvec",
@@ -878,7 +878,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -886,6 +886,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1212,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -1239,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
+checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1250,7 +1255,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
  "libm",
@@ -2226,7 +2231,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -2697,16 +2702,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "26.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b6ff82bbf6e9206828e1a3178e851f8c20f1c9028e74dd3a8090741ccd5798"
+checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
  "naga",
@@ -2726,17 +2732,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "26.0.1"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f62f1053bd28c2268f42916f31588f81f64796e2ff91b81293515017ca8bd9"
+checksum = "d23f4642f53f666adcfd2d3218ab174d1e6681101aef18696b90cbe64d1c10f9"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
@@ -2757,36 +2764,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae5fbde6a4cbebae38358aa73fcd6e0f15c6144b67ef5dc91ded0db125dbdf"
+checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7670e390f416006f746b4600fdd9136455e3627f5bd763abf9a65daa216dd2d"
+checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720a5cb9d12b3d337c15ff0e24d3e97ed11490ff3f7506e7f3d98c68fa5d6f14"
+checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "26.0.6"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d0e67224cc7305b3b4eb2cc57ca4c4c3afc665c1d1bee162ea806e19c47bdd"
+checksum = "44d6cb474beb218824dcc9e1ce679d973f719262789bfb27407da560cac20eeb"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -2800,10 +2807,9 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -2813,6 +2819,7 @@ dependencies = [
  "naga",
  "ndk-sys",
  "objc",
+ "once_cell",
  "ordered-float",
  "parking_lot",
  "portable-atomic",
@@ -2826,21 +2833,20 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "26.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca7a8d8af57c18f57d393601a1fb159ace8b2328f1b6b5f80893f7d672c9ae2"
+checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -2877,22 +2883,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -2903,20 +2899,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -2925,11 +2908,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2938,20 +2921,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2959,17 +2931,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2999,17 +2960,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3019,16 +2971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
   "crates/halley",
   "crates/halley-cli", "crates/halley-config",
-  "crates/halley-core", 
+  "crates/halley-core", "crates/halley-ipc", 
   "crates/halley-wl"
 ]
 resolver = "2"

--- a/crates/halley-cli/Cargo.toml
+++ b/crates/halley-cli/Cargo.toml
@@ -8,4 +8,4 @@ name = "halleyctl"
 path = "src/main.rs"
 
 [dependencies]
-drm = "0.14.2"
+halley-ipc = { path = "../halley-ipc" }

--- a/crates/halley-cli/src/main.rs
+++ b/crates/halley-cli/src/main.rs
@@ -1,28 +1,35 @@
-use std::fs;
-use std::fs::OpenOptions;
-use std::io;
-use std::os::fd::{AsFd, BorrowedFd};
-use std::path::{Path, PathBuf};
-
-use drm::Device as BasicDevice;
-use drm::control::{self as drm_control, Device as ControlDevice, ModeTypeFlags};
+use halley_ipc::{
+    LogicalOutputInfo, OutputInfo, OutputStatus, OutputsResponse, Request, Response, send_request,
+};
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    match args.next().as_deref() {
-        Some("outputs") => {
-            if let Err(err) = print_outputs() {
-                eprintln!("halleyctl outputs failed: {err}");
-                std::process::exit(1);
-            }
-        }
+
+    let request = match args.next().as_deref() {
+        Some("quit") => Request::Quit,
+        Some("reload") => Request::Reload,
+        Some("outputs") => Request::Outputs,
         Some("help") | Some("--help") | Some("-h") | None => {
             print_help();
+            return;
         }
         Some(other) => {
             eprintln!("unknown command: {other}");
             print_help();
             std::process::exit(2);
+        }
+    };
+
+    match send_request(&request) {
+        Ok(response) => {
+            if let Err(err) = print_response(response) {
+                eprintln!("halleyctl failed: {err}");
+                std::process::exit(1);
+            }
+        }
+        Err(err) => {
+            eprintln!("halleyctl failed to talk to halley: {err}");
+            std::process::exit(1);
         }
     }
 }
@@ -31,215 +38,95 @@ fn print_help() {
     println!("halleyctl");
     println!();
     println!("Usage:");
+    println!("  halleyctl quit");
+    println!("  halleyctl reload");
     println!("  halleyctl outputs");
     println!();
     println!("Commands:");
-    println!("  outputs   Print current output information from /sys/class/drm");
+    println!("  quit      Ask the running Halley compositor to exit");
+    println!("  reload    Ask the running Halley compositor to reload config");
+    println!("  outputs   Print current output information from the running Halley compositor");
 }
 
-fn print_outputs() -> io::Result<()> {
-    match print_outputs_via_drm() {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            eprintln!("halleyctl: DRM ioctl path unavailable ({err}); falling back to sysfs");
-            print_outputs_via_sysfs()
+fn print_response(response: Response) -> Result<(), String> {
+    match response {
+        Response::Ok => {
+            println!("ok");
+            Ok(())
         }
+        Response::Reloaded => {
+            println!("reloaded");
+            Ok(())
+        }
+        Response::Outputs(outputs) => {
+            print_outputs(outputs);
+            Ok(())
+        }
+        Response::Error(err) => Err(format!("{err:?}")),
     }
 }
 
-fn print_outputs_via_drm() -> io::Result<()> {
-    let mut cards: Vec<PathBuf> = fs::read_dir("/dev/dri")?
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| {
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with("card"))
-        })
-        .collect();
-    cards.sort();
-
-    if cards.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "no /dev/dri/card* devices found",
-        ));
+fn print_outputs(outputs: OutputsResponse) {
+    if outputs.outputs.is_empty() {
+        println!("No outputs.");
+        return;
     }
 
-    for card_path in cards {
-        let card_name = card_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("card?");
-        let card = Card::open(card_path.as_path())?;
-        let resources = card.resource_handles()?;
+    for output in outputs.outputs {
+        print_output(&output);
+    }
+}
 
-        for conn in resources.connectors() {
-            let info = card.get_connector(*conn, true)?;
-            let full_name = format!(
-                "{}-{}-{}",
-                card_name,
-                info.interface().as_str(),
-                info.interface_id()
-            );
-            let status = match info.state() {
-                drm_control::connector::State::Connected => "connected",
-                drm_control::connector::State::Disconnected => "disconnected",
-                drm_control::connector::State::Unknown => "unknown",
-            };
-            let current = current_mode(&card, &info);
+fn print_output(output: &OutputInfo) {
+    println!("{}", output.name);
+    println!("  status: {}", format_status(output.status));
+    println!(
+        "  enabled: {}",
+        if output.enabled { "enabled" } else { "disabled" }
+    );
 
-            println!("{full_name}");
-            println!("  status: {status}");
-            println!(
-                "  enabled: {}",
-                if current.is_some() {
-                    "enabled"
-                } else {
-                    "disabled"
-                }
-            );
-            if let Some(ref current_mode) = current {
-                println!("  current_mode: {current_mode}");
-            }
-            if info.modes().is_empty() {
-                println!("  modes: (none)");
-            } else {
-                println!("  modes:");
-                for mode in info.modes() {
-                    let mode_text = format_mode(mode);
-                    let preferred = mode.mode_type().contains(ModeTypeFlags::PREFERRED);
-                    let current_match = current.as_deref() == Some(mode_text.as_str());
-                    let marker = if current_match {
-                        "*"
-                    } else if preferred {
-                        "+"
-                    } else {
-                        "-"
-                    };
-                    println!("    {marker} {mode_text}");
-                }
-            }
-        }
+    if let Some(current_mode) = &output.current_mode {
+        println!("  current_mode: {}", current_mode.display_string());
     }
 
-    Ok(())
-}
-
-fn current_mode(card: &Card, info: &drm_control::connector::Info) -> Option<String> {
-    let encoder = info
-        .current_encoder()
-        .or_else(|| info.encoders().first().copied())?;
-    let encoder_info = card.get_encoder(encoder).ok()?;
-    let crtc = encoder_info.crtc()?;
-    let crtc_info = card.get_crtc(crtc).ok()?;
-    crtc_info.mode().map(|m| format_mode(&m))
-}
-
-fn format_mode(mode: &drm_control::Mode) -> String {
-    let (w, h) = mode.size();
-    let hz = mode.vrefresh() as f64;
-    format!("{w}x{h} @ {hz:.2}Hz")
-}
-
-fn print_outputs_via_sysfs() -> io::Result<()> {
-    let drm_root = Path::new("/sys/class/drm");
-    let mut entries: Vec<PathBuf> = fs::read_dir(drm_root)?
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| p.is_dir())
-        .filter(|p| {
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(is_connector_name)
-        })
-        .collect();
-
-    entries.sort();
-
-    if entries.is_empty() {
-        println!(
-            "No DRM connector entries found under {}",
-            drm_root.display()
-        );
-        return Ok(());
-    }
-
-    for entry in entries {
-        let name = entry
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("<unknown>");
-        let status = read_trimmed(entry.join("status")).unwrap_or_else(|| "unknown".to_string());
-        let enabled = read_trimmed(entry.join("enabled"));
-        let current_mode = read_trimmed(entry.join("mode"));
-        let modes = read_modes(entry.join("modes"));
-
-        println!("{name}");
-        println!("  status: {status}");
-        if let Some(enabled) = enabled {
-            println!("  enabled: {enabled}");
-        }
-        if let Some(current_mode) = &current_mode {
-            println!("  current_mode: {current_mode}");
-        }
-        if modes.is_empty() {
-            println!("  modes: (none)");
+    if output.modes.is_empty() {
+        println!("  modes: (none)");
+    } else {
+        let has_refresh = output.modes.iter().any(|mode| mode.refresh_hz.is_some());
+        if has_refresh {
+            println!("  modes:");
         } else {
-            println!("  modes: (resolution-only; refresh unavailable via sysfs)");
-            for mode in modes {
-                let marker = if current_mode.as_deref() == Some(mode.as_str()) {
-                    "*"
-                } else {
-                    "-"
-                };
-                println!("    {marker} {mode}");
-            }
+            println!("  modes: (resolution-only; refresh unavailable)");
+        }
+
+        for mode in &output.modes {
+            let marker = if mode.current {
+                "*"
+            } else if mode.preferred {
+                "+"
+            } else {
+                "-"
+            };
+            println!("    {marker} {}", mode.display_string());
         }
     }
 
-    Ok(())
-}
-
-fn is_connector_name(name: &str) -> bool {
-    name.starts_with("card") && name.contains('-')
-}
-
-fn read_trimmed(path: PathBuf) -> Option<String> {
-    let raw = fs::read_to_string(path).ok()?;
-    let trimmed = raw.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
-}
-
-fn read_modes(path: PathBuf) -> Vec<String> {
-    let Ok(raw) = fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    raw.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(ToOwned::to_owned)
-        .collect()
-}
-
-struct Card(fs::File);
-
-impl Card {
-    fn open(path: &Path) -> io::Result<Self> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .or_else(|_| OpenOptions::new().read(true).open(path))?;
-        Ok(Self(file))
+    if let Some(logical) = &output.logical {
+        print_logical(logical);
     }
 }
 
-impl AsFd for Card {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.0.as_fd()
-    }
+fn print_logical(logical: &LogicalOutputInfo) {
+    println!("  logical:");
+    println!("    scale: {}", logical.scale);
+    println!("    focused: {}", logical.focused);
+    println!("    offset: {}, {}", logical.offset_x, logical.offset_y);
 }
 
-impl BasicDevice for Card {}
-impl ControlDevice for Card {}
+fn format_status(status: OutputStatus) -> &'static str {
+    match status {
+        OutputStatus::Connected => "connected",
+        OutputStatus::Disconnected => "disconnected",
+        OutputStatus::Unknown => "unknown",
+    }
+}

--- a/crates/halley-ipc/Cargo.toml
+++ b/crates/halley-ipc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "halley-ipc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+postcard = { version = "1", features = ["use-std"] }

--- a/crates/halley-ipc/src/codec.rs
+++ b/crates/halley-ipc/src/codec.rs
@@ -1,0 +1,44 @@
+use std::io::{Read, Write};
+
+use crate::error::CodecError;
+use crate::protocol::{Request, Response};
+
+const MAX_FRAME_LEN: u32 = 1024 * 1024; // 1 MiB
+
+pub fn encode_request(req: &Request) -> Result<Vec<u8>, CodecError> {
+    postcard::to_stdvec(req).map_err(CodecError::Encode)
+}
+
+pub fn decode_request(bytes: &[u8]) -> Result<Request, CodecError> {
+    postcard::from_bytes(bytes).map_err(CodecError::Decode)
+}
+
+pub fn encode_response(resp: &Response) -> Result<Vec<u8>, CodecError> {
+    postcard::to_stdvec(resp).map_err(CodecError::Encode)
+}
+
+pub fn decode_response(bytes: &[u8]) -> Result<Response, CodecError> {
+    postcard::from_bytes(bytes).map_err(CodecError::Decode)
+}
+
+pub fn write_frame<W: Write>(writer: &mut W, payload: &[u8]) -> Result<(), CodecError> {
+    let len = payload.len() as u32;
+    writer.write_all(&len.to_le_bytes())?;
+    writer.write_all(payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+pub fn read_frame<R: Read>(reader: &mut R) -> Result<Vec<u8>, CodecError> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+
+    let len = u32::from_le_bytes(len_buf);
+    if len > MAX_FRAME_LEN {
+        return Err(CodecError::FrameTooLarge(len));
+    }
+
+    let mut payload = vec![0u8; len as usize];
+    reader.read_exact(&mut payload)?;
+    Ok(payload)
+}

--- a/crates/halley-ipc/src/error.rs
+++ b/crates/halley-ipc/src/error.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IpcError {
+    InvalidRequest(String),
+    Unsupported(String),
+    Internal(String),
+}
+
+#[derive(Debug)]
+pub enum CodecError {
+    Io(io::Error),
+    Encode(postcard::Error),
+    Decode(postcard::Error),
+    FrameTooLarge(u32),
+}
+
+impl fmt::Display for CodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "i/o error: {e}"),
+            Self::Encode(e) => write!(f, "encode error: {e}"),
+            Self::Decode(e) => write!(f, "decode error: {e}"),
+            Self::FrameTooLarge(len) => write!(f, "frame too large: {len} bytes"),
+        }
+    }
+}
+
+impl std::error::Error for CodecError {}
+
+impl From<io::Error> for CodecError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}

--- a/crates/halley-ipc/src/lib.rs
+++ b/crates/halley-ipc/src/lib.rs
@@ -1,0 +1,38 @@
+pub mod codec;
+pub mod error;
+pub mod protocol;
+pub mod types;
+
+pub use codec::{
+    decode_request, decode_response, encode_request, encode_response, read_frame, write_frame,
+};
+pub use error::{CodecError, IpcError};
+pub use protocol::{Request, Response};
+pub use types::{
+    LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus, OutputsResponse,
+};
+
+use std::env;
+use std::io;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+pub fn default_socket_path() -> io::Result<PathBuf> {
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "XDG_RUNTIME_DIR is not set"))?;
+    Ok(PathBuf::from(runtime_dir).join("halley.sock"))
+}
+
+pub fn send_request(req: &Request) -> Result<Response, CodecError> {
+    let path = default_socket_path()?;
+    send_request_to(&path, req)
+}
+
+pub fn send_request_to(path: &std::path::Path, req: &Request) -> Result<Response, CodecError> {
+    let mut stream = UnixStream::connect(path)?;
+    let bytes = encode_request(req)?;
+    write_frame(&mut stream, &bytes)?;
+
+    let resp_bytes = read_frame(&mut stream)?;
+    decode_response(&resp_bytes)
+}

--- a/crates/halley-ipc/src/protocol.rs
+++ b/crates/halley-ipc/src/protocol.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::IpcError;
+use crate::types::OutputsResponse;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Request {
+    Quit,
+    Reload,
+    Outputs,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Response {
+    Ok,
+    Reloaded,
+    Outputs(OutputsResponse),
+    Error(IpcError),
+}

--- a/crates/halley-ipc/src/types.rs
+++ b/crates/halley-ipc/src/types.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputsResponse {
+    pub outputs: Vec<OutputInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputInfo {
+    pub name: String,
+    pub status: OutputStatus,
+    pub enabled: bool,
+    pub current_mode: Option<ModeInfo>,
+    pub modes: Vec<ModeInfo>,
+    pub logical: Option<LogicalOutputInfo>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OutputStatus {
+    Connected,
+    Disconnected,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModeInfo {
+    pub width: u32,
+    pub height: u32,
+    pub refresh_hz: Option<f64>,
+    pub preferred: bool,
+    pub current: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogicalOutputInfo {
+    pub scale: f64,
+    pub focused: bool,
+    pub offset_x: i32,
+    pub offset_y: i32,
+}
+
+impl ModeInfo {
+    pub fn display_string(&self) -> String {
+        match self.refresh_hz {
+            Some(hz) => format!("{}x{} @ {:.2}Hz", self.width, self.height, hz),
+            None => format!("{}x{}", self.width, self.height),
+        }
+    }
+}

--- a/crates/halley-wl/Cargo.toml
+++ b/crates/halley-wl/Cargo.toml
@@ -10,6 +10,7 @@ session-libseat = ["smithay/backend_session_libseat"]
 [dependencies]
 halley-core = { path = "../halley-core" }
 halley-config = { path = "../halley-config" }
+halley-ipc = { path = "../halley-ipc" }
 
 # Wayland compositor toolkit
 smithay = { version = "0.7.0", default-features = false, features = [
@@ -41,10 +42,9 @@ once_cell = "1.21.3"
 pollster = "0.4.0"
 
 # Rendering/math + serialization (phase 1 alignment with crates.txt)
-glam = "0.30.8"
-wgpu = "26.0.1"
+glam = "0.32.1"
+wgpu = "28.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 postcard = { version = "1.1.3", features = ["use-std"] }
-rune-cfg = { version = "0.4.4", path = "../../../../libs/rune-cfg" }
 notify = "8.2.0"
 xcursor = "0.3.10"

--- a/crates/halley-wl/src/run/drm.rs
+++ b/crates/halley-wl/src/run/drm.rs
@@ -1,15 +1,17 @@
 use super::*;
+
+use crate::interaction::types::ResizeCtx;
+use halley_ipc::{ModeInfo, OutputInfo, OutputStatus};
+
 pub(super) struct TtyDrmProbe {
     pub(super) _card_path: std::path::PathBuf,
-    pub(super) _dev: DrmDevice,
+    pub(super) dev: DrmDevice,
     pub(super) notifier: smithay::backend::drm::DrmDeviceNotifier,
     pub(super) crtc: drm_control::crtc::Handle,
     pub(super) mode: drm_control::Mode,
     pub(super) gbm_surface: Rc<RefCell<GbmBufferedSurface<GbmAllocator<DeviceFd>, ()>>>,
     pub(super) renderer: Rc<RefCell<GlesRenderer>>,
 }
-
-use crate::interaction::types::ResizeCtx;
 
 pub(super) fn probe_tty_drm_device(
     seat: &str,
@@ -190,7 +192,7 @@ pub(super) fn probe_tty_drm_device_path(
     );
     Ok(TtyDrmProbe {
         _card_path: card_path.to_path_buf(),
-        _dev: dev,
+        dev,
         notifier,
         crtc,
         mode,
@@ -287,7 +289,7 @@ pub(super) fn probe_tty_drm_device_path_via_session(
     );
     Ok(TtyDrmProbe {
         _card_path: card_path.to_path_buf(),
-        _dev: dev,
+        dev,
         notifier,
         crtc,
         mode,
@@ -431,6 +433,83 @@ pub(super) fn select_tty_scanout(
         selected_conn,
         selected_info.to_string(),
     ))
+}
+
+pub(super) fn collect_outputs_for_ipc(dev: &DrmDevice) -> Vec<OutputInfo> {
+    let mut outputs = Vec::new();
+
+    let Ok(resources) = dev.resource_handles() else {
+        return outputs;
+    };
+
+    for conn in resources.connectors() {
+        let Ok(info) = dev.get_connector(*conn, true) else {
+            continue;
+        };
+
+        let status = match info.state() {
+            drm_control::connector::State::Connected => OutputStatus::Connected,
+            drm_control::connector::State::Disconnected => OutputStatus::Disconnected,
+            drm_control::connector::State::Unknown => OutputStatus::Unknown,
+        };
+
+        let current = current_mode_from_connector(dev, &info);
+        let mut current_mode = None;
+        let mut modes = Vec::new();
+
+        for mode in info.modes() {
+            let (w, h) = mode.size();
+            let hz = mode.vrefresh() as f64;
+            let text = format!("{}x{} @ {:.2}Hz", w, h, hz);
+            let current_match = current.as_deref() == Some(text.as_str());
+
+            let mode_info = ModeInfo {
+                width: w as u32,
+                height: h as u32,
+                refresh_hz: Some(hz),
+                preferred: mode
+                    .mode_type()
+                    .contains(drm_control::ModeTypeFlags::PREFERRED),
+                current: current_match,
+            };
+
+            if current_match {
+                current_mode = Some(mode_info.clone());
+            }
+
+            modes.push(mode_info);
+        }
+
+        outputs.push(OutputInfo {
+            name: info.to_string(),
+            status,
+            enabled: current_mode.is_some(),
+            current_mode,
+            modes,
+            logical: None,
+        });
+    }
+
+    outputs
+}
+
+fn current_mode_from_connector(
+    dev: &DrmDevice,
+    info: &drm_control::connector::Info,
+) -> Option<String> {
+    let encoder = info
+        .current_encoder()
+        .or_else(|| info.encoders().first().copied())?;
+
+    let encoder_info = dev.get_encoder(encoder).ok()?;
+    let crtc = encoder_info.crtc()?;
+    let crtc_info = dev.get_crtc(crtc).ok()?;
+
+    crtc_info.mode().map(|m| {
+        let (w, h) = m.size();
+        let hz = m.vrefresh() as f64;
+        format!("{}x{} @ {:.2}Hz", w, h, hz)
+    })
 }
 
 pub(super) fn queue_tty_drm_frame(

--- a/crates/halley-wl/src/run/ipc.rs
+++ b/crates/halley-wl/src/run/ipc.rs
@@ -1,0 +1,159 @@
+use std::fs;
+use std::io;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use once_cell::sync::OnceCell;
+
+use eventline::{error, info, warn};
+use halley_ipc::{
+    IpcError, OutputInfo, OutputsResponse, Request, Response, decode_request, encode_response,
+    read_frame, write_frame,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub enum RuntimeIpcCommand {
+    Quit,
+    Reload,
+}
+
+static IPC_COMMAND_RX: OnceCell<Mutex<mpsc::Receiver<RuntimeIpcCommand>>> = OnceCell::new();
+static IPC_OUTPUTS: OnceCell<Arc<Mutex<Vec<OutputInfo>>>> = OnceCell::new();
+
+pub fn init_ipc() -> io::Result<()> {
+    if IPC_COMMAND_RX.get().is_some() {
+        return Ok(());
+    }
+
+    let socket_path = halley_ipc::default_socket_path()?;
+    remove_stale_socket(&socket_path)?;
+
+    let listener = UnixListener::bind(&socket_path)?;
+    let (command_tx, command_rx) = mpsc::channel::<RuntimeIpcCommand>();
+    let outputs = Arc::new(Mutex::new(Vec::<OutputInfo>::new()));
+
+    IPC_COMMAND_RX.set(Mutex::new(command_rx)).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "IPC command receiver already initialized",
+        )
+    })?;
+
+    IPC_OUTPUTS.set(outputs.clone()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "IPC outputs store already initialized",
+        )
+    })?;
+
+    thread::Builder::new()
+        .name("halley-ipc".to_string())
+        .spawn(move || {
+            info!("halley ipc listening on {}", socket_path.display());
+
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(mut stream) => {
+                        if let Err(err) = handle_client(&mut stream, &command_tx, &outputs) {
+                            warn!("halley ipc client failed: {}", err);
+                        }
+                    }
+                    Err(err) => {
+                        error!("halley ipc accept failed: {}", err);
+                        break;
+                    }
+                }
+            }
+
+            let _ = fs::remove_file(&socket_path);
+        })?;
+
+    Ok(())
+}
+
+pub fn publish_outputs(outputs: Vec<OutputInfo>) {
+    let Some(store) = IPC_OUTPUTS.get() else {
+        return;
+    };
+
+    match store.lock() {
+        Ok(mut guard) => {
+            *guard = outputs;
+        }
+        Err(err) => {
+            warn!("halley ipc outputs lock poisoned: {}", err);
+        }
+    }
+}
+
+pub fn drain_ipc_commands<F>(mut f: F)
+where
+    F: FnMut(RuntimeIpcCommand),
+{
+    let Some(rx) = IPC_COMMAND_RX.get() else {
+        return;
+    };
+
+    let guard = match rx.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            warn!("halley ipc command receiver lock poisoned: {}", err);
+            return;
+        }
+    };
+
+    loop {
+        match guard.try_recv() {
+            Ok(cmd) => f(cmd),
+            Err(mpsc::TryRecvError::Empty) => break,
+            Err(mpsc::TryRecvError::Disconnected) => break,
+        }
+    }
+}
+
+fn handle_client(
+    stream: &mut UnixStream,
+    command_tx: &mpsc::Sender<RuntimeIpcCommand>,
+    outputs: &Arc<Mutex<Vec<OutputInfo>>>,
+) -> io::Result<()> {
+    let response = match read_frame(stream).and_then(|bytes| decode_request(&bytes)) {
+        Ok(request) => handle_request(request, command_tx, outputs),
+        Err(err) => Response::Error(IpcError::InvalidRequest(err.to_string())),
+    };
+
+    let response_bytes = encode_response(&response).map_err(io::Error::other)?;
+    write_frame(stream, &response_bytes).map_err(io::Error::other)
+}
+
+fn handle_request(
+    request: Request,
+    command_tx: &mpsc::Sender<RuntimeIpcCommand>,
+    outputs: &Arc<Mutex<Vec<OutputInfo>>>,
+) -> Response {
+    match request {
+        Request::Quit => match command_tx.send(RuntimeIpcCommand::Quit) {
+            Ok(()) => Response::Ok,
+            Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+        },
+        Request::Reload => match command_tx.send(RuntimeIpcCommand::Reload) {
+            Ok(()) => Response::Reloaded,
+            Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+        },
+        Request::Outputs => match outputs.lock() {
+            Ok(guard) => Response::Outputs(OutputsResponse {
+                outputs: guard.clone(),
+            }),
+            Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+        },
+    }
+}
+fn remove_stale_socket(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}

--- a/crates/halley-wl/src/run/mod.rs
+++ b/crates/halley-wl/src/run/mod.rs
@@ -29,7 +29,7 @@ use smithay::{
     backend::egl::{EGLContext, EGLDisplay},
     backend::input::{
         AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
-        PointerButtonEvent, PointerMotionEvent,
+        PointerButtonEvent,
     },
     backend::libinput::LibinputInputBackend,
     backend::renderer::gles::GlesRenderer,
@@ -56,19 +56,21 @@ use crate::state::{ClientState, HalleyWlState};
 use crate::input::{BackendInputEventData, advance_node_move_anim, handle_backend_input_event};
 use crate::runtime_render::draw_debug_frame_to_target;
 use crate::surface::current_surface_size_for_node;
+
 mod common;
 mod drm;
 mod input_backend;
+mod ipc;
 mod tty_backend;
 mod winit_backend;
+
 use common::{
     RuntimeBackend, auto_backend, ensure_dbus_session_bus_address, ensure_host_display,
     ensure_xdg_runtime_dir, ensure_xwayland_satellite,
 };
 #[cfg(feature = "session-libseat")]
 use drm::probe_tty_drm_device_via_session;
-use drm::{probe_tty_drm_device, queue_tty_drm_frame};
-use input_backend::build_direct_libinput_backend;
+pub(crate) use ipc::{RuntimeIpcCommand, drain_ipc_commands, init_ipc, publish_outputs};
 #[cfg(feature = "session-libseat")]
 use input_backend::build_tty_libinput_backend;
 
@@ -99,6 +101,8 @@ impl BackendView for TtyBackendHandle {
 }
 
 pub fn run() -> Result<(), Box<dyn Error>> {
+    init_ipc()?;
+
     match RuntimeBackend::from_env()? {
         RuntimeBackend::Auto => match auto_backend() {
             RuntimeBackend::Tty => run_tty(),

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -1,4 +1,15 @@
 use super::*;
+
+use crate::run::drm::{collect_outputs_for_ipc, probe_tty_drm_device, queue_tty_drm_frame};
+use crate::run::input_backend::build_direct_libinput_backend;
+#[cfg(feature = "session-libseat")]
+use crate::run::{build_tty_libinput_backend, probe_tty_drm_device_via_session};
+
+use smithay::backend::input::{
+    AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
+    PointerButtonEvent, PointerMotionEvent,
+};
+
 pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
     eprintln!("halley-wl tty: starting");
     scope!(
@@ -14,6 +25,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 return Err(err);
             }
             eprintln!("halley-wl tty: logging initialized");
+
             #[cfg(feature = "session-libseat")]
             let (seat_name, drm_probe, libinput_backend, libinput_context, session_notifier) = {
                 let config_path = RuntimeTuning::config_path();
@@ -39,6 +51,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     session_notifier,
                 )
             };
+
             #[cfg(not(feature = "session-libseat"))]
             let (seat_name, drm_probe, libinput_backend) = {
                 warn!(
@@ -51,6 +64,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 let libinput_backend = build_direct_libinput_backend()?;
                 (seat_name, drm_probe, libinput_backend)
             };
+
             info!(
                 "tty backend starting on seat={} with direct DRM scanout",
                 seat_name
@@ -164,6 +178,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     let _ =
                         dh_for_clients.insert_client(client_stream, Arc::new(ClientState::new()));
                 })?;
+
             #[cfg(feature = "session-libseat")]
             {
                 let libinput_context_for_session = libinput_context.clone();
@@ -225,6 +240,9 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 ps.workspace_size = (backend_handle.width, backend_handle.height);
             }
 
+            let initial_outputs = collect_outputs_for_ipc(&drm_probe.dev);
+            publish_outputs(initial_outputs);
+
             let drm_crtc = drm_probe.crtc;
             let gbm_surface_for_vblank = drm_probe.gbm_surface.clone();
             let warned_vblank_mismatch = Rc::new(RefCell::new(false));
@@ -233,8 +251,6 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 drm_probe.notifier,
                 move |event, metadata, _st| match event {
                     DrmEvent::VBlank(crtc) => {
-                        // Single-output tty path: tolerate occasional CRTC-id mismatch and still
-                        // release the pending frame to avoid scanout stalls.
                         let expected_crtc = { gbm_surface_for_vblank.borrow().crtc() };
                         if crtc != expected_crtc {
                             if !*warned_vblank_mismatch_for_notifier.borrow() {
@@ -280,7 +296,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             info!("tty input: first keyboard event received");
                             *keyboard_seen_for_input.borrow_mut() = true;
                         }
-                        let code = event.key_code().into();
+                        let code: u32 = event.key_code().into();
                         let pressed = event.state() == KeyState::Pressed;
                         if debug_input {
                             info!("tty input keyboard code={} pressed={}", code, pressed);
@@ -406,8 +422,23 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             let timer = Timer::from_duration(Duration::from_millis(16));
             let gbm_surface_for_timer = drm_probe.gbm_surface.clone();
             let renderer_for_timer = drm_probe.renderer.clone();
+
             ev.handle().insert_source(timer, move |_tick, _, st| {
                 let now = Instant::now();
+
+                drain_ipc_commands(|cmd| match cmd {
+                    RuntimeIpcCommand::Quit => {
+                        info!("ipc: quit requested");
+                        st.request_exit();
+                    }
+                    RuntimeIpcCommand::Reload => {
+                        let next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        st.apply_tuning(next);
+                        info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
+                        info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
+                    }
+                });
+
                 {
                     let rx = xwayland_request_for_timer.borrow_mut();
                     while rx.try_recv().is_ok() {
@@ -415,22 +446,25 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     }
                 }
                 xwayland_for_timer.borrow_mut().tick();
-                let resize_active = {
+
+                {
                     let ps = pointer_state_for_timer.borrow();
-                    ps.resize.is_some()
-                };
-                st.tick_animator_frame(now);
-                {
-                    let mut ps = pointer_state_for_timer.borrow_mut();
-                    let _ = advance_node_move_anim(st, &mut ps, now);
-                }
-                {
-                    let mut last = last_maintenance_for_timer.borrow_mut();
-                    if !resize_active
-                        && now.duration_since(*last).as_millis() as u64 >= st.tuning.tick_ms
+                    let resize_active = ps.resize.is_some();
+                    drop(ps);
+
+                    st.tick_animator_frame(now);
                     {
-                        st.tick_maintenance(now);
-                        *last = now;
+                        let mut ps = pointer_state_for_timer.borrow_mut();
+                        let _ = advance_node_move_anim(st, &mut ps, now);
+                    }
+                    {
+                        let mut last = last_maintenance_for_timer.borrow_mut();
+                        if !resize_active
+                            && now.duration_since(*last).as_millis() as u64 >= st.tuning.tick_ms
+                        {
+                            st.tick_maintenance(now);
+                            *last = now;
+                        }
                     }
                 }
 
@@ -447,6 +481,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     info!("reloaded config from {}", config_path_for_timer.as_str());
                     info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                 }
+
                 let ps = pointer_state_for_timer.borrow();
                 let resize_preview = ps.resize;
                 let cursor_screen = Some(ps.screen);
@@ -465,6 +500,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 } else {
                     st.send_frame_callbacks(now);
                 }
+
                 let secs = now.duration_since(input_started_at).as_secs();
                 if secs >= 5
                     && !*keyboard_seen_for_timer.borrow()
@@ -486,6 +522,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     );
                     *warned_pointer_missing_for_timer.borrow_mut() = true;
                 }
+
                 TimeoutAction::ToDuration(Duration::from_millis(16))
             })?;
 

--- a/crates/halley-wl/src/run/winit_backend.rs
+++ b/crates/halley-wl/src/run/winit_backend.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use halley_ipc::{LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus};
+
 fn apply_host_cursor(
     backend: &Rc<RefCell<smithay::backend::winit::WinitGraphicsBackend<GlesRenderer>>>,
     image: &smithay::input::pointer::CursorImageStatus,
@@ -21,6 +23,37 @@ fn apply_host_cursor(
     }
 }
 
+fn publish_winit_output_snapshot(width: i32, height: i32, focused: bool, offset_x: i32, offset_y: i32) {
+    let width = width.max(0) as u32;
+    let height = height.max(0) as u32;
+
+    publish_outputs(vec![OutputInfo {
+        name: "winit-0".to_string(),
+        status: OutputStatus::Connected,
+        enabled: true,
+        current_mode: Some(ModeInfo {
+            width,
+            height,
+            refresh_hz: None,
+            preferred: true,
+            current: true,
+        }),
+        modes: vec![ModeInfo {
+            width,
+            height,
+            refresh_hz: None,
+            preferred: true,
+            current: true,
+        }],
+        logical: Some(LogicalOutputInfo {
+            scale: 1.0,
+            focused,
+            offset_x,
+            offset_y,
+        }),
+    }]);
+}
+
 pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
     scope!(
         "halley-wl",
@@ -33,7 +66,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             init_logging()?;
             let _host_backend_guard = ensure_host_display()?;
 
-            // Wayland display (clients + globals live here)
             let mut display: Display<HalleyWlState> = Display::new()?;
             let dh = display.handle();
 
@@ -55,7 +87,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                 info!("dev actions enabled: ring tuning + node move (via configured keybinds)");
             }
 
-            // Global compositor state
             let mut state = HalleyWlState::new(&dh, tuning.clone());
             state.seat.add_pointer();
             if state
@@ -113,7 +144,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                 (Some(watch_rx), Some(watcher))
             };
 
-            // Wayland listening socket
             let listening = ListeningSocketSource::new_auto().map_err(|err| {
                 let xdg_runtime_dir =
                     env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "<unset>".to_string());
@@ -125,7 +155,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let sock_name = listening.socket_name().to_string_lossy().to_string();
             info!("WAYLAND_DISPLAY={}", sock_name);
 
-            // Winit backend (compositor runs in a window)
             let (backend, winit_source) = winit::init::<GlesRenderer>().map_err(|err| {
                 let wayland_display =
                     env::var("WAYLAND_DISPLAY").unwrap_or_else(|_| "<unset>".to_string());
@@ -144,8 +173,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let xwayland_for_timer = xwayland.clone();
             let xwayland_request_for_timer = xwayland_request_rx.clone();
             {
-                // Apply runtime config exactly the same way as manual reload keybind.
-                // This keeps startup baseline consistent with reload behavior.
                 let fresh = RuntimeTuning::load_from_path(config_path.as_str());
                 state.apply_tuning(fresh);
                 let ws = backend.borrow().window_size();
@@ -157,6 +184,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             apply_host_cursor(&backend, &state.cursor_image_status);
             let backend_for_winit = backend.clone();
             let backend_for_cursor_timer = backend.clone();
+            let backend_for_output_timer = backend.clone();
             let backend_handle_for_winit = backend_handle.clone();
             let backend_handle_for_timer = backend_handle.clone();
             let config_path_for_winit = config_path.clone();
@@ -178,14 +206,17 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let last_maintenance_at = Rc::new(RefCell::new(Instant::now()));
             let last_maintenance_for_timer = last_maintenance_at.clone();
 
-            // calloop loop
+            {
+                let ws = backend.borrow().window_size();
+                publish_winit_output_snapshot(ws.w as i32, ws.h as i32, true, 0, 0);
+            }
+
             let mut ev: EventLoop<HalleyWlState> = EventLoop::try_new()?;
             let _signal = ev.get_signal();
 
             let mut dh_for_clients = dh.clone();
             ev.handle()
                 .insert_source(listening, move |client_stream, _, _st| {
-                    // attach per-client data (needed by CompositorHandler::client_compositor_state)
                     let _ =
                         dh_for_clients.insert_client(client_stream, Arc::new(ClientState::new()));
                 })?;
@@ -205,8 +236,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                                     now.duration_since(at).as_millis() as u64
                                         >= HOVER_PREVIEW_DWELL_MS
                                 });
-                            // Staged hover UX:
-                            // 1) label-only hold, 2) preview appears while label relaxes.
                             let hover_node = if preview_ready { None } else { hovered };
                             let preview_hover_node = if preview_ready { hovered } else { None };
                             if let Err(err) = backend_handle_for_winit.draw_frame(
@@ -240,8 +269,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                                 }
                                 ps.workspace_size = (new_w, new_h);
                             }
-                            // Keep world camera size stable from config/runtime state.
-                            // Window pixel resize should not mutate world units.
                             let ps = pointer_state_for_winit.borrow();
                             let now = Instant::now();
                             const HOVER_PREVIEW_DWELL_MS: u64 = 1_500;
@@ -270,9 +297,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                             debug!("winit event: {:?}", event);
                             *mod_state_for_winit.borrow_mut() = ModState::default();
                             let mut ps = pointer_state_for_winit.borrow_mut();
-                            // In nested development, transient focus flicker can happen while
-                            // right-drag resizing. Do not forcibly cancel in-flight interactions
-                            // here; let pointer release/motion handlers finalize cleanly.
                             if ps.resize.is_none() {
                                 ps.drag = None;
                                 ps.move_anim.clear();
@@ -382,12 +406,28 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     }
                 })?;
 
-            // Removed optional extra direct-libinput hookup in winit backend.
-
-            // Periodic tick: evaluate commit activity state transitions (no spam)
             let timer = Timer::from_duration(Duration::from_millis(16));
             ev.handle().insert_source(timer, move |_tick, _, st| {
                 let now = Instant::now();
+
+                drain_ipc_commands(|cmd| match cmd {
+                    RuntimeIpcCommand::Quit => {
+                        info!("ipc: quit requested");
+                        st.request_exit();
+                    }
+                    RuntimeIpcCommand::Reload => {
+                        let next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        st.apply_tuning(next);
+                        info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
+                        info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
+                    }
+                });
+
+                {
+                    let ws = backend_for_output_timer.borrow().window_size();
+                    publish_winit_output_snapshot(ws.w as i32, ws.h as i32, true, 0, 0);
+                }
+
                 {
                     let rx = xwayland_request_for_timer.borrow_mut();
                     while rx.try_recv().is_ok() {
@@ -484,7 +524,6 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             info!("entering main loop");
 
             loop {
-                // 1) run calloop sources (socket, winit, timer, etc.)
                 ev.dispatch(None, &mut state)?;
 
                 if state.exit_requested() {
@@ -492,10 +531,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     break Ok(());
                 }
 
-                // 2) dispatch wayland clients
                 display.dispatch_clients(&mut state)?;
-
-                // 3) flush outgoing events
                 display.flush_clients()?;
             }
         }

--- a/crates/halley-wl/src/state/carry.rs
+++ b/crates/halley-wl/src/state/carry.rs
@@ -197,21 +197,13 @@ impl HalleyWlState {
         zone
     }
 
-    pub fn finalize_mouse_drag_state(&mut self, id: NodeId, pointer_world: Vec2, _now: Instant) {
+    pub fn finalize_mouse_drag_state(&mut self, id: NodeId, _pointer_world: Vec2, _now: Instant) {
         let Some(n) = self.field.node(id) else {
             return;
         };
         if n.kind != halley_core::field::NodeKind::Surface || !self.field.is_visible(id) {
             return;
         }
-        let focus_ring = self.active_focus_ring();
-        let pointer_zone = focus_ring.zone(self.viewport.center, pointer_world);
-        let target = if pointer_zone != FocusZone::Inside {
-            DecayLevel::Cold
-        } else {
-            DecayLevel::Hot
-        };
-        let _ = self.field.set_decay_level(id, target);
     }
 
     pub fn begin_carry_state_tracking(&mut self, id: NodeId) {

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -47,7 +47,6 @@ keybinds:
   # Basic compositor controls
   "$var.mod+r" "reload_config"
   "$var.mod+n" "minimize_focused"
-  "$var.mod+o" "overview_toggle"
   
   # Quit Halley
   "$var.mod+shift+q" "quit_halley"


### PR DESCRIPTION
This PR introduces Halley’s initial IPC control path and fixes a drag-release
decay issue that caused a brief collapse/reopen flicker when dropping windows
outside the focus ring.

IPC / halleyctl
---------------
Halley now exposes a compositor-owned IPC socket and a thin CLI client
(`halleyctl`) for interacting with the running compositor.

Implemented commands:

  halleyctl quit
  halleyctl reload
  halleyctl outputs

Key changes:
- Add `halley-ipc` crate with protocol, codec, and error layers
- Implement Unix socket IPC server inside `halley-wl`
- Route `quit` and `reload` through runtime IPC commands
- Move `outputs` reporting to compositor-owned data instead of CLI DRM probing
- Collect real TTY DRM connector + mode information and publish it via IPC
- Winit backend publishes a virtual output snapshot for IPC clients
- Drain IPC commands in backend timer loops
- Ensure XWayland request channel is driven in the TTY backend

This establishes the foundation for future runtime controls such as:

  halleyctl node *
  halleyctl viewport *
  halleyctl cluster *

Drag-release decay fix
----------------------
Fix a flicker where windows briefly collapsed and reopened when a dragged
surface was released outside the focus ring.

Previously `finalize_mouse_drag_state()` immediately forced the window into
`Cold` state on release. This conflicted with the maintenance decay system,
which is designed to apply delayed collapse timers.

Now drag release leaves the decay state unchanged and allows the maintenance
system to handle the transition naturally.

Result:
- No immediate Hot/Cold toggle on drag release
- No collapse/reopen flicker
- Decay timing is controlled entirely by maintenance policies

Outcome
-------
Halley now has:

- Working compositor IPC
- Thin CLI client (`halleyctl`)
- Accurate output reporting
- Stable drag-release decay behavior
- Proper XWayland driving in the TTY backend

This is the first step toward full runtime control of Halley via IPC.