### PR TITLE
feat(halley-wl): add linux-dmabuf import support and integrate X11 socket ownership for xwayland-satellite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,8 +564,6 @@ dependencies = [
 [[package]]
 name = "eventline"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7c4948448b7b133fe5f3b634289a6ae9abc8c6bd29694af9675922b376c18"
 dependencies = [
  "parking_lot",
  "serde",
@@ -850,6 +848,7 @@ dependencies = [
  "halley-config",
  "halley-core",
  "halley-ipc",
+ "libc",
  "notify",
  "once_cell",
  "pollster",

--- a/crates/halley-wl/Cargo.toml
+++ b/crates/halley-wl/Cargo.toml
@@ -29,9 +29,10 @@ xkbcommon = "0.9.0"
 smallvec = "1.15.1"
 
 rustix = "1.1.4"
+libc = "0.2"
 
 # Your logging
-eventline = "0.7.4"
+eventline = { version = "0.7.4", path = "../../../../libs/eventline" }
 
 # Useful
 once_cell = "1.21.3"

--- a/crates/halley-wl/src/backend_iface.rs
+++ b/crates/halley-wl/src/backend_iface.rs
@@ -3,7 +3,9 @@ use std::error::Error;
 use std::rc::Rc;
 
 use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::ImportDma;
 use smithay::backend::winit::WinitGraphicsBackend;
+use smithay::backend::{allocator::Format, allocator::dmabuf::Dmabuf};
 
 use crate::interaction::types::ResizeCtx;
 use crate::runtime_render::draw_debug_frame;
@@ -24,6 +26,33 @@ pub(crate) trait RenderBackend: BackendView {
     ) -> Result<(), Box<dyn Error>>;
 }
 
+pub(crate) trait DmabufImportBackend {
+    fn dmabuf_formats(&self) -> Vec<Format>;
+    fn import_dmabuf(&self, dmabuf: &Dmabuf) -> Result<(), Box<dyn Error>>;
+}
+
+pub(crate) struct TtyDmabufImportBackend {
+    inner: Rc<RefCell<GlesRenderer>>,
+}
+
+impl TtyDmabufImportBackend {
+    pub(crate) fn new(inner: Rc<RefCell<GlesRenderer>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl DmabufImportBackend for TtyDmabufImportBackend {
+    fn dmabuf_formats(&self) -> Vec<Format> {
+        self.inner.borrow().dmabuf_formats().iter().copied().collect()
+    }
+
+    fn import_dmabuf(&self, dmabuf: &Dmabuf) -> Result<(), Box<dyn Error>> {
+        let mut renderer = self.inner.borrow_mut();
+        renderer.import_dmabuf(dmabuf, None)?;
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct WinitBackendHandle {
     inner: Rc<RefCell<WinitGraphicsBackend<GlesRenderer>>>,
@@ -32,6 +61,23 @@ pub(crate) struct WinitBackendHandle {
 impl WinitBackendHandle {
     pub(crate) fn new(inner: Rc<RefCell<WinitGraphicsBackend<GlesRenderer>>>) -> Self {
         Self { inner }
+    }
+}
+
+impl DmabufImportBackend for WinitBackendHandle {
+    fn dmabuf_formats(&self) -> Vec<Format> {
+        self.inner
+            .borrow_mut()
+            .renderer()
+            .dmabuf_formats()
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    fn import_dmabuf(&self, dmabuf: &Dmabuf) -> Result<(), Box<dyn Error>> {
+        self.inner.borrow_mut().renderer().import_dmabuf(dmabuf, None)?;
+        Ok(())
     }
 }
 

--- a/crates/halley-wl/src/run/common.rs
+++ b/crates/halley-wl/src/run/common.rs
@@ -1,16 +1,24 @@
 use std::env;
 use std::error::Error;
 use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
 use std::io;
 use std::io::IsTerminal;
+use std::io::Write;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixListener;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
 use std::path::Path;
 use std::process::Child;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use eventline::{info, warn};
+use rustix::net::{AddressFamily, SocketAddrUnix, SocketFlags, SocketType, bind, listen, socket_with};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum RuntimeBackend {
@@ -197,11 +205,99 @@ pub(super) struct XwaylandSatellite {
     satellite_bin: String,
     wayland_display: String,
     display: String,
+    x11_sockets: Option<X11SocketReservation>,
     child: Option<Child>,
     restart_delay: Duration,
     restart_after: Option<Instant>,
     request_pending: bool,
     disabled: bool,
+}
+
+struct X11SocketReservation {
+    lock_path: PathBuf,
+    socket_path: PathBuf,
+    _lock_file: File,
+    filesystem_listener: UnixListener,
+    abstract_listener: OwnedFd,
+}
+
+impl X11SocketReservation {
+    fn try_new(display: &str) -> io::Result<Self> {
+        let Some(display_num) = display.strip_prefix(':') else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid X11 display `{display}`; expected :N"),
+            ));
+        };
+        if display_num.is_empty() || !display_num.chars().all(|ch| ch.is_ascii_digit()) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid X11 display `{display}`; expected :N"),
+            ));
+        }
+
+        let lock_path = PathBuf::from(format!("/tmp/.X{}-lock", display_num));
+        let socket_path = PathBuf::from(format!("/tmp/.X11-unix/X{}", display_num));
+
+        let mut lock_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)?;
+        let _ = writeln!(lock_file, "{}", std::process::id());
+
+        let reservation = (|| {
+            let filesystem_listener = UnixListener::bind(&socket_path)?;
+            filesystem_listener.set_nonblocking(true)?;
+
+            let abstract_listener = socket_with(
+                AddressFamily::UNIX,
+                SocketType::STREAM,
+                SocketFlags::NONBLOCK | SocketFlags::CLOEXEC,
+                None,
+            )?;
+            let abstract_name = socket_path.to_string_lossy().into_owned();
+            let abstract_addr = SocketAddrUnix::new_abstract_name(abstract_name.as_bytes())?;
+            bind(&abstract_listener, &abstract_addr)?;
+            listen(&abstract_listener, 128)?;
+
+            Ok(Self {
+                lock_path: lock_path.clone(),
+                socket_path: socket_path.clone(),
+                _lock_file: lock_file,
+                filesystem_listener,
+                abstract_listener,
+            })
+        })();
+
+        if reservation.is_err() {
+            let _ = fs::remove_file(&lock_path);
+            let _ = fs::remove_file(&socket_path);
+        }
+
+        reservation
+    }
+
+    fn filesystem_listener_for_event_loop(&self) -> io::Result<UnixListener> {
+        self.filesystem_listener.try_clone()
+    }
+
+    fn abstract_listener_for_event_loop(&self) -> io::Result<OwnedFd> {
+        Ok(rustix::io::dup(&self.abstract_listener)?)
+    }
+
+    fn child_listen_fds(&self) -> io::Result<Vec<OwnedFd>> {
+        Ok(vec![
+            rustix::io::dup(&self.filesystem_listener)?,
+            rustix::io::dup(&self.abstract_listener)?,
+        ])
+    }
+}
+
+impl Drop for X11SocketReservation {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.socket_path);
+        let _ = fs::remove_file(&self.lock_path);
+    }
 }
 
 impl XwaylandSatellite {
@@ -251,20 +347,60 @@ impl XwaylandSatellite {
             return;
         }
 
-        match Command::new(self.satellite_bin.as_str())
-            .arg(self.display.as_str())
-            .env("WAYLAND_DISPLAY", self.wayland_display.as_str())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::inherit())
-            .spawn()
-        {
+        let spawn_result = if let Some(sockets) = self.x11_sockets.as_ref() {
+            let listen_fds = match sockets.child_listen_fds() {
+                Ok(fds) => fds,
+                Err(err) => {
+                    warn!(
+                        "failed to duplicate X11 listen sockets for xwayland-satellite: {}; retrying",
+                        err
+                    );
+                    self.restart_after = Some(now + self.restart_delay);
+                    return;
+                }
+            };
+
+            let mut command = Command::new(self.satellite_bin.as_str());
+            command
+                .arg(self.display.as_str())
+                .env("WAYLAND_DISPLAY", self.wayland_display.as_str())
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::inherit());
+
+            for idx in 0..listen_fds.len() {
+                command.arg("-listenfd").arg((3 + idx).to_string());
+            }
+
+            let raw_fds: Vec<i32> = listen_fds.iter().map(AsRawFd::as_raw_fd).collect();
+            unsafe {
+                command.pre_exec(move || {
+                    for (idx, raw_fd) in raw_fds.iter().enumerate() {
+                        let target_fd = 3 + idx as i32;
+                        if libc::dup2(*raw_fd, target_fd) == -1 {
+                            return Err(io::Error::last_os_error());
+                        }
+                    }
+                    Ok(())
+                });
+            }
+
+            command.spawn()
+        } else {
+            Command::new(self.satellite_bin.as_str())
+                .arg(self.display.as_str())
+                .env("WAYLAND_DISPLAY", self.wayland_display.as_str())
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::inherit())
+                .spawn()
+        };
+
+        match spawn_result {
             Ok(child) => {
                 self.child = Some(child);
                 self.request_pending = false;
                 self.restart_after = None;
-                // SAFETY: Called on the main event-loop thread.
-                unsafe { env::set_var("DISPLAY", self.display.as_str()) };
                 info!(
                     "xwayland-satellite started via {} on DISPLAY={} (WAYLAND_DISPLAY={})",
                     self.satellite_bin, self.display, self.wayland_display
@@ -278,6 +414,20 @@ impl XwaylandSatellite {
                 self.restart_after = Some(now + self.restart_delay);
             }
         }
+    }
+
+    pub(super) fn filesystem_listener_source(&self) -> io::Result<Option<UnixListener>> {
+        self.x11_sockets
+            .as_ref()
+            .map(X11SocketReservation::filesystem_listener_for_event_loop)
+            .transpose()
+    }
+
+    pub(super) fn abstract_listener_source(&self) -> io::Result<Option<OwnedFd>> {
+        self.x11_sockets
+            .as_ref()
+            .map(X11SocketReservation::abstract_listener_for_event_loop)
+            .transpose()
     }
 }
 
@@ -303,6 +453,7 @@ pub(super) fn ensure_xwayland_satellite(
             satellite_bin: String::new(),
             wayland_display: wayland_display.to_string(),
             display: String::new(),
+            x11_sockets: None,
             child: None,
             restart_delay: Duration::from_millis(1500),
             restart_after: None,
@@ -341,6 +492,7 @@ pub(super) fn ensure_xwayland_satellite(
                 satellite_bin,
                 wayland_display: wayland_display.to_string(),
                 display: String::new(),
+                x11_sockets: None,
                 child: None,
                 restart_delay: Duration::from_millis(1500),
                 restart_after: None,
@@ -367,6 +519,7 @@ pub(super) fn ensure_xwayland_satellite(
                 satellite_bin,
                 wayland_display: wayland_display.to_string(),
                 display: String::new(),
+                x11_sockets: None,
                 child: None,
                 restart_delay: Duration::from_millis(1500),
                 restart_after: None,
@@ -380,6 +533,12 @@ pub(super) fn ensure_xwayland_satellite(
         .ok()
         .filter(|v| !v.trim().is_empty())
         .unwrap_or_else(next_free_x11_display);
+    let x11_sockets = X11SocketReservation::try_new(display.as_str()).map_err(|err| {
+        io::Error::other(format!(
+            "failed to reserve X11 display {} for xwayland-satellite: {}",
+            display, err
+        ))
+    })?;
     let restart_delay_ms = env::var("HALLEY_DEV_WL_XWAYLAND_RESTART_MS")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
@@ -390,6 +549,7 @@ pub(super) fn ensure_xwayland_satellite(
         satellite_bin,
         wayland_display: wayland_display.to_string(),
         display,
+        x11_sockets: Some(x11_sockets),
         child: None,
         restart_delay: Duration::from_millis(restart_delay_ms),
         restart_after: None,
@@ -397,11 +557,8 @@ pub(super) fn ensure_xwayland_satellite(
         disabled: false,
     };
 
-    // In on-demand mode, keep DISPLAY unset until first request.
-    if matches!(satellite.mode, XwaylandMode::OnDemand) {
-        // SAFETY: Called during startup before worker threads are spawned.
-        unsafe { env::remove_var("DISPLAY") };
-    }
+    // SAFETY: Called during startup before worker threads are spawned.
+    unsafe { env::set_var("DISPLAY", satellite.display.as_str()) };
     satellite.tick();
     Ok(satellite)
 }

--- a/crates/halley-wl/src/run/mod.rs
+++ b/crates/halley-wl/src/run/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::env;
 use std::error::Error;
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -14,7 +13,7 @@ use halley_config::RuntimeTuning;
 use calloop::EventLoop;
 use calloop::timer::{TimeoutAction, Timer};
 
-use eventline::{debug, info, scope, warn};
+use eventline::{debug, info, scope, warn, FileSetup, LogLevel, LogPolicy, RunHeader, Setup};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::OnceCell;
 
@@ -117,45 +116,44 @@ pub fn run_tty() -> Result<(), Box<dyn Error>> {
 
 fn init_logging() -> Result<(), Box<dyn Error>> {
     scope!("logging-init", success = "ready", {
-        pollster::block_on(eventline::runtime::init());
-
-        eventline::runtime::enable_console_output(true);
-        eventline::runtime::enable_console_color(true);
-        eventline::runtime::enable_console_duration(true);
         let level = env::var("HALLEY_WL_LOG")
             .ok()
-            .map(|v| v.trim().to_ascii_lowercase())
-            .and_then(|v| match v.as_str() {
-                "trace" => Some(eventline::runtime::LogLevel::Debug),
-                "debug" => Some(eventline::runtime::LogLevel::Debug),
-                "info" => Some(eventline::runtime::LogLevel::Info),
-                "warn" | "warning" => Some(eventline::runtime::LogLevel::Warning),
-                "error" => Some(eventline::runtime::LogLevel::Error),
-                "off" => Some(eventline::runtime::LogLevel::Off),
-                _ => None,
-            })
-            .unwrap_or(eventline::runtime::LogLevel::Info);
-        eventline::runtime::set_log_level(level);
+            .and_then(|v| parse_log_level(v.as_str()))
+            .unwrap_or(LogLevel::Info);
 
-        let log_file = env::var("HALLEY_WL_LOG_FILE")
-            .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
-            .or_else(default_halley_log_path);
-        if let Some(path) = log_file {
-            if let Some(parent) = Path::new(path.as_str()).parent() {
-                if let Err(err) = fs::create_dir_all(parent) {
-                    warn!(
-                        "failed to create log directory {}: {}",
-                        parent.display(),
-                        err
-                    );
+        let log_file = configured_halley_log_file();
+        let file = match log_file.as_ref() {
+            Some(None) => Some(FileSetup::Off),
+            Some(Some(path)) => Some(FileSetup::Rotating {
+                path: path.clone(),
+                policy: LogPolicy::default(),
+                header: Some(RunHeader::new("halley-wl")),
+            }),
+            None => default_halley_log_path().map(|path| FileSetup::Rotating {
+                path,
+                policy: LogPolicy::default(),
+                header: Some(RunHeader::new("halley-wl")),
+            }),
+        };
+
+        if let Err(err) = pollster::block_on(eventline::setup(Setup {
+            verbose: true,
+            level: Some(level),
+            file,
+        })) {
+            warn!("failed to configure logging: {}", err);
+        }
+
+        eventline::enable_console_color(true);
+        eventline::enable_console_duration(true);
+
+        match log_file {
+            Some(None) => info!("file logging disabled via HALLEY_WL_LOG_FILE"),
+            Some(Some(path)) => info!("file logging enabled: {}", path.display()),
+            None => {
+                if let Some(path) = default_halley_log_path() {
+                    info!("file logging enabled: {}", path.display());
                 }
-            }
-            if let Err(err) = eventline::runtime::enable_file_output(path.as_str()) {
-                warn!("failed to enable file logging at {}: {}", path, err);
-            } else {
-                info!("file logging enabled: {}", path);
             }
         }
 
@@ -163,42 +161,38 @@ fn init_logging() -> Result<(), Box<dyn Error>> {
     })
 }
 
-fn default_halley_log_path() -> Option<String> {
-    let state_home = env::var("XDG_STATE_HOME")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .map(PathBuf::from)
-        .or_else(|| {
-            env::var("HOME")
-                .ok()
-                .filter(|v| !v.trim().is_empty())
-                .map(|home| Path::new(home.as_str()).join(".local/state"))
-        });
-    if let Some(base) = state_home {
-        return Some(
-            base.join("halley")
-                .join("halley.log")
-                .to_string_lossy()
-                .to_string(),
-        );
+fn parse_log_level(raw: &str) -> Option<LogLevel> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "trace" | "debug" => Some(LogLevel::Debug),
+        "info" => Some(LogLevel::Info),
+        "warn" | "warning" => Some(LogLevel::Warning),
+        "error" => Some(LogLevel::Error),
+        "off" => Some(LogLevel::Off),
+        _ => None,
     }
+}
+
+fn configured_halley_log_file() -> Option<Option<PathBuf>> {
+    let raw = env::var("HALLEY_WL_LOG_FILE").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if matches!(trimmed.to_ascii_lowercase().as_str(), "off" | "false" | "0") {
+        return Some(None);
+    }
+    Some(Some(PathBuf::from(trimmed)))
+}
+
+fn default_halley_log_path() -> Option<PathBuf> {
     env::var("XDG_RUNTIME_DIR")
         .ok()
         .filter(|v| !v.trim().is_empty())
-        .map(|dir| {
-            Path::new(dir.as_str())
-                .join("halley-wl.log")
-                .to_string_lossy()
-                .to_string()
-        })
+        .map(|dir| Path::new(dir.as_str()).join("halley").join("halley.log"))
         .or_else(|| {
             Some(
-                PathBuf::from(format!(
-                    "/tmp/halley-wl-{}.log",
-                    rustix::process::getuid().as_raw()
-                ))
-                .to_string_lossy()
-                .to_string(),
+                PathBuf::from(format!("/tmp/halley-{}", rustix::process::getuid().as_raw()))
+                    .join("halley.log"),
             )
         })
 }

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+use calloop::{Interest, Mode, PostAction, generic::Generic};
 use crate::run::drm::{collect_outputs_for_ipc, queue_tty_drm_frame};
 use crate::run::{build_tty_libinput_backend, probe_tty_drm_device_via_session};
+use crate::backend_iface::{DmabufImportBackend, TtyDmabufImportBackend};
 
 use smithay::backend::input::{
     AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
@@ -76,6 +78,9 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             }
 
             let mut state = HalleyWlState::new(&dh, tuning.clone());
+            let dmabuf_importer: Rc<dyn DmabufImportBackend> =
+                Rc::new(TtyDmabufImportBackend::new(drm_probe.renderer.clone()));
+            state.configure_dmabuf_importer_for_fd(dmabuf_importer, drm_probe.dev.device_fd());
             state.set_app_focused(true);
             state.seat.add_pointer();
             if state
@@ -162,6 +167,27 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     let _ =
                         dh_for_clients.insert_client(client_stream, Arc::new(ClientState::new()));
                 })?;
+
+            if let Some(listener) = xwayland.borrow().filesystem_listener_source()? {
+                let xwayland_for_x11 = xwayland.clone();
+                ev.handle().insert_source(
+                    Generic::new(listener, Interest::READ, Mode::Level),
+                    move |_readiness, _listener, _st| {
+                        xwayland_for_x11.borrow_mut().request_start();
+                        Ok(PostAction::Continue)
+                    },
+                )?;
+            }
+            if let Some(listener) = xwayland.borrow().abstract_listener_source()? {
+                let xwayland_for_x11 = xwayland.clone();
+                ev.handle().insert_source(
+                    Generic::new(listener, Interest::READ, Mode::Level),
+                    move |_readiness, _listener, _st| {
+                        xwayland_for_x11.borrow_mut().request_start();
+                        Ok(PostAction::Continue)
+                    },
+                )?;
+            }
 
             {
                 let libinput_context_for_session = libinput_context.clone();

--- a/crates/halley-wl/src/run/winit_backend.rs
+++ b/crates/halley-wl/src/run/winit_backend.rs
@@ -1,6 +1,8 @@
 use super::*;
 
+use calloop::{Interest, Mode, PostAction, generic::Generic};
 use halley_ipc::{LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus};
+use crate::backend_iface::DmabufImportBackend;
 
 fn apply_host_cursor(
     backend: &Rc<RefCell<smithay::backend::winit::WinitGraphicsBackend<GlesRenderer>>>,
@@ -172,6 +174,8 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             })?;
             let backend = Rc::new(RefCell::new(backend));
             let backend_handle = WinitBackendHandle::new(backend.clone());
+            let dmabuf_importer: Rc<dyn DmabufImportBackend> = Rc::new(backend_handle.clone());
+            state.configure_dmabuf_importer(dmabuf_importer, None);
             let xwayland = Rc::new(RefCell::new(ensure_xwayland_satellite(sock_name.as_str())?));
             let (xwayland_request_tx, xwayland_request_rx) = mpsc::channel::<()>();
             register_xwayland_request_channel(xwayland_request_tx);
@@ -233,6 +237,27 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     let _ =
                         dh_for_clients.insert_client(client_stream, Arc::new(ClientState::new()));
                 })?;
+
+            if let Some(listener) = xwayland.borrow().filesystem_listener_source()? {
+                let xwayland_for_x11 = xwayland.clone();
+                ev.handle().insert_source(
+                    Generic::new(listener, Interest::READ, Mode::Level),
+                    move |_readiness, _listener, _st| {
+                        xwayland_for_x11.borrow_mut().request_start();
+                        Ok(PostAction::Continue)
+                    },
+                )?;
+            }
+            if let Some(listener) = xwayland.borrow().abstract_listener_source()? {
+                let xwayland_for_x11 = xwayland.clone();
+                ev.handle().insert_source(
+                    Generic::new(listener, Interest::READ, Mode::Level),
+                    move |_readiness, _listener, _st| {
+                        xwayland_for_x11.borrow_mut().request_start();
+                        Ok(PostAction::Continue)
+                    },
+                )?;
+            }
 
             ev.handle()
                 .insert_source(winit_source, move |event, _, st| match event {

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::os::unix::io::AsFd;
+use std::rc::Rc;
 use std::time::Instant;
 
 use halley_config::RuntimeTuning;
@@ -10,8 +12,9 @@ use halley_core::viewport::{FocusZone, Viewport};
 
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
-    delegate_compositor, delegate_data_control, delegate_data_device, delegate_layer_shell,
-    delegate_output, delegate_primary_selection, delegate_seat, delegate_shm, delegate_xdg_shell,
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_dmabuf,
+    delegate_layer_shell, delegate_output, delegate_primary_selection, delegate_seat,
+    delegate_shm, delegate_viewporter, delegate_xdg_shell,
     desktop::PopupManager,
     input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus},
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
@@ -20,6 +23,7 @@ use smithay::{
     wayland::{
         buffer::BufferHandler,
         compositor::{CompositorClientState, CompositorHandler, CompositorState},
+        dmabuf::{DmabufFeedbackBuilder, DmabufGlobal, DmabufState},
         output::OutputManagerState,
         selection::{
             SelectionHandler,
@@ -34,11 +38,13 @@ use smithay::{
             PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
         },
         shm::{ShmHandler, ShmState},
+        viewporter::ViewporterState,
     },
 };
 
 use crate::activity::CommitActivity;
 use crate::anim::{AnimSpec, Animator};
+use crate::backend_iface::DmabufImportBackend;
 mod carry;
 mod client;
 mod focus;
@@ -57,11 +63,14 @@ use focus::ViewportPanAnim;
 pub struct HalleyWlState {
     pub display_handle: DisplayHandle,
     pub compositor_state: CompositorState,
+    pub viewporter_state: ViewporterState,
     pub xdg_shell_state: XdgShellState,
     pub popup_manager: PopupManager,
     pub wlr_layer_shell_state: WlrLayerShellState,
     pub output_manager_state: OutputManagerState,
     pub shm_state: ShmState,
+    pub dmabuf_state: DmabufState,
+    pub dmabuf_global: Option<DmabufGlobal>,
     pub seat_state: SeatState<Self>,
     pub data_device_state: DataDeviceState,
     pub primary_selection_state: PrimarySelectionState,
@@ -75,6 +84,7 @@ pub struct HalleyWlState {
     pub tuning: RuntimeTuning,
     pub zoom_ref_size: Vec2,
     pub cursor_image_status: CursorImageStatus,
+    pub(crate) dmabuf_importer: Option<Rc<dyn DmabufImportBackend>>,
 
     pub surface_activity: HashMap<ObjectId, CommitActivity>,
     pub surface_to_node: HashMap<ObjectId, NodeId>,
@@ -148,11 +158,14 @@ impl HalleyWlState {
         let mut out = Self {
             display_handle: dh.clone(),
             compositor_state: CompositorState::new::<HalleyWlState>(dh),
+            viewporter_state: ViewporterState::new::<HalleyWlState>(dh),
             xdg_shell_state: XdgShellState::new::<HalleyWlState>(dh),
             popup_manager: PopupManager::default(),
             wlr_layer_shell_state: WlrLayerShellState::new::<HalleyWlState>(dh),
             output_manager_state: OutputManagerState::new_with_xdg_output::<HalleyWlState>(dh),
             shm_state: ShmState::new::<HalleyWlState>(dh, vec![]),
+            dmabuf_state: DmabufState::new(),
+            dmabuf_global: None,
             seat_state,
             data_device_state: DataDeviceState::new::<HalleyWlState>(dh),
             primary_selection_state,
@@ -165,6 +178,7 @@ impl HalleyWlState {
             viewport: tuning.viewport(),
             zoom_ref_size: tuning.viewport_size,
             cursor_image_status: CursorImageStatus::default_named(),
+            dmabuf_importer: None,
             tuning,
 
             surface_activity: HashMap::new(),
@@ -224,6 +238,42 @@ impl HalleyWlState {
             bounce: out.tuning.dev_anim_bounce,
         });
         out
+    }
+
+    pub(crate) fn configure_dmabuf_importer(
+        &mut self,
+        importer: Rc<dyn DmabufImportBackend>,
+        main_device: Option<libc::dev_t>,
+    ) {
+        let formats = importer.dmabuf_formats();
+        if formats.is_empty() {
+            return;
+        }
+
+        let global = match main_device {
+            Some(device) => {
+                let feedback = DmabufFeedbackBuilder::new(device, formats.iter().copied())
+                    .build()
+                    .expect("renderer dmabuf feedback should be constructible");
+                self.dmabuf_state
+                    .create_global_with_default_feedback::<HalleyWlState>(&self.display_handle, &feedback)
+            }
+            None => self
+                .dmabuf_state
+                .create_global::<HalleyWlState>(&self.display_handle, formats.iter().copied()),
+        };
+
+        self.dmabuf_importer = Some(importer);
+        self.dmabuf_global = Some(global);
+    }
+
+    pub(crate) fn configure_dmabuf_importer_for_fd<Fd: AsFd>(
+        &mut self,
+        importer: Rc<dyn DmabufImportBackend>,
+        device_fd: Fd,
+    ) {
+        let main_device = rustix::fs::fstat(device_fd).ok().map(|stat| stat.st_rdev);
+        self.configure_dmabuf_importer(importer, main_device);
     }
 
     pub(crate) fn advertise_primary_output(&mut self, name: &str, mode: OutputMode) {
@@ -392,3 +442,5 @@ impl HalleyWlState {
         }
     }
 }
+
+delegate_dmabuf!(HalleyWlState);

--- a/crates/halley-wl/src/state/wayland_handlers.rs
+++ b/crates/halley-wl/src/state/wayland_handlers.rs
@@ -5,12 +5,14 @@ use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{
     Client, Resource, protocol::wl_output::WlOutput, protocol::wl_surface::WlSurface,
 };
+use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::wayland::output::OutputHandler;
 use smithay::wayland::selection::data_device::set_data_device_focus;
 use smithay::wayland::selection::primary_selection::{
     PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
 };
 use smithay::wayland::selection::wlr_data_control::DataControlState;
+use smithay::wayland::dmabuf::{DmabufFeedback, DmabufGlobal, DmabufHandler, ImportNotifier};
 use smithay::wayland::shell::wlr_layer::{
     Layer, LayerSurface, LayerSurfaceConfigure, WlrLayerShellHandler, WlrLayerShellState,
 };
@@ -84,6 +86,7 @@ impl CompositorHandler for HalleyWlState {
 }
 
 delegate_compositor!(HalleyWlState);
+delegate_viewporter!(HalleyWlState);
 
 impl ShmHandler for HalleyWlState {
     fn shm_state(&self) -> &ShmState {
@@ -100,6 +103,38 @@ impl BufferHandler for HalleyWlState {
 }
 
 delegate_shm!(HalleyWlState);
+
+impl DmabufHandler for HalleyWlState {
+    fn dmabuf_state(&mut self) -> &mut smithay::wayland::dmabuf::DmabufState {
+        &mut self.dmabuf_state
+    }
+
+    fn dmabuf_imported(&mut self, global: &DmabufGlobal, dmabuf: Dmabuf, notifier: ImportNotifier) {
+        if self.dmabuf_global != Some(*global) {
+            notifier.failed();
+            return;
+        }
+
+        let Some(importer) = self.dmabuf_importer.as_ref() else {
+            notifier.failed();
+            return;
+        };
+
+        if importer.import_dmabuf(&dmabuf).is_ok() {
+            let _ = notifier.successful::<Self>();
+        } else {
+            notifier.failed();
+        }
+    }
+
+    fn new_surface_feedback(
+        &mut self,
+        _surface: &WlSurface,
+        _global: &DmabufGlobal,
+    ) -> Option<DmabufFeedback> {
+        None
+    }
+}
 
 impl XdgShellHandler for HalleyWlState {
     fn xdg_shell_state(&mut self) -> &mut XdgShellState {


### PR DESCRIPTION
Introduce linux-dmabuf buffer import support and update the Xwayland launch model so Halley owns the X11 display sockets.

DMABUF support:
- add Smithay linux-dmabuf protocol state and delegate wiring to HalleyWlState
- advertise renderer dmabuf formats at startup and publish DRM-backed feedback on tty
- validate client dmabuf buffers through the active GLES renderer in both tty and winit backends
- add the libc dependency required for typed dmabuf feedback device IDs

Xwayland integration:
- reserve the X11 display inside Halley by creating the X lock file and listen sockets directly
- start xwayland-satellite with inherited `-listenfd` sockets instead of letting it claim :N itself
- expose `DISPLAY` as soon as the compositor reserves the X11 display
- trigger xwayland-satellite startup from X11 socket readiness in tty and winit backends for true on-demand launch