### PR TITLE
ipc: add halleyctl runtime control path and align keybind actions

### DIFF
--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -17,10 +17,10 @@ pub struct KeyModifiers {
 #[derive(Clone, Debug)]
 pub struct Keybinds {
     pub modifier: KeyModifiers,
-    pub reload_config: u32,
+    pub reload: u32,
     pub minimize_focused: u32,
     pub overview_toggle: u32,
-    pub quit_compositor: u32,
+    pub quit: u32,
     pub primary_left: u32,
     pub primary_right: u32,
     pub primary_up: u32,
@@ -49,10 +49,10 @@ impl Default for Keybinds {
                 left_alt: true,
                 ..KeyModifiers::default()
             },
-            reload_config: 19,    // r
+            reload: 19,           // r
             minimize_focused: 49, // n
             overview_toggle: 24,  // o
-            quit_compositor: 16,  // q
+            quit: 16,             // q
             primary_left: 105,    // left
             primary_right: 106,   // right
             primary_up: 103,      // up

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -222,10 +222,10 @@ impl RuntimeTuning {
         format!(
             "mod={} reload={} minimize={} overview={} quit={} (requires_shift={}) custom_launches={} primary=[{},{},{},{}] secondary=[{},{},{},{}] move=[{},{},{},{}]",
             kb.modifier_name(),
-            evdev_to_key_name(kb.reload_config),
+            evdev_to_key_name(kb.reload),
             evdev_to_key_name(kb.minimize_focused),
             evdev_to_key_name(kb.overview_toggle),
-            evdev_to_key_name(kb.quit_compositor),
+            evdev_to_key_name(kb.quit),
             self.quit_requires_shift,
             self.launch_bindings.len(),
             evdev_to_key_name(kb.primary_left),

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -73,11 +73,7 @@ fn load_dev_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.keybinds.modifier =
         pick_modifiers(cfg, &["dev.keybinds.modifier"], out.keybinds.modifier);
 
-    out.keybinds.reload_config = pick_keycode(
-        cfg,
-        &["dev.keybinds.reload_config", "dev.keybinds.reload-config"],
-        out.keybinds.reload_config,
-    );
+    out.keybinds.reload = pick_keycode(cfg, &["dev.keybinds.reload"], out.keybinds.reload);
     out.keybinds.minimize_focused = pick_keycode(
         cfg,
         &["dev.keybinds.minimize_focused", "dev.keybinds.minimize-focused"],
@@ -88,11 +84,7 @@ fn load_dev_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         &["dev.keybinds.overview_toggle", "dev.keybinds.overview-toggle"],
         out.keybinds.overview_toggle,
     );
-    out.keybinds.quit_compositor = pick_keycode(
-        cfg,
-        &["dev.keybinds.quit_compositor", "dev.keybinds.quit-compositor"],
-        out.keybinds.quit_compositor,
-    );
+    out.keybinds.quit = pick_keycode(cfg, &["dev.keybinds.quit"], out.keybinds.quit);
 
     out.keybind_launch_command = pick_string(
         cfg,
@@ -231,7 +223,6 @@ fn load_focus_ring_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         out.focus_ring_offset_y,
     );
 
-    // Transitional compatibility with the older config shape.
     out.focus_ring_rx = pick_f32(
         cfg,
         &["focus-ring.primary-rx", "focus-ring.primary_rx"],
@@ -256,7 +247,6 @@ fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         out.primary_to_node_ms,
     );
 
-    // Backward compatibility for old two-stage configs.
     let legacy_preview = pick_u64(
         cfg,
         &[
@@ -593,8 +583,8 @@ fn apply_explicit_binding(
     let action_key = action_trimmed.to_ascii_lowercase();
 
     match action_key.as_str() {
-        "reload_config" | "reload-config" => {
-            out.keybinds.reload_config = key;
+        "reload" => {
+            out.keybinds.reload = key;
         }
         "minimize_focused" | "minimize-focused" => {
             out.keybinds.minimize_focused = key;
@@ -602,8 +592,8 @@ fn apply_explicit_binding(
         "overview_toggle" | "overview-toggle" => {
             out.keybinds.overview_toggle = key;
         }
-        "quit_halley" | "quit-halley" | "quit_compositor" | "quit-compositor" => {
-            out.keybinds.quit_compositor = key;
+        "quit" => {
+            out.keybinds.quit = key;
             out.quit_requires_shift = effective_mods.shift;
         }
         _ => {

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -22,7 +22,7 @@ pub(crate) fn key_is_compositor_binding(
 ) -> bool {
     let kb = &st.tuning.keybinds;
 
-    if key_matches(key_code, kb.quit_compositor) {
+    if key_matches(key_code, kb.quit) {
         let need = if st.tuning.quit_requires_shift {
             with_extra_shift(kb.modifier)
         } else {
@@ -39,7 +39,7 @@ pub(crate) fn key_is_compositor_binding(
         }
     }
 
-    if key_matches(key_code, kb.reload_config) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.modifier) {
         return true;
     }
 
@@ -82,7 +82,7 @@ pub(crate) fn apply_bound_key(
 
     let kb = st.tuning.keybinds.clone();
 
-    if key_matches(key_code, kb.quit_compositor) {
+    if key_matches(key_code, kb.quit) {
         let need = if st.tuning.quit_requires_shift {
             with_extra_shift(kb.modifier)
         } else {
@@ -102,7 +102,7 @@ pub(crate) fn apply_bound_key(
         }
     }
 
-    if key_matches(key_code, kb.reload_config) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.modifier) {
         let next = RuntimeTuning::load_from_path(config_path);
         st.apply_tuning(next);
         info!("manual config reload from {}", config_path);

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -45,12 +45,12 @@ keybinds:
   mod "lsuper"
 
   # Basic compositor controls
-  "$var.mod+r" "reload_config"
+  "$var.mod+r" "reload"
   "$var.mod+n" "minimize_focused"
-  
+
   # Quit Halley
-  "$var.mod+shift+q" "quit_halley"
-  
+  "$var.mod+shift+q" "quit"
+
   # Applications
   "$var.mod+return" "kitty"
   "$var.mod+p" "pavucontrol"

--- a/todo
+++ b/todo
@@ -1,9 +1,0 @@
-[x] land this config/parser cleanup
-
-[ ] do a small config audit and delete knobs you know you no longer want
-
-[ ] then build basic halley-ipc
-
-[ ] then move core user actions onto IPC
-
-[ ] then return to focus-ring/interactions with cleaner control surfaces


### PR DESCRIPTION
- add halley-ipc crate with protocol, codec, and error types
- add Unix socket IPC between halleyctl and halley-wl
- implement halleyctl commands for quit, reload, and outputs
- route quit/reload through compositor IPC handling
- expose compositor-owned output info over IPC
- collect real TTY DRM connector/mode data for halleyctl outputs
- publish virtual output info for winit backend
- wire IPC startup into runtime and drain commands in backend loops
- ensure tty backend drives xwayland request/tick handling
- rename legacy keybind actions to native runtime actions:
  - reload_config -> reload
  - quit_halley -> quit
- rename keybind fields from reload_config/quit_compositor to reload/quit
- keep minimize_focused as a native compositor action
- preserve arbitrary command bindings for app launch and shell execution
- update config parsing and runtime key handling to use the new action names