### PR TITLE
fix(resize): stabilize interactive resize geometry and refine surface collision bounds

### DIFF
--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -288,10 +288,16 @@ pub(crate) fn handle_pointer_button_input(
                                     x: start_w as f32,
                                     y: start_h as f32,
                                 });
+                            let start_bbox = halley_core::field::Vec2 {
+                                x: fallback_size.x.max(1.0),
+                                y: fallback_size.y.max(1.0),
+                            };
                             ps.resize = Some(ResizeCtx {
                                 node_id: h.node_id,
                                 start_surface_w: start_surface.x.max(96.0).round() as i32,
                                 start_surface_h: start_surface.y.max(72.0).round() as i32,
+                                start_bbox_w: start_bbox.x.round() as i32,
+                                start_bbox_h: start_bbox.y.round() as i32,
                                 start_left_px: start_left,
                                 start_right_px: start_right,
                                 start_top_px: start_top,
@@ -378,17 +384,23 @@ pub(crate) fn handle_pointer_button_input(
                     }
                     let final_w = resize.last_sent_w.max(96);
                     let final_h = resize.last_sent_h.max(72);
+                    let final_bbox_w = ((resize.start_bbox_w as f32)
+                        + ((final_w - resize.start_surface_w) as f32))
+                        .max(1.0);
+                    let final_bbox_h = ((resize.start_bbox_h as f32)
+                        + ((final_h - resize.start_surface_h) as f32))
+                        .max(1.0);
                     request_toplevel_resize_mode(st, resize.node_id, final_w, final_h, true);
                     request_toplevel_resize_mode(st, resize.node_id, final_w, final_h, false);
                     if let Some(n) = st.field.node_mut(resize.node_id) {
-                        n.intrinsic_size.x = final_w as f32;
-                        n.intrinsic_size.y = final_h as f32;
+                        n.intrinsic_size.x = final_bbox_w;
+                        n.intrinsic_size.y = final_bbox_h;
                     }
                     st.set_last_active_size_now(
                         resize.node_id,
                         halley_core::field::Vec2 {
-                            x: final_w as f32,
-                            y: final_h as f32,
+                            x: final_bbox_w,
+                            y: final_bbox_h,
                         },
                     );
                     st.set_recent_top_node(resize.node_id, now + Duration::from_millis(600));

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -180,15 +180,17 @@ pub(crate) fn handle_pointer_motion_absolute(
         let target_h = ((resize.start_surface_h as f32) + delta_h)
             .max(min_h)
             .round() as i32;
+        let target_bbox_w = ((resize.start_bbox_w as f32) + delta_w).max(1.0).round() as i32;
+        let target_bbox_h = ((resize.start_bbox_h as f32) + delta_h).max(1.0).round() as i32;
 
         let (left, right) = match resize.handle {
             ResizeHandle::Left | ResizeHandle::TopLeft | ResizeHandle::BottomLeft => {
                 let r = resize.start_right_px;
-                (r - target_w as f32, r)
+                (r - target_bbox_w as f32, r)
             }
             ResizeHandle::Right | ResizeHandle::TopRight | ResizeHandle::BottomRight => {
                 let l = resize.start_left_px;
-                (l, l + target_w as f32)
+                (l, l + target_bbox_w as f32)
             }
             ResizeHandle::Top | ResizeHandle::Bottom => {
                 (resize.start_left_px, resize.start_right_px)
@@ -197,11 +199,11 @@ pub(crate) fn handle_pointer_motion_absolute(
         let (top, bottom) = match resize.handle {
             ResizeHandle::Top | ResizeHandle::TopLeft | ResizeHandle::TopRight => {
                 let b = resize.start_bottom_px;
-                (b - target_h as f32, b)
+                (b - target_bbox_h as f32, b)
             }
             ResizeHandle::Bottom | ResizeHandle::BottomLeft | ResizeHandle::BottomRight => {
                 let t = resize.start_top_px;
-                (t, t + target_h as f32)
+                (t, t + target_bbox_h as f32)
             }
             ResizeHandle::Left | ResizeHandle::Right => {
                 (resize.start_top_px, resize.start_bottom_px)
@@ -226,15 +228,15 @@ pub(crate) fn handle_pointer_motion_absolute(
             center_sy,
         );
         if let Some(n) = st.field.node_mut(resize.node_id) {
-            n.intrinsic_size.x = target_w as f32;
-            n.intrinsic_size.y = target_h as f32;
+            n.intrinsic_size.x = target_bbox_w as f32;
+            n.intrinsic_size.y = target_bbox_h as f32;
             n.pos = center_world;
         }
         st.set_last_active_size_now(
             resize.node_id,
             halley_core::field::Vec2 {
-                x: target_w as f32,
-                y: target_h as f32,
+                x: target_bbox_w as f32,
+                y: target_bbox_h as f32,
             },
         );
         next.preview_left_px = left;

--- a/crates/halley-wl/src/interaction/types.rs
+++ b/crates/halley-wl/src/interaction/types.rs
@@ -46,6 +46,8 @@ pub(crate) struct ResizeCtx {
     pub(crate) node_id: halley_core::field::NodeId,
     pub(crate) start_surface_w: i32,
     pub(crate) start_surface_h: i32,
+    pub(crate) start_bbox_w: i32,
+    pub(crate) start_bbox_h: i32,
     pub(crate) start_left_px: f32,
     pub(crate) start_right_px: f32,
     pub(crate) start_top_px: f32,

--- a/crates/halley-wl/src/runtime_render/render_utils.rs
+++ b/crates/halley-wl/src/runtime_render/render_utils.rs
@@ -1,6 +1,8 @@
 use std::f32::consts::TAU;
 use std::time::Instant;
 
+use smithay::wayland::compositor::with_states;
+use smithay::wayland::shell::xdg::SurfaceCachedState;
 use smithay::{
     backend::renderer::{Color32F, Frame},
     desktop::utils::bbox_from_surface_tree,
@@ -91,6 +93,34 @@ pub(crate) fn sync_node_size_from_surface(
 
     st.bbox_loc
         .insert(node_id, (bbox.loc.x as f32, bbox.loc.y as f32));
+    let geometry = with_states(wl, |states| {
+        states
+            .cached_state
+            .get::<SurfaceCachedState>()
+            .current()
+            .geometry
+    });
+    if let Some(g) = geometry {
+        st.window_geometry.insert(
+            node_id,
+            (
+                g.loc.x as f32,
+                g.loc.y as f32,
+                g.size.w as f32,
+                g.size.h as f32,
+            ),
+        );
+    } else {
+        st.window_geometry.insert(
+            node_id,
+            (
+                bbox.loc.x as f32,
+                bbox.loc.y as f32,
+                bbox.size.w.max(1) as f32,
+                bbox.size.h.max(1) as f32,
+            ),
+        );
+    }
 
     let bw = bbox.size.w.max(1) as f32;
     let bh = bbox.size.h.max(1) as f32;

--- a/crates/halley-wl/src/state/carry.rs
+++ b/crates/halley-wl/src/state/carry.rs
@@ -3,17 +3,6 @@ use halley_core::docking::DockSide;
 use halley_core::viewport::{FocusRing, FocusZone};
 
 impl HalleyWlState {
-    #[inline]
-    fn dock_state_eval_footprint(&self, id: NodeId, live: Vec2) -> Vec2 {
-        match self.last_active_size.get(&id).copied() {
-            Some(last) => Vec2 {
-                x: live.x.max(last.x),
-                y: live.y.max(last.y),
-            },
-            None => live,
-        }
-    }
-
     pub fn enforce_docked_pairs(&mut self) {
         let pairs = self.field.docked_pairs();
         if pairs.is_empty() {
@@ -44,13 +33,10 @@ impl HalleyWlState {
                         x: (na.pos.x + nb.pos.x) * 0.5,
                         y: (na.pos.y + nb.pos.y) * 0.5,
                     },
-                    self.collision_size_for_node(na),
-                    self.collision_size_for_node(nb),
+                    self.collision_extents_for_node(na),
+                    self.collision_extents_for_node(nb),
                 )
             };
-
-            let a_edge_fp = self.dock_state_eval_footprint(a, sa);
-            let b_edge_fp = self.dock_state_eval_footprint(b, sb);
 
             // Docked-pair geometry should not auto-resurrect nodes explicitly
             // collapsed by the user. Keep the pair geometry enforced, but only
@@ -79,7 +65,11 @@ impl HalleyWlState {
             let gap = self.non_overlap_gap_world();
             match link_b_side {
                 DockSide::Left | DockSide::Right => {
-                    let sep = (a_edge_fp.x * 0.5 + b_edge_fp.x * 0.5 + gap).max(0.0);
+                    let sep = if link_b_side == DockSide::Right {
+                        (sa.right + sb.left + gap).max(0.0)
+                    } else {
+                        (sa.left + sb.right + gap).max(0.0)
+                    };
                     let half_sep = sep * 0.5;
                     let (ax, bx) = if link_b_side == DockSide::Right {
                         (mid.x - half_sep, mid.x + half_sep)
@@ -90,7 +80,11 @@ impl HalleyWlState {
                     let _ = self.field.carry(b, Vec2 { x: bx, y: mid.y });
                 }
                 DockSide::Top | DockSide::Bottom => {
-                    let sep = (a_edge_fp.y * 0.5 + b_edge_fp.y * 0.5 + gap).max(0.0);
+                    let sep = if link_b_side == DockSide::Top {
+                        (sa.top + sb.bottom + gap).max(0.0)
+                    } else {
+                        (sa.bottom + sb.top + gap).max(0.0)
+                    };
                     let half_sep = sep * 0.5;
                     let (ay, by) = if link_b_side == DockSide::Top {
                         (mid.y - half_sep, mid.y + half_sep)

--- a/crates/halley-wl/src/state/maintenance.rs
+++ b/crates/halley-wl/src/state/maintenance.rs
@@ -399,7 +399,7 @@ impl HalleyWlState {
             return false;
         }
 
-        let size = self.collision_size_for_node(n);
+        let ext = self.collision_extents_for_node(n);
         let half_vw = self.viewport.size.x * 0.5;
         let half_vh = self.viewport.size.y * 0.5;
 
@@ -408,10 +408,10 @@ impl HalleyWlState {
         let view_top = self.viewport.center.y - half_vh;
         let view_bottom = self.viewport.center.y + half_vh;
 
-        let node_left = n.pos.x - size.x * 0.5;
-        let node_right = n.pos.x + size.x * 0.5;
-        let node_top = n.pos.y - size.y * 0.5;
-        let node_bottom = n.pos.y + size.y * 0.5;
+        let node_left = n.pos.x - ext.left;
+        let node_right = n.pos.x + ext.right;
+        let node_top = n.pos.y - ext.top;
+        let node_bottom = n.pos.y + ext.bottom;
 
         node_right > view_left
             && node_left < view_right
@@ -431,10 +431,10 @@ impl HalleyWlState {
             return;
         }
         let apos = a.pos;
-        let asize = self.collision_size_for_node(a);
+        let aext = self.collision_extents_for_node(a);
         let pair_gap = self.non_overlap_gap_world();
 
-        let mut others: Vec<(NodeId, Vec2, Vec2, f32)> = self
+        let mut others: Vec<(NodeId, Vec2, super::overlap::CollisionExtents, f32)> = self
             .field
             .nodes()
             .iter()
@@ -447,23 +447,23 @@ impl HalleyWlState {
                 {
                     return None;
                 }
-                let osize = self.collision_size_for_node(n);
+                let oext = self.collision_extents_for_node(n);
                 let d2 = (n.pos.x - apos.x).powi(2) + (n.pos.y - apos.y).powi(2);
-                Some((id, n.pos, osize, d2))
+                Some((id, n.pos, oext, d2))
             })
             .collect();
 
         others.sort_by(|a, b| a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal));
 
         let mut moved = 0usize;
-        for (id, opos, osize, _) in others {
+        for (id, opos, oext, _) in others {
             if moved >= 3 {
                 break;
             }
             let dx = opos.x - apos.x;
             let dy = opos.y - apos.y;
-            let req_x = asize.x * 0.5 + osize.x * 0.5 + pair_gap;
-            let req_y = asize.y * 0.5 + osize.y * 0.5 + pair_gap;
+            let req_x = self.required_sep_x(apos.x, aext, opos.x, oext, pair_gap);
+            let req_y = self.required_sep_y(apos.y, aext, opos.y, oext, pair_gap);
             let ox = req_x - dx.abs();
             let oy = req_y - dy.abs();
             if ox <= 0.0 || oy <= 0.0 {
@@ -528,6 +528,8 @@ impl HalleyWlState {
                 self.zoom_last_observed_size.remove(&id);
                 self.zoom_resize_static_streak.remove(&id);
                 self.last_active_size.remove(&id);
+                self.bbox_loc.remove(&id);
+                self.window_geometry.remove(&id);
                 self.pending_spawn_activate_at_ms.remove(&id);
                 self.active_transition_until_ms.remove(&id);
                 self.primary_promote_cooldown_until_ms.remove(&id);

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -123,6 +123,7 @@ pub struct HalleyWlState {
     exit_requested: bool,
 
     pub(crate) bbox_loc: HashMap<NodeId, (f32, f32)>,
+    pub(crate) window_geometry: HashMap<NodeId, (f32, f32, f32, f32)>,
     pub(crate) recent_top_node: Option<NodeId>,
     pub(crate) recent_top_until: Option<Instant>,
 
@@ -207,6 +208,7 @@ impl HalleyWlState {
             exit_requested: false,
 
             bbox_loc: HashMap::new(),
+            window_geometry: HashMap::new(),
             recent_top_node: None,
             recent_top_until: None,
 

--- a/crates/halley-wl/src/state/overlap.rs
+++ b/crates/halley-wl/src/state/overlap.rs
@@ -2,6 +2,34 @@ use super::*;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::Resource;
 
+#[derive(Clone, Copy, Debug)]
+pub(super) struct CollisionExtents {
+    pub left: f32,
+    pub right: f32,
+    pub top: f32,
+    pub bottom: f32,
+}
+
+impl CollisionExtents {
+    #[inline]
+    pub(super) fn symmetric(size: Vec2) -> Self {
+        Self {
+            left: size.x * 0.5,
+            right: size.x * 0.5,
+            top: size.y * 0.5,
+            bottom: size.y * 0.5,
+        }
+    }
+
+    #[inline]
+    fn size(self) -> Vec2 {
+        Vec2 {
+            x: (self.left + self.right).max(0.0),
+            y: (self.top + self.bottom).max(0.0),
+        }
+    }
+}
+
 impl HalleyWlState {
     #[inline]
     fn world_units_per_px_xy(&self) -> (f32, f32) {
@@ -13,6 +41,38 @@ impl HalleyWlState {
     pub(super) fn non_overlap_gap_world(&self) -> f32 {
         let (wx, wy) = self.world_units_per_px_xy();
         self.tuning.non_overlap_gap_px.max(0.0) * ((wx + wy) * 0.5)
+    }
+
+    #[inline]
+    pub(super) fn required_sep_x(
+        &self,
+        a_pos_x: f32,
+        a_ext: CollisionExtents,
+        b_pos_x: f32,
+        b_ext: CollisionExtents,
+        gap: f32,
+    ) -> f32 {
+        if b_pos_x >= a_pos_x {
+            a_ext.right + b_ext.left + gap
+        } else {
+            a_ext.left + b_ext.right + gap
+        }
+    }
+
+    #[inline]
+    pub(super) fn required_sep_y(
+        &self,
+        a_pos_y: f32,
+        a_ext: CollisionExtents,
+        b_pos_y: f32,
+        b_ext: CollisionExtents,
+        gap: f32,
+    ) -> f32 {
+        if b_pos_y >= a_pos_y {
+            a_ext.bottom + b_ext.top + gap
+        } else {
+            a_ext.top + b_ext.bottom + gap
+        }
     }
 
     pub(crate) fn carry_surface_non_overlap(&mut self, id: NodeId, to: Vec2) -> bool {
@@ -30,7 +90,7 @@ impl HalleyWlState {
             return self.field.carry(id, to);
         }
 
-        let mover_size = self.collision_size_for_node(n);
+        let mover_ext = self.collision_extents_for_node(n);
         let gap = self.non_overlap_gap_world();
         let damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0);
         let mut mover_pos = to;
@@ -39,7 +99,7 @@ impl HalleyWlState {
         const MAX_PUSHES_PER_PASS: usize = 2;
 
         for _ in 0..16 {
-            let others: Vec<(NodeId, Vec2, Vec2, bool)> = self
+            let others: Vec<(NodeId, Vec2, CollisionExtents, bool)> = self
                 .field
                 .nodes()
                 .iter()
@@ -53,7 +113,7 @@ impl HalleyWlState {
                     Some((
                         oid,
                         other.pos,
-                        self.collision_size_for_node(other),
+                        self.collision_extents_for_node(other),
                         other.pinned,
                     ))
                 })
@@ -62,15 +122,15 @@ impl HalleyWlState {
             let mut changed = false;
             let mut pushes_this_pass = 0usize;
 
-            for (oid, opos, osize, opinned) in others {
+            for (oid, opos, oext, opinned) in others {
                 if pushes_this_pass >= MAX_PUSHES_PER_PASS {
                     break;
                 }
 
                 let dx = opos.x - mover_pos.x;
                 let dy = opos.y - mover_pos.y;
-                let req_x = mover_size.x * 0.5 + osize.x * 0.5 + gap;
-                let req_y = mover_size.y * 0.5 + osize.y * 0.5 + gap;
+                let req_x = self.required_sep_x(mover_pos.x, mover_ext, opos.x, oext, gap);
+                let req_y = self.required_sep_y(mover_pos.y, mover_ext, opos.y, oext, gap);
 
                 let ox = req_x - dx.abs();
                 let oy = req_y - dy.abs();
@@ -182,12 +242,12 @@ impl HalleyWlState {
             return self.field.carry(id, to);
         }
 
-        let mover_size = self.collision_size_for_node(n);
+        let mover_ext = self.collision_extents_for_node(n);
         let gap = self.non_overlap_gap_world();
         let mut mover_pos = to;
 
         for _ in 0..24 {
-            let others: Vec<(NodeId, Vec2, Vec2)> = self
+            let others: Vec<(NodeId, Vec2, CollisionExtents)> = self
                 .field
                 .nodes()
                 .iter()
@@ -198,17 +258,17 @@ impl HalleyWlState {
                     if other.kind != halley_core::field::NodeKind::Surface {
                         return None;
                     }
-                    Some((oid, other.pos, self.collision_size_for_node(other)))
+                    Some((oid, other.pos, self.collision_extents_for_node(other)))
                 })
                 .collect();
 
             let mut changed = false;
 
-            for (oid, opos, osize) in others {
+            for (oid, opos, oext) in others {
                 let dx = mover_pos.x - opos.x;
                 let dy = mover_pos.y - opos.y;
-                let req_x = mover_size.x * 0.5 + osize.x * 0.5 + gap;
-                let req_y = mover_size.y * 0.5 + osize.y * 0.5 + gap;
+                let req_x = self.required_sep_x(mover_pos.x, mover_ext, opos.x, oext, gap);
+                let req_y = self.required_sep_y(mover_pos.y, mover_ext, opos.y, oext, gap);
                 let ox = req_x - dx.abs();
                 let oy = req_y - dy.abs();
 
@@ -288,7 +348,7 @@ impl HalleyWlState {
         anim_scale.clamp(0.22, 1.4)
     }
 
-    fn node_collision_size(&self, label: &str, anim_scale: f32) -> Vec2 {
+    fn node_collision_extents(&self, label: &str, anim_scale: f32) -> CollisionExtents {
         let zx = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let zy = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
         let z = ((zx + zy) * 0.5).clamp(1.0, 8.0);
@@ -302,23 +362,24 @@ impl HalleyWlState {
             .clamp(24.0, 320.0);
         let pad_px = 6.0;
 
-        let left_half_px = dot_half_px + pad_px;
-        let right_half_px = label_gap_px + label_w_px + pad_px;
-        let half_w_px = left_half_px.max(right_half_px).max(4.0);
-        let half_h_px = (dot_half_px.max(label_h_px * 0.5) + pad_px).max(4.0);
-        let bounds_w_px = (half_w_px * 2.0).max(8.0);
-        let bounds_h_px = (half_h_px * 2.0).max(8.0);
+        let dot_d_px = (dot_half_px * 2.0).max(1.0);
+        let marker_w_px = (dot_d_px + label_gap_px + label_w_px + pad_px * 2.0).max(8.0);
+        let marker_h_px = (dot_d_px.max(label_h_px) + pad_px * 2.0).max(8.0);
 
         let world_per_px_x = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let world_per_px_y = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
-
-        Vec2 {
-            x: bounds_w_px * world_per_px_x.max(0.01),
-            y: bounds_h_px * world_per_px_y.max(0.01),
-        }
+        CollisionExtents::symmetric(Vec2 {
+            // Keep collision bounds aligned with the rendered pill instead of the
+            // larger hover proxy so node-to-window spacing matches window spacing.
+            x: marker_w_px * world_per_px_x.max(0.01),
+            y: marker_h_px * world_per_px_y.max(0.01),
+        })
     }
 
-    pub(super) fn collision_size_for_node(&self, n: &halley_core::field::Node) -> Vec2 {
+    pub(super) fn collision_extents_for_node(
+        &self,
+        n: &halley_core::field::Node,
+    ) -> CollisionExtents {
         let now = Instant::now();
         let anim = self.anim_style_for(n.id, n.state.clone(), now);
 
@@ -331,19 +392,36 @@ impl HalleyWlState {
                     .unwrap_or(n.intrinsic_size);
                 let s = Self::active_collision_scale(anim.scale, basis.x, basis.y);
                 let (world_per_px_x, world_per_px_y) = self.world_units_per_px_xy();
-                let base_w = (basis.x - 4.0).max(32.0);
-                let base_h = (basis.y - 14.0).max(32.0);
+                let bbox_w = n.intrinsic_size.x.max(1.0);
+                let bbox_h = n.intrinsic_size.y.max(1.0);
+                let (bbox_lx, bbox_ly) = self.bbox_loc.get(&n.id).copied().unwrap_or((0.0, 0.0));
+                let (geo_lx, geo_ly, geo_w, geo_h) = self
+                    .window_geometry
+                    .get(&n.id)
+                    .copied()
+                    .unwrap_or((bbox_lx, bbox_ly, bbox_w, bbox_h));
 
-                Vec2 {
-                    x: base_w * s * world_per_px_x,
-                    y: base_h * s * world_per_px_y,
+                let left = (bbox_w * 0.5 + bbox_lx - geo_lx).max(16.0);
+                let right = (geo_lx + geo_w - bbox_lx - bbox_w * 0.5).max(16.0);
+                let top = (bbox_h * 0.5 + bbox_ly - geo_ly).max(16.0);
+                let bottom = (geo_ly + geo_h - bbox_ly - bbox_h * 0.5).max(16.0);
+
+                CollisionExtents {
+                    left: left * s * world_per_px_x,
+                    right: right * s * world_per_px_x,
+                    top: top * s * world_per_px_y,
+                    bottom: bottom * s * world_per_px_y,
                 }
             }
             halley_core::field::NodeState::Node | halley_core::field::NodeState::Core => {
-                self.node_collision_size(&n.label, anim.scale)
+                self.node_collision_extents(&n.label, anim.scale)
             }
-            halley_core::field::NodeState::Drifting => n.footprint,
+            halley_core::field::NodeState::Drifting => CollisionExtents::symmetric(n.footprint),
         }
+    }
+
+    pub(super) fn collision_size_for_node(&self, n: &halley_core::field::Node) -> Vec2 {
+        self.collision_extents_for_node(n).size()
     }
 
     pub(super) fn resolve_surface_overlap(&mut self) {
@@ -409,14 +487,14 @@ impl HalleyWlState {
                         continue;
                     }
 
-                    let sa = self.collision_size_for_node(na);
-                    let sb = self.collision_size_for_node(nb);
+                    let ea = self.collision_extents_for_node(na);
+                    let eb = self.collision_extents_for_node(nb);
 
                     let dx = b_pos.x - a_pos.x;
                     let dy = b_pos.y - a_pos.y;
 
-                    let req_x = sa.x * 0.5 + sb.x * 0.5 + gap;
-                    let req_y = sa.y * 0.5 + sb.y * 0.5 + gap;
+                    let req_x = self.required_sep_x(a_pos.x, ea, b_pos.x, eb, gap);
+                    let req_y = self.required_sep_y(a_pos.y, ea, b_pos.y, eb, gap);
                     let ox = req_x - dx.abs();
                     let oy = req_y - dy.abs();
 

--- a/crates/halley-wl/src/state/surface_lifecycle.rs
+++ b/crates/halley-wl/src/state/surface_lifecycle.rs
@@ -43,6 +43,7 @@ impl HalleyWlState {
 
         let pair_gap = gap;
         let conflict_at = |p: Vec2, field: &Field, size: Vec2, pair_gap: f32| -> bool {
+            let candidate = super::overlap::CollisionExtents::symmetric(size);
             field.nodes().values().any(|other| {
                 if other.kind != halley_core::field::NodeKind::Surface {
                     return false;
@@ -50,9 +51,9 @@ impl HalleyWlState {
                 if !field.is_visible(other.id) {
                     return false;
                 }
-                let other_size = self.collision_size_for_node(other);
-                let req_x = size.x * 0.5 + other_size.x * 0.5 + pair_gap;
-                let req_y = size.y * 0.5 + other_size.y * 0.5 + pair_gap;
+                let other_ext = self.collision_extents_for_node(other);
+                let req_x = self.required_sep_x(p.x, candidate, other.pos.x, other_ext, pair_gap);
+                let req_y = self.required_sep_y(p.y, candidate, other.pos.y, other_ext, pair_gap);
                 (p.x - other.pos.x).abs() < req_x && (p.y - other.pos.y).abs() < req_y
             })
         };
@@ -85,34 +86,38 @@ impl HalleyWlState {
                 .filter(|n| self.field.is_visible(n.id))
                 .max_by_key(|n| n.id.as_u64());
             if let Some(a) = anchor {
-                let a_size = self.collision_size_for_node(a);
-                let dx = a_size.x * 0.5 + size.x * 0.5 + pair_gap;
-                let dy = a_size.y * 0.5 + size.y * 0.5 + pair_gap;
+                let a_ext = self.collision_extents_for_node(a);
+                let new_ext = super::overlap::CollisionExtents::symmetric(size);
+                let dx_right =
+                    self.required_sep_x(a.pos.x, a_ext, a.pos.x + 1.0, new_ext, pair_gap);
+                let dx_left = self.required_sep_x(a.pos.x, a_ext, a.pos.x - 1.0, new_ext, pair_gap);
+                let dy_down = self.required_sep_y(a.pos.y, a_ext, a.pos.y + 1.0, new_ext, pair_gap);
+                let dy_up = self.required_sep_y(a.pos.y, a_ext, a.pos.y - 1.0, new_ext, pair_gap);
                 let sign = if n.is_multiple_of(2) { 1.0 } else { -1.0 };
                 let candidates = [
                     Vec2 {
-                        x: a.pos.x + sign * dx,
+                        x: a.pos.x + if sign > 0.0 { dx_right } else { -dx_left },
                         y: a.pos.y,
                     },
                     Vec2 {
-                        x: a.pos.x - sign * dx,
+                        x: a.pos.x - if sign > 0.0 { dx_left } else { -dx_right },
                         y: a.pos.y,
                     },
                     Vec2 {
                         x: a.pos.x,
-                        y: a.pos.y + dy,
+                        y: a.pos.y + dy_down,
                     },
                     Vec2 {
                         x: a.pos.x,
-                        y: a.pos.y - dy,
+                        y: a.pos.y - dy_up,
                     },
                     Vec2 {
-                        x: a.pos.x + sign * dx,
-                        y: a.pos.y + dy * 0.5,
+                        x: a.pos.x + if sign > 0.0 { dx_right } else { -dx_left },
+                        y: a.pos.y + dy_down * 0.5,
                     },
                     Vec2 {
-                        x: a.pos.x - sign * dx,
-                        y: a.pos.y - dy * 0.5,
+                        x: a.pos.x - if sign > 0.0 { dx_left } else { -dx_right },
+                        y: a.pos.y - dy_up * 0.5,
                     },
                 ];
                 if let Some(p) = candidates
@@ -149,9 +154,10 @@ impl HalleyWlState {
                     continue;
                 };
                 let old_pos = old.pos;
-                let old_size = self.collision_size_for_node(old);
-                let req_x = old_size.x * 0.5 + size.x * 0.5 + pair_gap;
-                let req_y = old_size.y * 0.5 + size.y * 0.5 + pair_gap;
+                let old_ext = self.collision_extents_for_node(old);
+                let new_ext = super::overlap::CollisionExtents::symmetric(size);
+                let req_x = self.required_sep_x(pos.x, new_ext, old_pos.x, old_ext, pair_gap);
+                let req_y = self.required_sep_y(pos.y, new_ext, old_pos.y, old_ext, pair_gap);
                 let dx = old_pos.x - pos.x;
                 let dy = old_pos.y - pos.y;
                 if dx.abs() < req_x && dy.abs() < req_y {
@@ -201,6 +207,8 @@ impl HalleyWlState {
             self.zoom_last_observed_size.remove(&id);
             self.zoom_resize_static_streak.remove(&id);
             self.last_active_size.remove(&id);
+            self.bbox_loc.remove(&id);
+            self.window_geometry.remove(&id);
             self.pending_spawn_activate_at_ms.remove(&id);
             self.active_transition_until_ms.remove(&id);
             self.primary_promote_cooldown_until_ms.remove(&id);

--- a/crates/halley-wl/src/surface/surface_ops.rs
+++ b/crates/halley-wl/src/surface/surface_ops.rs
@@ -47,6 +47,19 @@ pub(crate) fn current_surface_size_for_node(
         if st.surface_to_node.get(&key).copied() != Some(node_id) {
             continue;
         }
+        let geo = with_states(&wl, |states| {
+            states
+                .cached_state
+                .get::<SurfaceCachedState>()
+                .current()
+                .geometry
+        });
+        if let Some(g) = geo {
+            return Some(halley_core::field::Vec2 {
+                x: g.size.w.max(1) as f32,
+                y: g.size.h.max(1) as f32,
+            });
+        }
         if let Some(sz) = top.current_state().size {
             return Some(halley_core::field::Vec2 {
                 x: sz.w.max(1) as f32,


### PR DESCRIPTION
This PR improves resize correctness and compositor spatial consistency by fixing
geometry mismatches during interactive resize and refining how surface collision
bounds are derived from window geometry.

## Summary

Two issues were addressed:

1. Windows could shift slightly after completing an interactive resize because
   resize logic mixed two different geometry sources: the client-configured
   surface size and the compositor-visible bounding box (bbox).

2. Surface collision and spatial logic previously relied on geometry that could
   diverge from the actual rendered window bounds.

Together these fixes make resize preview, final placement, and spatial collision
behavior consistent with the compositor-visible window geometry.

---

## Commit 1: Fix interactive resize geometry

Fixes a bug where windows could move slightly after completing an interactive
resize due to mixing configured surface size with rendered bbox size.

Key improvements:

• **Track configured size and bbox size separately**
  - Added `start_bbox_w` and `start_bbox_h` to `ResizeState`.
  - Preserves the delta between configured surface size and visible bounds,
    which is important for CSD or any surface where decorations affect geometry.

• **Seed resize from cached geometry**
  - `current_surface_size_for_node()` now prefers cached
    `SurfaceCachedState.geometry` before falling back to
    `current_state().size` or `bbox_from_surface_tree(...)`.
  - Prevents resizes starting from stale or incomplete geometry.

• **Correct interactive resize preview math**
  - Clients still receive configured `target_w` / `target_h`.
  - Resize preview and compositor placement now use
    `target_bbox_w` / `target_bbox_h`.

• **Fix final resize commit geometry**
  - On resize release, the configured size is sent to the client
    while the final bbox is reconstructed from the original bbox delta.
  - Node `intrinsic_size` and `last_active_size` are updated using
    bbox dimensions so compositor collision and docking logic remain stable.

Result: windows no longer shift position after interactive resize.

---

## Commit 2: Refine surface collision bounds

Improves spatial correctness by deriving surface collision bounds from
window geometry rather than inconsistent intermediate values.

This ensures compositor logic such as overlap detection, docking, and
placement operates on the same geometry that rendering and resize preview
use.

---

## Result

These changes align resize preview, client configure size, compositor spatial
footprint, and rendered window bounds. The compositor now uses a consistent
geometry model across resize interactions, spatial logic, and final window
placement.