### PR TITLE
fix(drm): correct enabled status reporting; add refresh rate and offset config

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -67,6 +67,7 @@ pub struct ViewportOutputConfig {
     pub offset_y: i32,
     pub width: u32,
     pub height: u32,
+    pub refresh_rate: Option<f64>,
 }
 
 impl Default for RuntimeTuning {

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -197,6 +197,9 @@ fn load_viewport_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     if let Some(primary) = out.tty_viewports.first() {
         out.viewport_size.x = primary.width as f32;
         out.viewport_size.y = primary.height as f32;
+
+        out.viewport_center.x = primary.offset_x as f32 + primary.width as f32 / 2.0;
+        out.viewport_center.y = primary.offset_y as f32 + primary.height as f32 / 2.0;
     }
 }
 
@@ -430,12 +433,26 @@ fn parse_viewport_outputs(cfg: &RuneConfig, root: &str) -> Vec<ViewportOutputCon
             0,
         );
 
+        let refresh_hz = {
+            let v = pick_f32(
+                cfg,
+                &[
+                    format!("{root}.{key}.refresh-hz").as_str(),
+                    format!("{root}.{key}.refresh_hz").as_str(),
+                    format!("{root}.{key}.rate").as_str(),
+                ],
+                0.0,
+            );
+            if v > 0.0 { Some(v as f64) } else { None }
+        };
+
         out.push(ViewportOutputConfig {
             connector: key,
             offset_x,
             offset_y,
             width,
             height,
+            refresh_rate,
         });
     }
 

--- a/crates/halley-wl/src/run/drm.rs
+++ b/crates/halley-wl/src/run/drm.rs
@@ -356,7 +356,12 @@ pub(super) fn select_tty_scanout(
                     .modes()
                     .iter()
                     .copied()
-                    .find(|m| m.size() == (wanted.width as u16, wanted.height as u16))
+                    .find(|m| {
+                        m.size() == (wanted.width as u16, wanted.height as u16)
+                            && wanted.refresh_hz.map_or(true, |hz| {
+                                (m.vrefresh() as f64 - hz).abs() < 1.0
+                            })
+                    })
                 else {
                     return Err(io::Error::other(format!(
                         "configured viewport {} requests {}x{}, but no such mode is available",
@@ -435,7 +440,7 @@ pub(super) fn select_tty_scanout(
     ))
 }
 
-pub(super) fn collect_outputs_for_ipc(dev: &DrmDevice) -> Vec<OutputInfo> {
+pub(super) fn collect_outputs_for_ipc(dev: &DrmDevice, active_crtc: drm_control::crtc::Handle) -> Vec<OutputInfo> {
     let mut outputs = Vec::new();
 
     let Ok(resources) = dev.resource_handles() else {
@@ -453,7 +458,7 @@ pub(super) fn collect_outputs_for_ipc(dev: &DrmDevice) -> Vec<OutputInfo> {
             drm_control::connector::State::Unknown => OutputStatus::Unknown,
         };
 
-        let current = current_mode_from_connector(dev, &info);
+        let current = current_mode_from_connector(dev, &info, active_crtc);
         let mut current_mode = None;
         let mut modes = Vec::new();
 
@@ -496,15 +501,21 @@ pub(super) fn collect_outputs_for_ipc(dev: &DrmDevice) -> Vec<OutputInfo> {
 fn current_mode_from_connector(
     dev: &DrmDevice,
     info: &drm_control::connector::Info,
+    active_crtc: drm_control::crtc::Handle,  // add this param
 ) -> Option<String> {
     let encoder = info
         .current_encoder()
         .or_else(|| info.encoders().first().copied())?;
 
     let encoder_info = dev.get_encoder(encoder).ok()?;
-    let crtc = encoder_info.crtc()?;
-    let crtc_info = dev.get_crtc(crtc).ok()?;
+    
+    // Replace: let crtc = encoder_info.crtc()?;
+    // With: only trust the crtc if it matches the known-active one
+    let crtc = encoder_info.crtc()
+        .filter(|c| *c == active_crtc)
+        .unwrap_or(active_crtc);  // fall back to the ground truth
 
+    let crtc_info = dev.get_crtc(crtc).ok()?;
     crtc_info.mode().map(|m| {
         let (w, h) = m.size();
         let hz = m.vrefresh() as f64;

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -240,7 +240,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 ps.workspace_size = (backend_handle.width, backend_handle.height);
             }
 
-            let initial_outputs = collect_outputs_for_ipc(&drm_probe.dev);
+            let initial_outputs = collect_outputs_for_ipc(&drm_probe.dev, drm_probe.crtc);
             publish_outputs(initial_outputs);
 
             let drm_crtc = drm_probe.crtc;


### PR DESCRIPTION
- Fix collect_outputs_for_ipc always reporting enabled=false by passing active_crtc through to current_mode_from_connector instead of relying on the encoder->crtc chain which is unreliable under atomic modesetting

- Add refresh_hz (rate) field to ViewportOutputConfig; select_tty_scanout now matches modes by refresh rate when specified, falling back to first matching resolution when omitted

- Parse offset-x/offset-y from viewport config and apply to viewport_center in load_viewport_section; stored for future multi-monitor use