### PR TITLE
feat(wl): make window spawning deterministic, collision-aware, and viewport-anchored

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -43,7 +43,6 @@ pub struct RuntimeTuning {
 
     pub non_overlap_gap_px: f32,
     pub non_overlap_active_gap_scale: f32,
-    pub new_window_on_top: bool,
     pub non_overlap_bump_newer: bool,
     pub non_overlap_bump_damping: f32,
     pub drag_smoothing_boost: f32,
@@ -107,7 +106,6 @@ impl Default for RuntimeTuning {
 
             non_overlap_gap_px: 20.0,
             non_overlap_active_gap_scale: 0.22,
-            new_window_on_top: true,
             non_overlap_bump_newer: false,
             non_overlap_bump_damping: 0.35,
             drag_smoothing_boost: 6.0,

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use super::{KeyModifiers, LaunchBinding};
-use crate::RuntimeTuning;
 use crate::keybinds::{key_name_to_evdev, modifiers_empty, parse_chord, parse_modifiers};
 use crate::layout::ViewportOutputConfig;
 use crate::legacy::{parse_legacy_keybinds, strip_legacy_keybind_block};
+use crate::RuntimeTuning;
 
 use rune_cfg::RuneConfig;
 
@@ -28,7 +28,6 @@ impl RuntimeTuning {
         load_nodes_section(&cfg, &mut out);
         load_clusters_section(&cfg, &mut out);
         load_decay_section(&cfg, &mut out);
-        load_tile_section(&cfg, &mut out);
         load_docking_section(&cfg, &mut out);
         load_physics_section(&cfg, &mut out);
         load_keybind_sections(&cfg, &mut out);
@@ -353,14 +352,6 @@ fn load_decay_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.docked_offscreen_delay_ms = docked_s.saturating_mul(1000);
 }
 
-fn load_tile_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.new_window_on_top = pick_bool(
-        cfg,
-        &["tile.new-on-top", "tile.new_on_top"],
-        out.new_window_on_top,
-    );
-}
-
 fn load_docking_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.non_overlap_gap_px = pick_f32(
         cfg,
@@ -475,7 +466,11 @@ fn parse_viewport_outputs(cfg: &RuneConfig, root: &str) -> Vec<ViewportOutputCon
                 ],
                 0.0,
             );
-            if v > 0.0 { Some(v as f64) } else { None }
+            if v > 0.0 {
+                Some(v as f64)
+            } else {
+                None
+            }
         };
 
         out.push(ViewportOutputConfig {

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -226,13 +226,15 @@ pub(crate) fn handle_pointer_axis_input(
     let steps = steps.clamp(-4.0, 4.0);
     pointer_state.borrow_mut().panning = false;
     let step = (steps.abs() * 80.0).max(22.0);
-    st.note_pan_activity(Instant::now());
+    let now = Instant::now();
+    st.note_pan_activity(now);
     st.viewport.pan(halley_core::field::Vec2 {
         x: 0.0,
         y: step * steps.signum(),
     });
     st.tuning.viewport_center = st.viewport.center;
     st.tuning.viewport_size = st.viewport.size;
+    st.note_pan_viewport_change(now);
     backend.request_redraw();
 }
 

--- a/crates/halley-wl/src/input/pointer_focus.rs
+++ b/crates/halley-wl/src/input/pointer_focus.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use eventline::info;
-use smithay::desktop::{PopupManager, WindowSurfaceType, utils::under_from_surface_tree};
+use smithay::desktop::{utils::under_from_surface_tree, PopupManager, WindowSurfaceType};
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Logical, Point};
 
@@ -38,11 +38,7 @@ fn popup_focus_for_screen(
         })
         .collect();
 
-    if st.tuning.new_window_on_top {
-        toplevels.sort_by_key(|(node_id, _, _, _)| node_id.as_u64());
-    } else {
-        toplevels.sort_by_key(|(node_id, _, _, _)| std::cmp::Reverse(node_id.as_u64()));
-    }
+    toplevels.sort_by_key(|(node_id, _, _, _)| node_id.as_u64());
     if let Some(idx) = toplevels
         .iter()
         .position(|(node_id, _, _, _)| Some(*node_id) == recent_top_node)

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -300,13 +300,15 @@ pub(crate) fn handle_pointer_motion_absolute(
         let dy_px = active_sy - lsy;
         let dx_world = dx_px * st.viewport.size.x.max(1.0) / (ws_w as f32).max(1.0);
         let dy_world = -dy_px * st.viewport.size.y.max(1.0) / (ws_h as f32).max(1.0);
-        st.note_pan_activity(Instant::now());
+        let now = Instant::now();
+        st.note_pan_activity(now);
         st.viewport.pan(halley_core::field::Vec2 {
             x: -dx_world,
             y: -dy_world,
         });
         st.tuning.viewport_center = st.viewport.center;
         st.tuning.viewport_size = st.viewport.size;
+        st.note_pan_viewport_change(now);
         ps.pan_last_screen = (active_sx, active_sy);
         backend.request_redraw();
     }

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -4,11 +4,11 @@ use std::time::Instant;
 
 use smithay::{
     backend::renderer::{
-        Color32F, Frame,
-        element::{Kind, surface::render_elements_from_surface_tree, utils::CropRenderElement},
+        element::{surface::render_elements_from_surface_tree, utils::CropRenderElement, Kind},
         gles::GlesRenderer,
+        Color32F, Frame,
     },
-    desktop::{PopupManager, utils::bbox_from_surface_tree},
+    desktop::{utils::bbox_from_surface_tree, PopupManager},
     reexports::wayland_server::Resource,
     utils::{Physical, Rectangle, Size},
 };
@@ -135,11 +135,7 @@ pub(crate) fn collect_active_surfaces(
         })
         .collect();
 
-    if st.tuning.new_window_on_top {
-        wl_surfaces.sort_by_key(|(id, _)| std::cmp::Reverse(id.as_u64()));
-    } else {
-        wl_surfaces.sort_by_key(|(id, _)| id.as_u64());
-    }
+    wl_surfaces.sort_by_key(|(id, _)| std::cmp::Reverse(id.as_u64()));
 
     for (node_id, wl) in wl_surfaces {
         let bbox = if resize_preview.is_some_and(|rz| rz.node_id == node_id) {

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -467,6 +467,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     let resize_active = ps.resize.is_some();
                     drop(ps);
 
+                    st.tick_frame_effects(now);
                     st.tick_animator_frame(now);
                     {
                         let mut ps = pointer_state_for_timer.borrow_mut();

--- a/crates/halley-wl/src/run/winit_backend.rs
+++ b/crates/halley-wl/src/run/winit_backend.rs
@@ -480,6 +480,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     let ps = pointer_state_for_timer.borrow();
                     ps.resize.is_some()
                 };
+                st.tick_frame_effects(now);
                 st.tick_animator_frame(now);
                 {
                     let mut ps = pointer_state_for_timer.borrow_mut();

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::os::unix::io::AsFd;
 use std::rc::Rc;
 use std::time::Instant;
@@ -41,6 +41,42 @@ mod client;
 mod render_state;
 mod runtime_state;
 pub use client::ClientState;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpawnFrontierPoint {
+    pub pos: Vec2,
+    pub score: f32,
+    pub dir: Vec2,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SpawnPatch {
+    pub anchor: Vec2,
+    pub focus_node: Option<NodeId>,
+    pub focus_pos: Vec2,
+    pub growth_dir: Vec2,
+    pub placements_in_patch: u32,
+    pub frontier: Vec<SpawnFrontierPoint>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingSpawnPan {
+    pub node_id: NodeId,
+    pub target_center: Vec2,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ActiveSpawnPan {
+    pub node_id: NodeId,
+    pub pan_start_at_ms: u64,
+    pub reveal_at_ms: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SpawnAnchorMode {
+    Focus,
+    View,
+}
 
 pub struct HalleyWlState {
     pub display_handle: DisplayHandle,
@@ -122,6 +158,13 @@ pub struct HalleyWlState {
     pub(crate) recent_top_until: Option<Instant>,
 
     pub(crate) spawn_cursor: u32,
+    pub(crate) spawn_patch: Option<SpawnPatch>,
+    pub(crate) spawn_anchor_mode: SpawnAnchorMode,
+    pub(crate) spawn_view_anchor: Vec2,
+    pub(crate) spawn_pan_start_center: Option<Vec2>,
+    pub(crate) spawn_last_pan_ms: u64,
+    pub(crate) pending_spawn_pan_queue: VecDeque<PendingSpawnPan>,
+    pub(crate) active_spawn_pan: Option<ActiveSpawnPan>,
     pub(crate) started_at: Instant,
     pub(crate) last_debug_dump_at: Instant,
 }
@@ -132,6 +175,7 @@ impl HalleyWlState {
         tuning: RuntimeTuning,
     ) -> Self {
         let now = Instant::now();
+        let initial_view_anchor = tuning.viewport_center;
         let mut seat_state = SeatState::new();
         let seat = seat_state.new_wl_seat(dh, "halley");
         let primary_selection_state = PrimarySelectionState::new::<HalleyWlState>(dh);
@@ -212,6 +256,13 @@ impl HalleyWlState {
             recent_top_until: None,
 
             spawn_cursor: 0,
+            spawn_patch: None,
+            spawn_anchor_mode: SpawnAnchorMode::Focus,
+            spawn_view_anchor: initial_view_anchor,
+            spawn_pan_start_center: None,
+            spawn_last_pan_ms: 0,
+            pending_spawn_pan_queue: VecDeque::new(),
+            active_spawn_pan: None,
             started_at: now,
             last_debug_dump_at: now,
         };
@@ -316,7 +367,6 @@ impl HalleyWlState {
         self.reconcile_surface_bindings();
         let now_ms = now.duration_since(self.started_at).as_millis() as u64;
         let _ = self.recent_top_node_active(now);
-        self.tick_viewport_pan_animation(now_ms);
         if self.active_cluster_workspace.is_some() {
             self.layout_active_cluster_workspace(now_ms);
             self.animator.observe_field(&self.field, now);

--- a/crates/halley-wl/src/state/render_state.rs
+++ b/crates/halley-wl/src/state/render_state.rs
@@ -131,6 +131,12 @@ impl HalleyWlState {
         self.animator.observe_field(&self.field, now);
     }
 
+    pub fn tick_frame_effects(&mut self, now: Instant) {
+        let now_ms = self.now_ms(now);
+        self.tick_viewport_pan_animation(now_ms);
+        self.tick_pending_spawn_pan(now, now_ms);
+    }
+
     pub fn send_frame_callbacks(&mut self, now: Instant) {
         let elapsed_ms = now.duration_since(self.started_at).as_millis();
         let time_ms = elapsed_ms.min(u32::MAX as u128) as u32;

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -6,13 +6,13 @@ use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{
     Client, Resource, protocol::wl_output::WlOutput, protocol::wl_surface::WlSurface,
 };
+use smithay::wayland::compositor::with_states;
 use smithay::wayland::dmabuf::{DmabufFeedback, DmabufGlobal, DmabufHandler, ImportNotifier};
 use smithay::wayland::output::OutputHandler;
 use smithay::wayland::selection::data_device::set_data_device_focus;
 use smithay::wayland::selection::primary_selection::{
     PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
 };
-use smithay::wayland::compositor::with_states;
 use smithay::wayland::selection::wlr_data_control::DataControlState;
 use smithay::wayland::shell::wlr_layer::{
     Layer, LayerSurface, LayerSurfaceConfigure, WlrLayerShellHandler, WlrLayerShellState,
@@ -186,14 +186,15 @@ impl XdgShellHandler for HalleyWlState {
 
         // Create a core node for the underlying wl_surface.
         let wl = toplevel.wl_surface().clone();
-        let id = self.ensure_node_for_surface(&wl, "toplevel", initial_toplevel_size(self, &toplevel));
+        let id =
+            self.ensure_node_for_surface(&wl, "toplevel", initial_toplevel_size(self, &toplevel));
         let now = Instant::now();
         let _ = self.field.touch(id, self.now_ms(now));
-        // New windows should be immediately typeable and stay focused until
-        // the user explicitly focuses another surface.
-        self.set_interaction_focus(Some(id), 30_000, now);
 
         if is_transient {
+            // New transient windows should be immediately typeable and stay
+            // focused until the user explicitly focuses another surface.
+            self.set_interaction_focus(Some(id), 30_000, now);
             // Cancel the delayed activation that would call
             // push_neighbors_for_activation. The surface is already Active and
             // Hot from ensure_node_for_surface; we just don’t want it shoving
@@ -201,6 +202,8 @@ impl XdgShellHandler for HalleyWlState {
             self.pending_spawn_activate_at_ms.remove(&id);
             // Still play the appear animation so it doesn’t just snap in.
             self.mark_active_transition(id, now, 620);
+        } else {
+            self.queue_spawn_pan_to_node(id, now);
         }
 
         self.resolve_surface_overlap();

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -1,19 +1,230 @@
 use std::time::Instant;
 
 use halley_core::decay::DecayLevel;
-use halley_core::field::{Field, NodeId, Vec2};
+use halley_core::field::{NodeId, Vec2};
 use smithay::reexports::wayland_server::{
-    Resource, backend::ObjectId, protocol::wl_surface::WlSurface,
+    backend::ObjectId, protocol::wl_surface::WlSurface, Resource,
 };
 
 use crate::activity::CommitActivity;
 use crate::state::HalleyWlState;
 use crate::wm::overlap::CollisionExtents;
 
+/// Generates candidate spawn positions using a Fermat spiral (golden-angle
+/// phyllotaxis). Placing candidates at successive golden-angle increments
+/// produces the most isotropic possible coverage — the same sunflower-seed
+/// packing used in botany — with no preferred axis to lock growth onto.
+///
+/// Ring is `ceil(sqrt(n))` so points at roughly equal radii share a ring,
+/// preserving the existing ring-threshold semantics for frontier tracking.
+fn spawn_fermat_candidates(step: f32, count: usize) -> Vec<(Vec2, u32)> {
+    // 2π(1 - 1/φ) ≈ 137.508° — the golden angle in radians.
+    const GOLDEN_ANGLE: f32 = 2.399_963_2_f32;
+    let mut out = Vec::with_capacity(count);
+    out.push((Vec2 { x: 0.0, y: 0.0 }, 0u32));
+    for n in 1..count {
+        let angle = n as f32 * GOLDEN_ANGLE;
+        let radius = (n as f32).sqrt() * step;
+        let ring = (n as f32).sqrt().ceil() as u32;
+        out.push((
+            Vec2 {
+                x: angle.cos() * radius,
+                y: angle.sin() * radius,
+            },
+            ring,
+        ));
+    }
+    out
+}
+
 impl HalleyWlState {
+    /// Number of Fermat spiral candidates tried when nothing adjacent fits.
+    /// 89 is a Fibonacci number and gives decent radial coverage (~10 rings).
+    const SPAWN_FERMAT_COUNT: usize = 89;
+    /// How far to jump (in window diagonals) when seeding a fresh island.
+    const SPAWN_ISLAND_JUMP_DIAGONALS: f32 = 5.5;
+
     #[inline]
     fn surface_key(surface: &WlSurface) -> ObjectId {
         surface.id()
+    }
+
+    fn vec_sub(a: Vec2, b: Vec2) -> Vec2 {
+        Vec2 {
+            x: a.x - b.x,
+            y: a.y - b.y,
+        }
+    }
+
+    fn vec_len(v: Vec2) -> f32 {
+        (v.x * v.x + v.y * v.y).sqrt()
+    }
+
+    fn vec_dot(a: Vec2, b: Vec2) -> f32 {
+        a.x * b.x + a.y * b.y
+    }
+
+    fn vec_norm(v: Vec2) -> Vec2 {
+        let len = Self::vec_len(v);
+        if len <= 0.001 {
+            Vec2 { x: 0.0, y: 0.0 }
+        } else {
+            Vec2 {
+                x: v.x / len,
+                y: v.y / len,
+            }
+        }
+    }
+
+    /// Returns the currently focused surface node's id, center position, and
+    /// intrinsic size — the anchor for adjacent placement.
+    fn focused_surface(&self) -> Option<(NodeId, Vec2, Vec2)> {
+        let id = self.last_input_surface_node()?;
+        let node = self.field.node(id)?;
+        Some((id, node.pos, node.intrinsic_size))
+    }
+
+    fn current_spawn_focus(&self) -> (Option<NodeId>, Vec2) {
+        if self.spawn_anchor_mode == crate::state::SpawnAnchorMode::View {
+            return (None, self.spawn_view_anchor);
+        }
+        if let Some(id) = self.last_input_surface_node() {
+            if let Some(node) = self.field.node(id) {
+                return (Some(id), node.pos);
+            }
+        }
+        (None, self.viewport.center)
+    }
+
+    /// Try to place a window of `size` directly adjacent to the currently
+    /// focused window. Checks right → left → below → above and returns the
+    /// first position that fits, or `None` if all four are blocked.
+    ///
+    /// In view-anchor mode (user panned away from focused window) this step is
+    /// skipped so new windows open near the viewport rather than off-screen.
+    fn try_spawn_adjacent(&self, size: Vec2) -> Option<Vec2> {
+        if self.spawn_anchor_mode == crate::state::SpawnAnchorMode::View {
+            return None;
+        }
+        let (focus_id, focus_pos, focus_size) = self.focused_surface()?;
+        let gap = self.non_overlap_gap_world();
+        // Half-extents of the focus and new window, used to compute
+        // edge-to-edge offsets so the new window sits flush with a gap.
+        let fx = focus_size.x * 0.5;
+        let fy = focus_size.y * 0.5;
+        let nx = size.x * 0.5;
+        let ny = size.y * 0.5;
+        let candidates = [
+            Vec2 { x: focus_pos.x + fx + gap + nx, y: focus_pos.y }, // right
+            Vec2 { x: focus_pos.x - fx - gap - nx, y: focus_pos.y }, // left
+            Vec2 { x: focus_pos.x, y: focus_pos.y + fy + gap + ny }, // below
+            Vec2 { x: focus_pos.x, y: focus_pos.y - fy - gap - ny }, // above
+        ];
+        candidates
+            .into_iter()
+            .find(|&pos| self.spawn_candidate_fits(pos, size, Some(focus_id)))
+    }
+
+    /// Try to place a window of `size` using a Fermat spiral expanding
+    /// outward from `center`. Returns the first position that fits.
+    fn try_spawn_fermat(&self, center: Vec2, size: Vec2) -> Option<Vec2> {
+        let gap = self.non_overlap_gap_world();
+        let step = ((size.x + gap) * (size.y + gap)).sqrt();
+        for (offset, _ring) in spawn_fermat_candidates(step, Self::SPAWN_FERMAT_COUNT) {
+            let pos = Vec2 {
+                x: center.x + offset.x,
+                y: center.y + offset.y,
+            };
+            if self.spawn_candidate_fits(pos, size, None) {
+                return Some(pos);
+            }
+        }
+        None
+    }
+
+    /// Last-resort placement: jump to a fresh island anchor and pan there.
+    /// Tries the stored growth direction first, then rotations of it.
+    /// Returns `(position, needs_pan=true)` on success, or falls back to
+    /// viewport center with `needs_pan=false` if even the jump fails.
+    fn try_island_jump(&mut self, size: Vec2) -> (Vec2, bool) {
+        let jump_dist = size.x.hypot(size.y) * Self::SPAWN_ISLAND_JUMP_DIAGONALS;
+        let base = self
+            .spawn_patch
+            .as_ref()
+            .map(|p| p.anchor)
+            .unwrap_or(self.viewport.center);
+        let base_dir = self
+            .spawn_patch
+            .as_ref()
+            .map(|p| p.growth_dir)
+            .unwrap_or(Vec2 { x: 1.0, y: 0.0 });
+
+        // Try the current growth direction, then 90° rotations.
+        let rotations: [Vec2; 4] = [
+            base_dir,
+            Vec2 { x: -base_dir.y, y: base_dir.x },
+            Vec2 { x: -base_dir.x, y: -base_dir.y },
+            Vec2 { x: base_dir.y, y: -base_dir.x },
+        ];
+        for dir in rotations {
+            let island_center = Vec2 {
+                x: base.x + dir.x * jump_dist,
+                y: base.y + dir.y * jump_dist,
+            };
+            if let Some(pos) = self.try_spawn_fermat(island_center, size) {
+                self.spawn_patch = Some(crate::state::SpawnPatch {
+                    anchor: island_center,
+                    focus_node: None,
+                    focus_pos: island_center,
+                    growth_dir: dir,
+                    placements_in_patch: 0,
+                    frontier: Vec::new(),
+                });
+                return (pos, true);
+            }
+        }
+        // Absolute fallback — nothing fit anywhere.
+        (self.viewport.center, false)
+    }
+
+    fn spawn_candidate_fits(&self, pos: Vec2, size: Vec2, skip_node: Option<NodeId>) -> bool {
+        let pair_gap = self.non_overlap_gap_world();
+        let candidate = CollisionExtents::symmetric(size);
+        !self.field.nodes().values().any(|other| {
+            if Some(other.id) == skip_node
+                || other.kind != halley_core::field::NodeKind::Surface
+                || !self.field.is_visible(other.id)
+            {
+                return false;
+            }
+            let other_ext = self.spawn_obstacle_extents_for_node(other);
+            let req_x = self.required_sep_x(pos.x, candidate, other.pos.x, other_ext, pair_gap);
+            let req_y = self.required_sep_y(pos.y, candidate, other.pos.y, other_ext, pair_gap);
+            (pos.x - other.pos.x).abs() < req_x && (pos.y - other.pos.y).abs() < req_y
+        })
+    }
+
+    /// Returns `(position, needs_pan)`. `needs_pan` is `true` when an island
+    /// jump occurred and the caller should pan the viewport to the new window.
+    ///
+    /// Priority order:
+    ///   1. Directly adjacent to focused window  (right → left → below → above)
+    ///   2. Fermat spiral outward from focused position  (first fit)
+    ///   3. Island jump: new anchor in growth direction  (+ pan)
+    fn pick_spawn_position(&mut self, size: Vec2) -> (Vec2, bool) {
+        // Step 1: adjacent to focused window.
+        if let Some(pos) = self.try_spawn_adjacent(size) {
+            return (pos, false);
+        }
+
+        // Step 2: Fermat spiral from focus / view anchor.
+        let focus_pos = self.current_spawn_focus().1;
+        if let Some(pos) = self.try_spawn_fermat(focus_pos, size) {
+            return (pos, false);
+        }
+
+        // Step 3: everything near focus is packed — jump to a fresh island.
+        self.try_island_jump(size)
     }
 
     pub fn note_commit(&mut self, surface: &WlSurface, now: Instant) {
@@ -42,114 +253,12 @@ impl HalleyWlState {
             return id;
         }
 
-        let n = self.spawn_cursor;
         self.spawn_cursor += 1;
         let size = Vec2 {
             x: size_px.0.max(64) as f32,
             y: size_px.1.max(64) as f32,
         };
-        let gap = self.non_overlap_gap_world();
-
-        let pair_gap = gap;
-        let conflict_at = |p: Vec2, field: &Field, size: Vec2, pair_gap: f32| -> bool {
-            let candidate = CollisionExtents::symmetric(size);
-            field.nodes().values().any(|other| {
-                if other.kind != halley_core::field::NodeKind::Surface {
-                    return false;
-                }
-                if !field.is_visible(other.id) {
-                    return false;
-                }
-                let other_ext = self.collision_extents_for_node(other);
-                let req_x = self.required_sep_x(p.x, candidate, other.pos.x, other_ext, pair_gap);
-                let req_y = self.required_sep_y(p.y, candidate, other.pos.y, other_ext, pair_gap);
-                (p.x - other.pos.x).abs() < req_x && (p.y - other.pos.y).abs() < req_y
-            })
-        };
-
-        let previous_active: Vec<NodeId> = if self.tuning.new_window_on_top {
-            self.field
-                .nodes()
-                .iter()
-                .filter_map(|(&id, n)| {
-                    (self.field.is_visible(id)
-                        && n.kind == halley_core::field::NodeKind::Surface
-                        && n.state == halley_core::field::NodeState::Active)
-                        .then_some(id)
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
-
-        let mut pos = Vec2 {
-            x: self.viewport.center.x,
-            y: self.viewport.center.y,
-        };
-        if !self.tuning.new_window_on_top {
-            let anchor = self
-                .field
-                .nodes()
-                .values()
-                .filter(|n| n.kind == halley_core::field::NodeKind::Surface)
-                .filter(|n| self.field.is_visible(n.id))
-                .max_by_key(|n| n.id.as_u64());
-            if let Some(a) = anchor {
-                let a_ext = self.collision_extents_for_node(a);
-                let new_ext = CollisionExtents::symmetric(size);
-                let dx_right =
-                    self.required_sep_x(a.pos.x, a_ext, a.pos.x + 1.0, new_ext, pair_gap);
-                let dx_left = self.required_sep_x(a.pos.x, a_ext, a.pos.x - 1.0, new_ext, pair_gap);
-                let dy_down = self.required_sep_y(a.pos.y, a_ext, a.pos.y + 1.0, new_ext, pair_gap);
-                let dy_up = self.required_sep_y(a.pos.y, a_ext, a.pos.y - 1.0, new_ext, pair_gap);
-                let sign = if n.is_multiple_of(2) { 1.0 } else { -1.0 };
-                let candidates = [
-                    Vec2 {
-                        x: a.pos.x + if sign > 0.0 { dx_right } else { -dx_left },
-                        y: a.pos.y,
-                    },
-                    Vec2 {
-                        x: a.pos.x - if sign > 0.0 { dx_left } else { -dx_right },
-                        y: a.pos.y,
-                    },
-                    Vec2 {
-                        x: a.pos.x,
-                        y: a.pos.y + dy_down,
-                    },
-                    Vec2 {
-                        x: a.pos.x,
-                        y: a.pos.y - dy_up,
-                    },
-                    Vec2 {
-                        x: a.pos.x + if sign > 0.0 { dx_right } else { -dx_left },
-                        y: a.pos.y + dy_down * 0.5,
-                    },
-                    Vec2 {
-                        x: a.pos.x - if sign > 0.0 { dx_left } else { -dx_right },
-                        y: a.pos.y - dy_up * 0.5,
-                    },
-                ];
-                if let Some(p) = candidates
-                    .into_iter()
-                    .find(|p| !conflict_at(*p, &self.field, size, pair_gap))
-                {
-                    pos = p;
-                } else {
-                    for i in 0..24u32 {
-                        let ring = 200.0 + ((i / 8) as f32) * 120.0;
-                        let theta = (i % 8) as f32 * std::f32::consts::TAU / 8.0;
-                        let p = Vec2 {
-                            x: self.viewport.center.x + ring * theta.cos(),
-                            y: self.viewport.center.y + ring * theta.sin(),
-                        };
-                        if !conflict_at(p, &self.field, size, pair_gap) {
-                            pos = p;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        let (pos, needs_pan) = self.pick_spawn_position(size);
 
         let id = self.field.spawn_surface(label.to_string(), pos, size);
         let _ = self
@@ -157,45 +266,94 @@ impl HalleyWlState {
             .set_state(id, halley_core::field::NodeState::Active);
         let _ = self.field.set_decay_level(id, DecayLevel::Hot);
 
-        if self.tuning.new_window_on_top {
-            for old_id in previous_active {
-                let Some(old) = self.field.node(old_id) else {
-                    continue;
-                };
-                let old_pos = old.pos;
-                let old_ext = self.collision_extents_for_node(old);
-                let new_ext = CollisionExtents::symmetric(size);
-                let req_x = self.required_sep_x(pos.x, new_ext, old_pos.x, old_ext, pair_gap);
-                let req_y = self.required_sep_y(pos.y, new_ext, old_pos.y, old_ext, pair_gap);
-                let dx = old_pos.x - pos.x;
-                let dy = old_pos.y - pos.y;
-                if dx.abs() < req_x && dy.abs() < req_y {
-                    let mut target = old_pos;
-                    let overlap_x = req_x - dx.abs();
-                    let overlap_y = req_y - dy.abs();
-                    if overlap_x >= overlap_y {
-                        let dir = if dx >= 0.0 { 1.0 } else { -1.0 };
-                        target.x = pos.x + dir * (req_x + 1.0);
-                    } else {
-                        let dir = if dy >= 0.0 { 1.0 } else { -1.0 };
-                        target.y = pos.y + dir * (req_y + 1.0);
-                    }
-                    let _ = self.field.carry(old_id, target);
-                }
-                let _ = self.field.set_decay_level(old_id, DecayLevel::Cold);
-            }
-        }
-
         self.surface_to_node.insert(key, id);
         self.zoom_nominal_size.insert(id, size);
         self.last_active_size.insert(id, size);
-        let now = Instant::now();
-        self.pending_spawn_activate_at_ms
-            .insert(id, self.now_ms(now).saturating_add(220));
         if self.tuning.dev_anim_enabled {
-            self.animator.observe_field(&self.field, now);
+            self.animator.observe_field(&self.field, Instant::now());
+        }
+        // Island jump: pan the viewport to the new window so the spatial move
+        // feels intentional rather than silently spawning off-screen.
+        if needs_pan {
+            self.queue_spawn_pan_to_node(id, Instant::now());
         }
         id
+    }
+
+    pub(crate) fn queue_spawn_pan_to_node(&mut self, id: NodeId, now: Instant) {
+        let Some(target_center) = self.field.node(id).map(|node| node.pos) else {
+            return;
+        };
+        let _ = self.field.set_detached(id, true);
+        self.pending_spawn_activate_at_ms.remove(&id);
+        self.pending_spawn_pan_queue.push_back(crate::state::PendingSpawnPan {
+            node_id: id,
+            target_center,
+        });
+        self.maybe_start_pending_spawn_pan(now);
+    }
+
+    pub(crate) fn maybe_start_pending_spawn_pan(&mut self, now: Instant) {
+        if self.active_spawn_pan.is_some() {
+            return;
+        }
+
+        let now_ms = self.now_ms(now);
+        while let Some(next) = self.pending_spawn_pan_queue.pop_front() {
+            if self.field.node(next.node_id).is_none() {
+                continue;
+            }
+
+            let did_pan = self.animate_viewport_center_to_delayed(
+                next.target_center,
+                now,
+                Self::VIEWPORT_PAN_PRELOAD_MS,
+            );
+            self.active_spawn_pan = Some(crate::state::ActiveSpawnPan {
+                node_id: next.node_id,
+                pan_start_at_ms: now_ms.saturating_add(if did_pan {
+                    Self::VIEWPORT_PAN_PRELOAD_MS
+                } else {
+                    0
+                }),
+                reveal_at_ms: now_ms.saturating_add(if did_pan {
+                    Self::VIEWPORT_PAN_PRELOAD_MS + Self::VIEWPORT_PAN_DURATION_MS
+                } else {
+                    0
+                }),
+            });
+            break;
+        }
+    }
+
+    pub(crate) fn tick_pending_spawn_pan(&mut self, now: Instant, now_ms: u64) {
+        let Some(active) = self.active_spawn_pan else {
+            self.maybe_start_pending_spawn_pan(now);
+            return;
+        };
+
+        if self.field.node(active.node_id).is_none() {
+            self.active_spawn_pan = None;
+            self.maybe_start_pending_spawn_pan(now);
+            return;
+        }
+
+        let pan_finished = now_ms >= active.reveal_at_ms
+            || (now_ms >= active.pan_start_at_ms && self.viewport_pan_anim.is_none());
+        if !pan_finished {
+            return;
+        }
+
+        let _ = self.field.set_detached(active.node_id, false);
+        let _ = self.field.set_decay_level(active.node_id, DecayLevel::Hot);
+        if let Some(node) = self.field.node(active.node_id) {
+            self.last_active_size.insert(active.node_id, node.intrinsic_size);
+        }
+        self.mark_active_transition(active.node_id, now, 620);
+        self.set_interaction_focus(Some(active.node_id), 30_000, now);
+        self.push_neighbors_for_activation(active.node_id);
+        self.active_spawn_pan = None;
+        self.maybe_start_pending_spawn_pan(now);
     }
 
     pub fn drop_surface(&mut self, surface: &WlSurface) {
@@ -242,5 +400,160 @@ impl HalleyWlState {
             self.smoothed_render_pos.remove(&id);
             let _ = self.field.remove(id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fermat_candidates_cover_all_octants() {
+        let candidates = spawn_fermat_candidates(100.0, 89);
+        let mut octants = [false; 8];
+        for (pos, _) in candidates.iter().skip(1) {
+            let angle = pos.y.atan2(pos.x);
+            let octant = ((angle / (std::f32::consts::PI / 4.0)).rem_euclid(8.0)) as usize;
+            octants[octant.min(7)] = true;
+        }
+        assert!(
+            octants.iter().all(|&covered| covered),
+            "some octants not covered: {:?}",
+            octants
+        );
+    }
+
+    #[test]
+    fn try_spawn_adjacent_prefers_right_then_left() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+
+        let size = Vec2 { x: 100.0, y: 80.0 };
+        let focus = state
+            .field
+            .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, size);
+        let _ = state.field.set_state(focus, halley_core::field::NodeState::Active);
+        state.last_surface_focus_ms.insert(focus, 1);
+        state.interaction_focus = Some(focus);
+
+        // With nothing to the right, adjacent placement should go right.
+        let pos = state.try_spawn_adjacent(size).expect("should fit right");
+        assert!(pos.x > 0.0, "expected right placement, got {:?}", pos);
+        assert_eq!(pos.y, 0.0, "y should match focus");
+    }
+
+    #[test]
+    fn try_spawn_adjacent_falls_back_to_left_when_right_blocked() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+
+        let size = Vec2 { x: 100.0, y: 80.0 };
+        let focus = state
+            .field
+            .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, size);
+        let _ = state.field.set_state(focus, halley_core::field::NodeState::Active);
+        state.last_surface_focus_ms.insert(focus, 1);
+        state.interaction_focus = Some(focus);
+
+        // Block the right slot.
+        let gap = state.non_overlap_gap_world();
+        let right_x = size.x + gap + size.x * 0.5;
+        let _ = state.field.spawn_surface("blocker", Vec2 { x: right_x, y: 0.0 }, size);
+
+        let pos = state.try_spawn_adjacent(size).expect("should fit left");
+        assert!(pos.x < 0.0, "expected left placement, got {:?}", pos);
+    }
+
+
+    #[test]
+    fn try_spawn_fermat_returns_none_when_fully_packed() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+
+        let size = Vec2 { x: 100.0, y: 80.0 };
+        let gap = state.non_overlap_gap_world();
+        let step = ((size.x + gap) * (size.y + gap)).sqrt();
+        // Place blockers at every Fermat candidate position.
+        for (offset, _) in spawn_fermat_candidates(step, HalleyWlState::SPAWN_FERMAT_COUNT) {
+            let pos = Vec2 { x: offset.x, y: offset.y };
+            state.field.spawn_surface("blocker", pos, size);
+        }
+
+        assert!(
+            state.try_spawn_fermat(Vec2 { x: 0.0, y: 0.0 }, size).is_none(),
+            "should return None when all candidates are blocked"
+        );
+    }
+
+    #[test]
+    fn try_spawn_adjacent_skipped_in_view_anchor_mode() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+
+        let size = Vec2 { x: 100.0, y: 80.0 };
+        let focus = state
+            .field
+            .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, size);
+        state.last_surface_focus_ms.insert(focus, 1);
+        state.interaction_focus = Some(focus);
+
+        // Trigger view-anchor mode via a meaningful pan.
+        let now = Instant::now();
+        state.note_pan_activity(now);
+        state.viewport.center = Vec2 { x: 700.0, y: 0.0 };
+        state.note_pan_viewport_change(now);
+
+        assert_eq!(state.spawn_anchor_mode, crate::state::SpawnAnchorMode::View);
+        assert!(
+            state.try_spawn_adjacent(size).is_none(),
+            "adjacent placement should be skipped in view-anchor mode"
+        );
+    }
+
+    #[test]
+    fn current_spawn_focus_uses_view_anchor_after_meaningful_pan_handoff() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        let focused = state.field.spawn_surface(
+            "focused",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 80.0 },
+        );
+        state.last_surface_focus_ms.insert(focused, 1);
+        state.interaction_focus = Some(focused);
+
+        let now = Instant::now();
+        state.note_pan_activity(now);
+        state.viewport.center = Vec2 { x: 700.0, y: 0.0 };
+        state.note_pan_viewport_change(now);
+
+        assert_eq!(state.spawn_anchor_mode, crate::state::SpawnAnchorMode::View);
+        assert_eq!(state.current_spawn_focus(), (None, Vec2 { x: 700.0, y: 0.0 }));
     }
 }

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -9,12 +9,18 @@ use smithay::wayland::selection::primary_selection::set_primary_focus;
 
 pub(crate) struct ViewportPanAnim {
     pub(super) start_ms: u64,
+    pub(super) delay_ms: u64,
     pub(super) duration_ms: u64,
     pub(super) from_center: Vec2,
     pub(super) to_center: Vec2,
 }
 
 impl HalleyWlState {
+    pub(crate) const VIEWPORT_PAN_PRELOAD_MS: u64 = 70;
+    pub(crate) const VIEWPORT_PAN_DURATION_MS: u64 = 260;
+    const SPAWN_VIEW_HANDOFF_PAN_RATIO: f32 = 0.35;
+    const SPAWN_VIEW_HANDOFF_FOCUS_RATIO: f32 = 0.25;
+
     fn wl_surface_for_node(&self, id: NodeId) -> Option<WlSurface> {
         for top in self.xdg_shell_state.toplevel_surfaces() {
             let wl = top.wl_surface().clone();
@@ -110,6 +116,9 @@ impl HalleyWlState {
         self.viewport_pan_anim = None;
         let now_ms = self.now_ms(now);
         self.pan_dominant_until_ms = now_ms.saturating_add(220);
+        self.spawn_last_pan_ms = now_ms;
+        self.spawn_pan_start_center
+            .get_or_insert(self.viewport.center);
         if self.tuning.restore_last_active_on_pan_return {
             if self.pan_restore_active_focus.is_none() {
                 self.pan_restore_active_focus = self.last_focused_active_surface_node();
@@ -119,11 +128,62 @@ impl HalleyWlState {
         self.suspend_state_checks = false;
     }
 
+    fn spawn_view_handoff_pan_distance(&self) -> f32 {
+        self.viewport.size.x.min(self.viewport.size.y) * Self::SPAWN_VIEW_HANDOFF_PAN_RATIO
+    }
+
+    fn spawn_view_handoff_focus_distance(&self) -> f32 {
+        self.viewport.size.x.hypot(self.viewport.size.y) * Self::SPAWN_VIEW_HANDOFF_FOCUS_RATIO
+    }
+
+    pub(crate) fn note_pan_viewport_change(&mut self, _now: Instant) {
+        if self.spawn_anchor_mode == crate::state::SpawnAnchorMode::View {
+            self.spawn_view_anchor = self.viewport.center;
+        }
+        let Some(start_center) = self.spawn_pan_start_center else {
+            return;
+        };
+
+        let moved = ((self.viewport.center.x - start_center.x).powi(2)
+            + (self.viewport.center.y - start_center.y).powi(2))
+        .sqrt();
+        if moved < self.spawn_view_handoff_pan_distance() {
+            return;
+        }
+
+        let focus_far = self
+            .last_input_surface_node()
+            .and_then(|id| self.field.node(id))
+            .map(|node| {
+                let dx = self.viewport.center.x - node.pos.x;
+                let dy = self.viewport.center.y - node.pos.y;
+                dx.hypot(dy) >= self.spawn_view_handoff_focus_distance()
+            })
+            .unwrap_or(true);
+        if !focus_far {
+            return;
+        }
+
+        self.spawn_anchor_mode = crate::state::SpawnAnchorMode::View;
+        self.spawn_view_anchor = self.viewport.center;
+        self.spawn_patch = None;
+        self.spawn_pan_start_center = Some(self.viewport.center);
+    }
+
     pub fn set_pan_restore_focus_target(&mut self, id: NodeId) {
         self.pan_restore_active_focus = Some(id);
     }
 
     pub fn animate_viewport_center_to(&mut self, target_center: Vec2, now: Instant) -> bool {
+        self.animate_viewport_center_to_delayed(target_center, now, 0)
+    }
+
+    pub fn animate_viewport_center_to_delayed(
+        &mut self,
+        target_center: Vec2,
+        now: Instant,
+        delay_ms: u64,
+    ) -> bool {
         let from = self.viewport.center;
         let dx = target_center.x - from.x;
         let dy = target_center.y - from.y;
@@ -132,7 +192,8 @@ impl HalleyWlState {
         }
         self.viewport_pan_anim = Some(ViewportPanAnim {
             start_ms: self.now_ms(now),
-            duration_ms: 260,
+            delay_ms,
+            duration_ms: Self::VIEWPORT_PAN_DURATION_MS,
             from_center: from,
             to_center: target_center,
         });
@@ -143,8 +204,15 @@ impl HalleyWlState {
         let Some(anim) = &self.viewport_pan_anim else {
             return;
         };
+        if now_ms <= anim.start_ms.saturating_add(anim.delay_ms) {
+            self.viewport.center = anim.from_center;
+            self.tuning.viewport_center = self.viewport.center;
+            self.tuning.viewport_size = self.viewport.size;
+            return;
+        }
         let dur = anim.duration_ms.max(1);
-        let t = ((now_ms.saturating_sub(anim.start_ms)) as f32 / dur as f32).clamp(0.0, 1.0);
+        let elapsed_ms = now_ms.saturating_sub(anim.start_ms.saturating_add(anim.delay_ms));
+        let t = (elapsed_ms as f32 / dur as f32).clamp(0.0, 1.0);
         let e = if t < 0.5 {
             4.0 * t * t * t
         } else {
@@ -294,6 +362,8 @@ impl HalleyWlState {
                 self.interaction_focus_until_ms =
                     self.interaction_focus_until_ms.max(requested_until);
                 self.update_focus_tracking_for_surface(fid, now_ms);
+                self.spawn_anchor_mode = crate::state::SpawnAnchorMode::Focus;
+                self.spawn_pan_start_center = None;
                 self.reassert_wayland_keyboard_focus_if_drifted(id);
             } else {
                 self.interaction_focus_until_ms = 0;
@@ -306,6 +376,8 @@ impl HalleyWlState {
         if let Some(fid) = id {
             self.interaction_focus_until_ms = now_ms.saturating_add(hold_ms.max(1));
             self.update_focus_tracking_for_surface(fid, now_ms);
+            self.spawn_anchor_mode = crate::state::SpawnAnchorMode::Focus;
+            self.spawn_pan_start_center = None;
         } else {
             self.interaction_focus_until_ms = 0;
         }

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -376,6 +376,46 @@ impl HalleyWlState {
         })
     }
 
+    fn surface_window_collision_extents(&self, n: &halley_core::field::Node) -> CollisionExtents {
+        let basis = self
+            .last_active_size
+            .get(&n.id)
+            .copied()
+            .unwrap_or(n.intrinsic_size);
+        let (world_per_px_x, world_per_px_y) = self.world_units_per_px_xy();
+        let bbox_w = n.intrinsic_size.x.max(1.0);
+        let bbox_h = n.intrinsic_size.y.max(1.0);
+        let (bbox_lx, bbox_ly) = self.bbox_loc.get(&n.id).copied().unwrap_or((0.0, 0.0));
+        let (geo_lx, geo_ly, geo_w, geo_h) = self
+            .window_geometry
+            .get(&n.id)
+            .copied()
+            .unwrap_or((bbox_lx, bbox_ly, bbox_w, bbox_h));
+
+        let left = (bbox_w * 0.5 + bbox_lx - geo_lx).max(16.0);
+        let right = (geo_lx + geo_w - bbox_lx - bbox_w * 0.5).max(16.0);
+        let top = (bbox_h * 0.5 + bbox_ly - geo_ly).max(16.0);
+        let bottom = (geo_ly + geo_h - bbox_ly - bbox_h * 0.5).max(16.0);
+
+        CollisionExtents {
+            left: left * basis.x.max(1.0) / bbox_w * world_per_px_x,
+            right: right * basis.x.max(1.0) / bbox_w * world_per_px_x,
+            top: top * basis.y.max(1.0) / bbox_h * world_per_px_y,
+            bottom: bottom * basis.y.max(1.0) / bbox_h * world_per_px_y,
+        }
+    }
+
+    pub(crate) fn spawn_obstacle_extents_for_node(
+        &self,
+        n: &halley_core::field::Node,
+    ) -> CollisionExtents {
+        if n.kind == halley_core::field::NodeKind::Surface {
+            self.surface_window_collision_extents(n)
+        } else {
+            self.collision_extents_for_node(n)
+        }
+    }
+
     pub(crate) fn collision_extents_for_node(
         &self,
         n: &halley_core::field::Node,
@@ -391,29 +431,19 @@ impl HalleyWlState {
                     .copied()
                     .unwrap_or(n.intrinsic_size);
                 let s = Self::active_collision_scale(anim.scale, basis.x, basis.y);
-                let (world_per_px_x, world_per_px_y) = self.world_units_per_px_xy();
-                let bbox_w = n.intrinsic_size.x.max(1.0);
-                let bbox_h = n.intrinsic_size.y.max(1.0);
-                let (bbox_lx, bbox_ly) = self.bbox_loc.get(&n.id).copied().unwrap_or((0.0, 0.0));
-                let (geo_lx, geo_ly, geo_w, geo_h) = self
-                    .window_geometry
-                    .get(&n.id)
-                    .copied()
-                    .unwrap_or((bbox_lx, bbox_ly, bbox_w, bbox_h));
-
-                let left = (bbox_w * 0.5 + bbox_lx - geo_lx).max(16.0);
-                let right = (geo_lx + geo_w - bbox_lx - bbox_w * 0.5).max(16.0);
-                let top = (bbox_h * 0.5 + bbox_ly - geo_ly).max(16.0);
-                let bottom = (geo_ly + geo_h - bbox_ly - bbox_h * 0.5).max(16.0);
+                let ext = self.surface_window_collision_extents(n);
 
                 CollisionExtents {
-                    left: left * s * world_per_px_x,
-                    right: right * s * world_per_px_x,
-                    top: top * s * world_per_px_y,
-                    bottom: bottom * s * world_per_px_y,
+                    left: ext.left * s,
+                    right: ext.right * s,
+                    top: ext.top * s,
+                    bottom: ext.bottom * s,
                 }
             }
-            halley_core::field::NodeState::Node | halley_core::field::NodeState::Core => {
+            halley_core::field::NodeState::Node => {
+                self.node_collision_extents(&n.label, anim.scale)
+            }
+            halley_core::field::NodeState::Core => {
                 self.node_collision_extents(&n.label, anim.scale)
             }
             halley_core::field::NodeState::Drifting => CollisionExtents::symmetric(n.footprint),
@@ -633,5 +663,44 @@ impl HalleyWlState {
             top.send_configure();
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapsed_surface_nodes_use_marker_collision_extents() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.zoom_ref_size = Vec2 { x: 1600.0, y: 1200.0 };
+
+        let id = state.field.spawn_surface(
+            "collapsed-firefox",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 1200.0, y: 900.0 },
+        );
+        let _ = state
+            .field
+            .set_state(id, halley_core::field::NodeState::Node);
+
+        let node = state.field.node(id).expect("node");
+        let ext = state.collision_extents_for_node(node);
+
+        assert!(
+            ext.left + ext.right < 300.0,
+            "collapsed node collision width should stay marker-sized, got {:?}",
+            ext
+        );
+        assert!(
+            ext.top + ext.bottom < 120.0,
+            "collapsed node collision height should stay marker-sized, got {:?}",
+            ext
+        );
     }
 }

--- a/examples/halley-finale.rune
+++ b/examples/halley-finale.rune
@@ -206,7 +206,6 @@ end
 # Weighted tile layout used inside clusters.
 tile:
   # Newly opened windows appear with higher priority
-  new-on-top true
 
   gaps:
     inner 8

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -20,7 +20,6 @@ clusters:
 end
 
 tile:
-  new-on-top true
 end
 
 docking:


### PR DESCRIPTION
Rework new toplevel placement so new windows appear in a more predictable order and no longer spawn on
top of existing window geometry. Spawning now follows a clear strategy: try the focused window’s
right/left/below/above edges first, then search outward with a Fermat spiral for evenly distributed
fallback candidates, and finally jump to a new “island” when the local area is packed. When an island
jump happens, the compositor now pans to the new window before revealing and focusing it, so off-
screen spawns feel intentional instead of looking like missing windows.

Tie spawn anchoring to user context instead of a global “new window on top” toggle. Focused-window
placement remains the default, but a sufficiently large manual pan now hands spawning off to the
current viewport center, so launching apps after navigating elsewhere opens them near what the user is
looking at rather than back near the old focus. When focus is restored, spawn anchoring resets back to
focus mode. This also adds delayed viewport-pan support and a queued spawn-pan flow so spawned windows
can be detached, revealed after the pan, then activated cleanly.

Use real window geometry as the obstacle model for spawn collision checks and active overlap
resolution. Active surfaces keep asymmetric collision extents derived from bbox and window geometry,
while collapsed surface nodes use marker-sized collision bounds instead of full window-sized bounds.
The practical effect is better spacing around actual client windows, fewer false collisions from
collapsed nodes, and more accurate non-overlap behavior during spawn, focus changes, and resize
interactions.

Simplify stacking and pointer hit/render ordering by removing tile.new-on-top / new_window_on_top
behavior entirely. Active surfaces are now consistently ordered by node id with “recent top” promotion
applied explicitly, which makes popup targeting, rendering, and focus hit-testing less ambiguous.
Config parsing and example configs were updated to drop the removed setting.

Adjust toplevel creation semantics so regular new windows go through the spawn-pan/reveal path, while
transient child toplevels still become immediately typeable without pushing their parent around.
Maintenance/render ticking was split so viewport-pan animation and pending spawn-pan processing run as
frame effects, and pan input paths now notify the spawn-anchor handoff logic whenever the viewport
moves.

Add tests covering the new placement model: Fermat candidate coverage, adjacent-placement direction
preference and fallback behavior, fully packed spiral failure, view-anchor handoff after panning, and
collapsed-node collision sizing.