### PR TITLE
feat(config): add configurable pointer actions and expand input key aliases

### DIFF
--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -42,6 +42,19 @@ pub struct LaunchBinding {
     pub command: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PointerBindingAction {
+    MoveWindow,
+    ResizeWindow,
+}
+
+#[derive(Clone, Debug)]
+pub struct PointerBinding {
+    pub modifiers: KeyModifiers,
+    pub button: u32,
+    pub action: PointerBindingAction,
+}
+
 impl Default for Keybinds {
     fn default() -> Self {
         Self {
@@ -368,15 +381,38 @@ pub fn key_name_to_evdev(name: &str) -> Option<u32> {
         "insert" => Some(110),
         "delete" => Some(111),
 
+        "mouseleft" | "leftmouse" | "leftbutton" | "btnleft" | "btn_left" => Some(272),
+        "mouseright" | "rightmouse" | "rightbutton" | "btnright" | "btn_right" => Some(273),
+        "mousemiddle" | "middlemouse" | "middlebutton" | "btnmiddle" | "btn_middle" => Some(274),
+        "mouse4" | "mouseback" | "sidebutton" | "btnside" | "btn_side" => Some(275),
+        "mouse5" | "mouseforward" | "extrabutton" | "btnextra" | "btn_extra" => Some(276),
+
         "xf86audiomute" | "audiomute" | "mute" => Some(113),
         "xf86audiolowervolume" | "audiolowervolume" | "volumedown" => Some(114),
         "xf86audioraisevolume" | "audioraisevolume" | "volumeup" => Some(115),
+        "xf86audiostop" | "audiostop" | "stopmedia" => Some(166),
         "xf86audioplay" | "audioplay" | "playpause" => Some(164),
         "xf86audioprev" | "audioprev" | "previoussong" => Some(165),
         "xf86audionext" | "audionext" | "nextsong" => Some(163),
+        "xf86audiorecord" | "audiorecord" => Some(167),
+        "xf86audiorewind" | "audiorewind" | "rewind" => Some(168),
+        "xf86homepage" | "homepage" => Some(172),
+        "xf86search" | "search" => Some(217),
+        "xf86monbrightnessdown" | "brightnessdown" => Some(224),
+        "xf86monbrightnessup" | "brightnessup" => Some(225),
+        "xf86mail" | "mail" => Some(155),
+        "xf86calculator" | "calculator" => Some(140),
+        "xf86sleep" | "sleep" => Some(142),
+        "xf86audiopause" | "audiopause" => Some(201),
+        "xf86audiomicmute" | "audiomicmute" | "micmute" => Some(248),
 
         _ => None,
     }
+}
+
+#[inline]
+pub fn is_pointer_button_code(code: u32) -> bool {
+    matches!(code, 272..=276)
 }
 
 pub fn evdev_to_key_name(code: u32) -> &'static str {
@@ -456,12 +492,72 @@ pub fn evdev_to_key_name(code: u32) -> &'static str {
         109 => "PageDown",
         110 => "Insert",
         111 => "Delete",
+        140 => "XF86Calculator",
+        142 => "XF86Sleep",
+        155 => "XF86Mail",
         113 => "XF86AudioMute",
         114 => "XF86AudioLowerVolume",
         115 => "XF86AudioRaiseVolume",
         163 => "XF86AudioNext",
         164 => "XF86AudioPlay",
         165 => "XF86AudioPrev",
+        166 => "XF86AudioStop",
+        167 => "XF86AudioRecord",
+        168 => "XF86AudioRewind",
+        172 => "XF86HomePage",
+        201 => "XF86AudioPause",
+        217 => "XF86Search",
+        224 => "XF86MonBrightnessDown",
+        225 => "XF86MonBrightnessUp",
+        248 => "XF86AudioMicMute",
+        272 => "MouseLeft",
+        273 => "MouseRight",
+        274 => "MouseMiddle",
+        275 => "MouseBack",
+        276 => "MouseForward",
         _ => "?",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{evdev_to_key_name, key_name_to_evdev, parse_chord, parse_modifiers};
+
+    #[test]
+    fn generic_alt_modifier_matches_either_side_in_config() {
+        let mods = parse_modifiers("alt").expect("alt should parse");
+        assert!(mods.alt);
+        assert!(!mods.left_alt);
+        assert!(!mods.right_alt);
+
+        let (chord_mods, key) = parse_chord("alt+r").expect("alt+r should parse");
+        assert!(chord_mods.alt);
+        assert_eq!(key, 19);
+    }
+
+    #[test]
+    fn mouse_button_aliases_resolve_to_pointer_button_codes() {
+        assert_eq!(key_name_to_evdev("mouseleft"), Some(272));
+        assert_eq!(key_name_to_evdev("btn_right"), Some(273));
+        assert_eq!(key_name_to_evdev("middlemouse"), Some(274));
+        assert_eq!(key_name_to_evdev("mouseback"), Some(275));
+        assert_eq!(key_name_to_evdev("mouseforward"), Some(276));
+    }
+
+    #[test]
+    fn xf86_media_aliases_resolve_to_expected_codes() {
+        assert_eq!(key_name_to_evdev("XF86AudioMute"), Some(113));
+        assert_eq!(key_name_to_evdev("XF86AudioStop"), Some(166));
+        assert_eq!(key_name_to_evdev("XF86AudioPause"), Some(201));
+        assert_eq!(key_name_to_evdev("XF86AudioMicMute"), Some(248));
+        assert_eq!(key_name_to_evdev("XF86MonBrightnessUp"), Some(225));
+    }
+
+    #[test]
+    fn reverse_lookup_uses_canonical_names_for_new_codes() {
+        assert_eq!(evdev_to_key_name(272), "MouseLeft");
+        assert_eq!(evdev_to_key_name(275), "MouseBack");
+        assert_eq!(evdev_to_key_name(166), "XF86AudioStop");
+        assert_eq!(evdev_to_key_name(248), "XF86AudioMicMute");
     }
 }

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -6,7 +6,7 @@ use halley_core::decay::FocusRingDecayPolicy;
 use halley_core::field::Vec2;
 use halley_core::viewport::{FocusRing, Viewport};
 
-use super::{Keybinds, LaunchBinding};
+use super::{KeyModifiers, Keybinds, LaunchBinding, PointerBinding, PointerBindingAction};
 use crate::keybinds::evdev_to_key_name;
 
 #[derive(Clone, Debug)]
@@ -53,6 +53,7 @@ pub struct RuntimeTuning {
     pub keybinds: Keybinds,
     pub keybind_launch_command: String,
     pub launch_bindings: Vec<LaunchBinding>,
+    pub pointer_bindings: Vec<PointerBinding>,
     pub quit_requires_shift: bool,
 
     pub tty_viewports: Vec<ViewportOutputConfig>,
@@ -116,6 +117,7 @@ impl Default for RuntimeTuning {
             keybinds: Keybinds::default(),
             keybind_launch_command: String::new(),
             launch_bindings: Vec::new(),
+            pointer_bindings: default_pointer_bindings(Keybinds::default().modifier),
             quit_requires_shift: true,
 
             tty_viewports: Vec::new(),
@@ -242,6 +244,21 @@ impl RuntimeTuning {
             evdev_to_key_name(kb.move_down),
         )
     }
+}
+
+pub(crate) fn default_pointer_bindings(modifier: KeyModifiers) -> Vec<PointerBinding> {
+    vec![
+        PointerBinding {
+            modifiers: modifier,
+            button: 272,
+            action: PointerBindingAction::MoveWindow,
+        },
+        PointerBinding {
+            modifiers: modifier,
+            button: 273,
+            action: PointerBindingAction::ResizeWindow,
+        },
+    ]
 }
 
 fn default_config_path() -> PathBuf {

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -3,5 +3,5 @@ pub mod layout;
 pub mod legacy;
 pub mod parse;
 
-pub use keybinds::{KeyModifiers, Keybinds, LaunchBinding};
+pub use keybinds::{KeyModifiers, Keybinds, LaunchBinding, PointerBinding, PointerBindingAction};
 pub use layout::{RuntimeTuning, ViewportOutputConfig};

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
-use super::{KeyModifiers, LaunchBinding};
-use crate::keybinds::{key_name_to_evdev, modifiers_empty, parse_chord, parse_modifiers};
-use crate::layout::ViewportOutputConfig;
-use crate::legacy::{parse_legacy_keybinds, strip_legacy_keybind_block};
+use super::{KeyModifiers, LaunchBinding, PointerBinding, PointerBindingAction};
 use crate::RuntimeTuning;
+use crate::keybinds::{
+    is_pointer_button_code, key_name_to_evdev, modifiers_empty, parse_chord, parse_modifiers,
+};
+use crate::layout::{ViewportOutputConfig, default_pointer_bindings};
+use crate::legacy::{parse_legacy_keybinds, strip_legacy_keybind_block};
 
 use rune_cfg::RuneConfig;
 
@@ -388,6 +390,7 @@ fn load_physics_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 fn load_keybind_sections(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.keybinds.modifier = pick_modifiers(cfg, &["keybinds.mod"], out.keybinds.modifier);
     out.launch_bindings.clear();
+    out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
     apply_explicit_keybind_overrides(cfg, out);
 }
 
@@ -466,11 +469,7 @@ fn parse_viewport_outputs(cfg: &RuneConfig, root: &str) -> Vec<ViewportOutputCon
                 ],
                 0.0,
             );
-            if v > 0.0 {
-                Some(v as f64)
-            } else {
-                None
-            }
+            if v > 0.0 { Some(v as f64) } else { None }
         };
 
         out.push(ViewportOutputConfig {
@@ -585,6 +584,7 @@ fn apply_explicit_keybind_overrides_map(
 
     if let Some(m) = parse_modifiers(mod_token.as_str()) {
         out.keybinds.modifier = m;
+        out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
     }
 
     for (chord, action) in bindings {
@@ -640,6 +640,12 @@ fn apply_explicit_binding(
             out.keybinds.quit = key;
             out.quit_requires_shift = effective_mods.shift;
         }
+        "move_window" | "move-window" if is_pointer_button_code(key) => {
+            upsert_pointer_binding(out, effective_mods, key, PointerBindingAction::MoveWindow);
+        }
+        "resize_window" | "resize-window" if is_pointer_button_code(key) => {
+            upsert_pointer_binding(out, effective_mods, key, PointerBindingAction::ResizeWindow);
+        }
         _ => {
             out.keybind_launch_command = action_trimmed.to_string();
             upsert_launch_binding(out, effective_mods, key, action_trimmed);
@@ -661,5 +667,27 @@ fn upsert_launch_binding(out: &mut RuntimeTuning, mods: KeyModifiers, key: u32, 
         modifiers: mods,
         key,
         command: command.to_string(),
+    });
+}
+
+fn upsert_pointer_binding(
+    out: &mut RuntimeTuning,
+    mods: KeyModifiers,
+    button: u32,
+    action: PointerBindingAction,
+) {
+    if let Some(existing) = out
+        .pointer_bindings
+        .iter_mut()
+        .find(|b| b.button == button && b.modifiers == mods)
+    {
+        existing.action = action;
+        return;
+    }
+
+    out.pointer_bindings.push(PointerBinding {
+        modifiers: mods,
+        button,
+        action,
     });
 }

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 use eventline::info;
+use halley_config::PointerBindingAction;
 use smithay::input::pointer::{ButtonEvent, MotionEvent};
 use smithay::utils::SERIAL_COUNTER;
 
@@ -93,17 +94,26 @@ fn dispatch_pointer_button(
 }
 
 #[inline]
-fn compositor_button_binding_matches(
+fn matching_pointer_binding(
     st: &HalleyWlState,
     mods: &ModState,
     button_code: u32,
-) -> bool {
-    matches!(button_code, 0x110 | 0x111) && modifier_active(mods, st.tuning.keybinds.modifier)
+) -> Option<PointerBindingAction> {
+    st.tuning
+        .pointer_bindings
+        .iter()
+        .find(|binding| binding.button == button_code && modifier_active(mods, binding.modifiers))
+        .map(|binding| binding.action)
 }
 
-fn title_click_is_double(ps: &PointerState, node_id: halley_core::field::NodeId, now: Instant) -> bool {
+fn title_click_is_double(
+    ps: &PointerState,
+    node_id: halley_core::field::NodeId,
+    now: Instant,
+) -> bool {
     ps.last_title_click.is_some_and(|last| {
-        last.node_id == node_id && now.duration_since(last.at).as_millis() as u64 <= NODE_DOUBLE_CLICK_MS
+        last.node_id == node_id
+            && now.duration_since(last.at).as_millis() as u64 <= NODE_DOUBLE_CLICK_MS
     })
 }
 
@@ -167,16 +177,24 @@ fn begin_resize(
     };
     let fallback_size = n.intrinsic_size;
     let fallback_pos = n.pos;
-    let (start_left, start_top, start_right, start_bottom) =
-        active_node_screen_rect(st, frame.ws_w, frame.ws_h, hit.node_id, Instant::now(), None).unwrap_or_else(|| {
-            let center_scr = world_to_screen(st, frame.ws_w, frame.ws_h, fallback_pos.x, fallback_pos.y);
-            (
-                (center_scr.0 as f32) - fallback_size.x * 0.5,
-                (center_scr.1 as f32) - fallback_size.y * 0.5,
-                (center_scr.0 as f32) + fallback_size.x * 0.5,
-                (center_scr.1 as f32) + fallback_size.y * 0.5,
-            )
-        });
+    let (start_left, start_top, start_right, start_bottom) = active_node_screen_rect(
+        st,
+        frame.ws_w,
+        frame.ws_h,
+        hit.node_id,
+        Instant::now(),
+        None,
+    )
+    .unwrap_or_else(|| {
+        let center_scr =
+            world_to_screen(st, frame.ws_w, frame.ws_h, fallback_pos.x, fallback_pos.y);
+        (
+            (center_scr.0 as f32) - fallback_size.x * 0.5,
+            (center_scr.1 as f32) - fallback_size.y * 0.5,
+            (center_scr.0 as f32) + fallback_size.x * 0.5,
+            (center_scr.1 as f32) + fallback_size.y * 0.5,
+        )
+    });
     let handle = pick_resize_handle_from_screen(
         (start_left, start_top, start_right, start_bottom),
         (frame.sx, frame.sy),
@@ -188,10 +206,11 @@ fn begin_resize(
     st.begin_resize_interaction(hit.node_id, Instant::now());
     let start_w = (start_right - start_left).max(96.0).round() as i32;
     let start_h = (start_bottom - start_top).max(72.0).round() as i32;
-    let start_surface = current_surface_size_for_node(st, hit.node_id).unwrap_or(halley_core::field::Vec2 {
-        x: start_w as f32,
-        y: start_h as f32,
-    });
+    let start_surface =
+        current_surface_size_for_node(st, hit.node_id).unwrap_or(halley_core::field::Vec2 {
+            x: start_w as f32,
+            y: start_h as f32,
+        });
     let (start_geo_lx, start_geo_ly, _, _) = window_geometry_for_node(st, hit.node_id).unwrap_or((
         0.0,
         0.0,
@@ -363,7 +382,7 @@ fn handle_left_press(
     st: &mut HalleyWlState,
     ps: &mut PointerState,
     backend: &dyn BackendView,
-    mods: &ModState,
+    drag_binding_active: bool,
     hit: Option<HitNode>,
     frame: ButtonFrame,
 ) {
@@ -378,8 +397,7 @@ fn handle_left_press(
         return;
     }
 
-    let drag_mod_ok = modifier_active(mods, st.tuning.keybinds.modifier);
-    if !drag_mod_ok
+    if !drag_binding_active
         && st.field.node(hit.node_id).is_some_and(|n| {
             n.kind == halley_core::field::NodeKind::Surface && st.field.is_visible(hit.node_id)
         })
@@ -388,7 +406,7 @@ fn handle_left_press(
     }
 
     let mut handled_node_click = false;
-    if !drag_mod_ok && !hit.on_titlebar && !hit.is_core {
+    if !drag_binding_active && !hit.on_titlebar && !hit.is_core {
         let is_node = st
             .field
             .node(hit.node_id)
@@ -406,7 +424,7 @@ fn handle_left_press(
     let drag_target_ok = st.field.node(hit.node_id).is_some_and(|n| {
         n.kind == halley_core::field::NodeKind::Surface && st.field.is_visible(hit.node_id)
     });
-    if drag_mod_ok && drag_target_ok && !handled_node_click {
+    if drag_binding_active && drag_target_ok && !handled_node_click {
         begin_drag(st, ps, backend, hit, frame.world_now);
     }
 
@@ -431,7 +449,7 @@ fn handle_right_press(
     st: &mut HalleyWlState,
     ps: &mut PointerState,
     backend: &dyn BackendView,
-    mods: &ModState,
+    resize_binding_active: bool,
     hit: Option<HitNode>,
     frame: ButtonFrame,
 ) {
@@ -449,8 +467,59 @@ fn handle_right_press(
         .field
         .node(hit.node_id)
         .is_some_and(|n| n.state == halley_core::field::NodeState::Active);
-    let resize_mod_ok = modifier_active(mods, st.tuning.keybinds.modifier);
-    if resize_mod_ok && can_resize {
+    if resize_binding_active && can_resize {
+        begin_resize(st, ps, backend, hit, frame);
+    }
+}
+
+fn handle_move_binding_press(
+    st: &mut HalleyWlState,
+    ps: &mut PointerState,
+    backend: &dyn BackendView,
+    hit: Option<HitNode>,
+    frame: ButtonFrame,
+) {
+    if frame.workspace_active {
+        clear_pointer_activity(st, ps);
+        return;
+    }
+
+    let Some(hit) = hit else {
+        ps.panning = true;
+        ps.pan_last_screen = (frame.sx, frame.sy);
+        ps.last_title_click = None;
+        return;
+    };
+    let drag_target_ok = st.field.node(hit.node_id).is_some_and(|n| {
+        n.kind == halley_core::field::NodeKind::Surface && st.field.is_visible(hit.node_id)
+    });
+    if drag_target_ok {
+        begin_drag(st, ps, backend, hit, frame.world_now);
+    }
+}
+
+fn handle_resize_binding_press(
+    st: &mut HalleyWlState,
+    ps: &mut PointerState,
+    backend: &dyn BackendView,
+    hit: Option<HitNode>,
+    frame: ButtonFrame,
+) {
+    if frame.workspace_active {
+        clear_pointer_activity(st, ps);
+        return;
+    }
+
+    let Some(hit) = hit else {
+        ps.panning = true;
+        ps.pan_last_screen = (frame.sx, frame.sy);
+        return;
+    };
+    let can_resize = st
+        .field
+        .node(hit.node_id)
+        .is_some_and(|n| n.state == halley_core::field::NodeState::Active);
+    if can_resize {
         begin_resize(st, ps, backend, hit, frame);
     }
 }
@@ -459,31 +528,38 @@ fn handle_button_release(
     st: &mut HalleyWlState,
     ps: &mut PointerState,
     backend: &dyn BackendView,
-    left: bool,
-    right: bool,
+    button_code: u32,
+    action: Option<PointerBindingAction>,
     world_now: halley_core::field::Vec2,
 ) {
-    if left {
-        if let Some(d) = ps.drag {
-            let now = Instant::now();
-            if d.started_active {
-                st.finalize_mouse_drag_state(d.node_id, world_now, now);
-            } else {
-                st.update_carry_state_preview_at(d.node_id, world_now, now);
+    match action {
+        Some(PointerBindingAction::MoveWindow) => {
+            if let Some(d) = ps.drag {
+                let now = Instant::now();
+                if d.started_active {
+                    st.finalize_mouse_drag_state(d.node_id, world_now, now);
+                } else {
+                    st.update_carry_state_preview_at(d.node_id, world_now, now);
+                }
+                let _ = st.field.finalize_dock_on_drag_release(d.node_id);
+                st.end_carry_state_tracking(d.node_id);
+                ps.preview_block_until = Some(now + Duration::from_millis(360));
             }
-            let _ = st.field.finalize_dock_on_drag_release(d.node_id);
-            st.end_carry_state_tracking(d.node_id);
-            ps.preview_block_until = Some(now + Duration::from_millis(360));
+            ps.drag = None;
+            st.field.clear_dock_preview();
+            ps.panning = false;
+            if ps.resize.is_some() {
+                finalize_resize(st, ps, backend);
+            }
         }
-        ps.drag = None;
-        st.field.clear_dock_preview();
-        ps.panning = false;
-        if ps.resize.is_some() {
+        Some(PointerBindingAction::ResizeWindow) => {
             finalize_resize(st, ps, backend);
         }
-    }
-    if right {
-        finalize_resize(st, ps, backend);
+        None => {
+            if button_code == 0x110 || button_code == 0x111 {
+                ps.panning = false;
+            }
+        }
     }
 }
 
@@ -513,20 +589,20 @@ pub(crate) fn handle_pointer_button_input(
         workspace_active: st.has_active_cluster_workspace(),
     };
     let mods = mod_state.borrow().clone();
-    let intercepted = match button_state {
-        ButtonState::Pressed => compositor_button_binding_matches(st, &mods, button_code),
+    let matched_action = match button_state {
+        ButtonState::Pressed => matching_pointer_binding(st, &mods, button_code),
         ButtonState::Released => ps.intercepted_buttons.remove(&button_code),
     };
-    if matches!(button_state, ButtonState::Pressed) && intercepted {
-        ps.intercepted_buttons.insert(button_code);
+    let intercepted = matched_action.is_some();
+    if matches!(button_state, ButtonState::Pressed)
+        && let Some(action) = matched_action
+    {
+        ps.intercepted_buttons.insert(button_code, action);
     }
     if !intercepted {
         dispatch_pointer_button(st, frame, ps.resize, button_code, button_state);
     }
     ps.world = world_now;
-    if !left && !right {
-        return;
-    }
     if matches!(button_state, ButtonState::Pressed)
         && !intercepted
         && let Some((surface, _)) = layer_focus
@@ -556,12 +632,29 @@ pub(crate) fn handle_pointer_button_input(
                     st,
                     &mut ps,
                     backend,
-                    &mods,
+                    matches!(matched_action, Some(PointerBindingAction::MoveWindow)),
                     hit,
                     frame,
                 );
             } else if right {
-                handle_right_press(st, &mut ps, backend, &mods, hit, frame);
+                handle_right_press(
+                    st,
+                    &mut ps,
+                    backend,
+                    matches!(matched_action, Some(PointerBindingAction::ResizeWindow)),
+                    hit,
+                    frame,
+                );
+            } else {
+                match matched_action {
+                    Some(PointerBindingAction::MoveWindow) => {
+                        handle_move_binding_press(st, &mut ps, backend, hit, frame);
+                    }
+                    Some(PointerBindingAction::ResizeWindow) => {
+                        handle_resize_binding_press(st, &mut ps, backend, hit, frame);
+                    }
+                    None => {}
+                }
             }
         }
         ButtonState::Released => {
@@ -580,7 +673,7 @@ pub(crate) fn handle_pointer_button_input(
                     ps.panning
                 );
             }
-            handle_button_release(st, &mut ps, backend, left, right, world_now);
+            handle_button_release(st, &mut ps, backend, button_code, matched_action, world_now);
         }
     }
 }

--- a/crates/halley-wl/src/input/pointer_focus.rs
+++ b/crates/halley-wl/src/input/pointer_focus.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use eventline::info;
-use smithay::desktop::{utils::under_from_surface_tree, PopupManager, WindowSurfaceType};
+use smithay::desktop::{PopupManager, WindowSurfaceType, utils::under_from_surface_tree};
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Logical, Point};
 

--- a/crates/halley-wl/src/interaction/types.rs
+++ b/crates/halley-wl/src/interaction/types.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
+use halley_config::PointerBindingAction;
+
 #[derive(Default, Clone)]
 pub(crate) struct ModState {
     pub(crate) super_down: bool,
@@ -111,7 +113,7 @@ pub(crate) struct PointerState {
     /// Pointer buttons whose press was intercepted by the compositor. The
     /// matching release must also be intercepted so clients do not receive a
     /// stray release after a compositor-owned drag/resize gesture.
-    pub(crate) intercepted_buttons: HashSet<u32>,
+    pub(crate) intercepted_buttons: HashMap<u32, PointerBindingAction>,
     pub(crate) drag: Option<DragCtx>,
     pub(crate) resize: Option<ResizeCtx>,
     pub(crate) move_anim: HashMap<halley_core::field::NodeId, NodeMoveAnim>,
@@ -132,7 +134,7 @@ impl Default for PointerState {
             screen: (0.0, 0.0),
             workspace_size: (1, 1),
             hover_node: None,
-            intercepted_buttons: HashSet::new(),
+            intercepted_buttons: HashMap::new(),
             drag: None,
             resize: None,
             move_anim: HashMap::new(),

--- a/crates/halley-wl/src/render/frame_render.rs
+++ b/crates/halley-wl/src/render/frame_render.rs
@@ -54,8 +54,9 @@ struct SceneCollections {
 
 struct CursorScene {
     cursor_status: smithay::input::pointer::CursorImageStatus,
-    cursor_surface_elements:
-        Vec<smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement<GlesRenderer>>,
+    cursor_surface_elements: Vec<
+        smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement<GlesRenderer>,
+    >,
 }
 
 fn draw_clamped_border_rect<F: smithay::backend::renderer::Frame>(
@@ -193,20 +194,8 @@ pub(crate) fn draw_debug_frame_to_target(
     let mut frame = renderer.render(framebuffer, size, frame_transform)?;
     frame.clear(Color32F::new(0.04, 0.05, 0.06, 1.0), &[prepared.damage])?;
 
-    draw_debug_frame_scene(
-        &mut frame,
-        st,
-        size,
-        &prepared,
-        &scene,
-        hover_node,
-    )?;
-    draw_cursor_layer(
-        &mut frame,
-        prepared.damage,
-        cursor_screen,
-        &cursor,
-    )?;
+    draw_debug_frame_scene(&mut frame, st, size, &prepared, &scene, hover_node)?;
+    draw_cursor_layer(&mut frame, prepared.damage, cursor_screen, &cursor)?;
 
     let _ = frame.finish()?;
     Ok(())
@@ -336,8 +325,7 @@ fn draw_debug_frame_scene(
     prepared: &PreparedFrameState,
     scene: &SceneCollections,
     hover_node: Option<halley_core::field::NodeId>,
-) -> Result<(), Box<dyn Error>>
-{
+) -> Result<(), Box<dyn Error>> {
     if !scene.layer_under_elements.is_empty() {
         let _ = draw_render_elements(frame, 1.0, &scene.layer_under_elements, &[prepared.damage]);
     }
@@ -514,8 +502,7 @@ fn draw_cursor_layer(
     damage: Rectangle<i32, Physical>,
     cursor_screen: Option<(f32, f32)>,
     cursor: &CursorScene,
-) -> Result<(), Box<dyn Error>>
-{
+) -> Result<(), Box<dyn Error>> {
     if let Some((sx, sy)) = cursor_screen {
         let draw_fallback_arrow = match &cursor.cursor_status {
             smithay::input::pointer::CursorImageStatus::Hidden => false,

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -4,11 +4,11 @@ use std::time::Instant;
 
 use smithay::{
     backend::renderer::{
-        element::{surface::render_elements_from_surface_tree, utils::CropRenderElement, Kind},
-        gles::GlesRenderer,
         Color32F, Frame,
+        element::{Kind, surface::render_elements_from_surface_tree, utils::CropRenderElement},
+        gles::GlesRenderer,
     },
-    desktop::{utils::bbox_from_surface_tree, PopupManager},
+    desktop::{PopupManager, utils::bbox_from_surface_tree},
     reexports::wayland_server::Resource,
     utils::{Physical, Rectangle, Size},
 };

--- a/crates/halley-wl/src/run/drm.rs
+++ b/crates/halley-wl/src/run/drm.rs
@@ -211,10 +211,10 @@ pub(super) fn select_tty_scanout(
                 .find(|(_, info)| info.to_string() == wanted.connector)
             {
                 let Some(mode) = info.modes().iter().copied().find(|m| {
-                        m.size() == (wanted.width as u16, wanted.height as u16)
-                            && wanted
-                                .refresh_rate
-                                .is_none_or(|hz| (m.vrefresh() as f64 - hz).abs() < 1.0)
+                    m.size() == (wanted.width as u16, wanted.height as u16)
+                        && wanted
+                            .refresh_rate
+                            .is_none_or(|hz| (m.vrefresh() as f64 - hz).abs() < 1.0)
                 }) else {
                     return Err(io::Error::other(format!(
                         "configured viewport {} requests {}x{}, but no such mode is available",

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -421,7 +421,8 @@ impl HalleyWlState {
             .resize_static_node
             .is_some_and(|_| now_ms < self.resize_static_until_ms);
         if resize_settling
-            && let (Some(id), Some(lock_pos)) = (self.resize_static_node, self.resize_static_lock_pos)
+            && let (Some(id), Some(lock_pos)) =
+                (self.resize_static_node, self.resize_static_lock_pos)
             && let Some(n) = self.field.node(id)
             && ((n.pos.x - lock_pos.x).abs() > 0.05 || (n.pos.y - lock_pos.y).abs() > 0.05)
         {

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -297,19 +297,37 @@ mod tests {
 
     #[test]
     fn clamp_initial_window_size_raises_tiny_windows() {
-        let out = clamp_initial_window_size(Vec2 { x: 1600.0, y: 1200.0 }, (220, 180));
+        let out = clamp_initial_window_size(
+            Vec2 {
+                x: 1600.0,
+                y: 1200.0,
+            },
+            (220, 180),
+        );
         assert_eq!(out, (480, 312));
     }
 
     #[test]
     fn clamp_initial_window_size_trims_short_wide_windows() {
-        let out = clamp_initial_window_size(Vec2 { x: 1600.0, y: 1200.0 }, (1600, 240));
+        let out = clamp_initial_window_size(
+            Vec2 {
+                x: 1600.0,
+                y: 1200.0,
+            },
+            (1600, 240),
+        );
         assert_eq!(out, (1312, 312));
     }
 
     #[test]
     fn clamp_initial_window_size_preserves_sensible_windows() {
-        let out = clamp_initial_window_size(Vec2 { x: 1600.0, y: 1200.0 }, (900, 700));
+        let out = clamp_initial_window_size(
+            Vec2 {
+                x: 1600.0,
+                y: 1200.0,
+            },
+            (900, 700),
+        );
         assert_eq!(out, (900, 700));
     }
 }

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use halley_core::decay::DecayLevel;
 use halley_core::field::{NodeId, Vec2};
 use smithay::reexports::wayland_server::{
-    backend::ObjectId, protocol::wl_surface::WlSurface, Resource,
+    Resource, backend::ObjectId, protocol::wl_surface::WlSurface,
 };
 
 use crate::activity::CommitActivity;
@@ -103,10 +103,22 @@ impl HalleyWlState {
         let nx = size.x * 0.5;
         let ny = size.y * 0.5;
         let candidates = [
-            Vec2 { x: focus_pos.x + fx + gap + nx, y: focus_pos.y }, // right
-            Vec2 { x: focus_pos.x - fx - gap - nx, y: focus_pos.y }, // left
-            Vec2 { x: focus_pos.x, y: focus_pos.y + fy + gap + ny }, // below
-            Vec2 { x: focus_pos.x, y: focus_pos.y - fy - gap - ny }, // above
+            Vec2 {
+                x: focus_pos.x + fx + gap + nx,
+                y: focus_pos.y,
+            }, // right
+            Vec2 {
+                x: focus_pos.x - fx - gap - nx,
+                y: focus_pos.y,
+            }, // left
+            Vec2 {
+                x: focus_pos.x,
+                y: focus_pos.y + fy + gap + ny,
+            }, // below
+            Vec2 {
+                x: focus_pos.x,
+                y: focus_pos.y - fy - gap - ny,
+            }, // above
         ];
         candidates
             .into_iter()
@@ -150,9 +162,18 @@ impl HalleyWlState {
         // Try the current growth direction, then 90° rotations.
         let rotations: [Vec2; 4] = [
             base_dir,
-            Vec2 { x: -base_dir.y, y: base_dir.x },
-            Vec2 { x: -base_dir.x, y: -base_dir.y },
-            Vec2 { x: base_dir.y, y: -base_dir.x },
+            Vec2 {
+                x: -base_dir.y,
+                y: base_dir.x,
+            },
+            Vec2 {
+                x: -base_dir.x,
+                y: -base_dir.y,
+            },
+            Vec2 {
+                x: base_dir.y,
+                y: -base_dir.x,
+            },
         ];
         for dir in rotations {
             let island_center = Vec2 {
@@ -274,10 +295,11 @@ impl HalleyWlState {
         };
         let _ = self.field.set_detached(id, true);
         self.pending_spawn_activate_at_ms.remove(&id);
-        self.pending_spawn_pan_queue.push_back(crate::state::PendingSpawnPan {
-            node_id: id,
-            target_center,
-        });
+        self.pending_spawn_pan_queue
+            .push_back(crate::state::PendingSpawnPan {
+                node_id: id,
+                target_center,
+            });
         self.maybe_start_pending_spawn_pan(now);
     }
 
@@ -335,7 +357,8 @@ impl HalleyWlState {
         let _ = self.field.set_detached(active.node_id, false);
         let _ = self.field.set_decay_level(active.node_id, DecayLevel::Hot);
         if let Some(node) = self.field.node(active.node_id) {
-            self.last_active_size.insert(active.node_id, node.intrinsic_size);
+            self.last_active_size
+                .insert(active.node_id, node.intrinsic_size);
         }
         self.mark_active_transition(active.node_id, now, 620);
         self.set_interaction_focus(Some(active.node_id), 30_000, now);
@@ -419,13 +442,18 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let size = Vec2 { x: 100.0, y: 80.0 };
         let focus = state
             .field
             .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, size);
-        let _ = state.field.set_state(focus, halley_core::field::NodeState::Active);
+        let _ = state
+            .field
+            .set_state(focus, halley_core::field::NodeState::Active);
         state.last_surface_focus_ms.insert(focus, 1);
         state.interaction_focus = Some(focus);
 
@@ -443,25 +471,31 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let size = Vec2 { x: 100.0, y: 80.0 };
         let focus = state
             .field
             .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, size);
-        let _ = state.field.set_state(focus, halley_core::field::NodeState::Active);
+        let _ = state
+            .field
+            .set_state(focus, halley_core::field::NodeState::Active);
         state.last_surface_focus_ms.insert(focus, 1);
         state.interaction_focus = Some(focus);
 
         // Block the right slot.
         let gap = state.non_overlap_gap_world();
         let right_x = size.x + gap + size.x * 0.5;
-        let _ = state.field.spawn_surface("blocker", Vec2 { x: right_x, y: 0.0 }, size);
+        let _ = state
+            .field
+            .spawn_surface("blocker", Vec2 { x: right_x, y: 0.0 }, size);
 
         let pos = state.try_spawn_adjacent(size).expect("should fit left");
         assert!(pos.x < 0.0, "expected left placement, got {:?}", pos);
     }
-
 
     #[test]
     fn try_spawn_fermat_returns_none_when_fully_packed() {
@@ -471,19 +505,27 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let size = Vec2 { x: 100.0, y: 80.0 };
         let gap = state.non_overlap_gap_world();
         let step = ((size.x + gap) * (size.y + gap)).sqrt();
         // Place blockers at every Fermat candidate position.
         for (offset, _) in spawn_fermat_candidates(step, HalleyWlState::SPAWN_FERMAT_COUNT) {
-            let pos = Vec2 { x: offset.x, y: offset.y };
+            let pos = Vec2 {
+                x: offset.x,
+                y: offset.y,
+            };
             state.field.spawn_surface("blocker", pos, size);
         }
 
         assert!(
-            state.try_spawn_fermat(Vec2 { x: 0.0, y: 0.0 }, size).is_none(),
+            state
+                .try_spawn_fermat(Vec2 { x: 0.0, y: 0.0 }, size)
+                .is_none(),
             "should return None when all candidates are blocked"
         );
     }
@@ -495,7 +537,10 @@ mod tests {
             .expect("display")
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let size = Vec2 { x: 100.0, y: 80.0 };
         let focus = state
@@ -542,7 +587,10 @@ mod tests {
         state.note_pan_viewport_change(now);
 
         assert_eq!(state.spawn_anchor_mode, crate::state::SpawnAnchorMode::View);
-        assert_eq!(state.current_spawn_focus(), (None, Vec2 { x: 700.0, y: 0.0 }));
+        assert_eq!(
+            state.current_spawn_focus(),
+            (None, Vec2 { x: 700.0, y: 0.0 })
+        );
     }
 
     #[test]
@@ -565,7 +613,9 @@ mod tests {
 
         assert_eq!(state.current_spawn_focus(), (None, state.viewport.center));
         assert!(
-            state.try_spawn_adjacent(Vec2 { x: 100.0, y: 80.0 }).is_none(),
+            state
+                .try_spawn_adjacent(Vec2 { x: 100.0, y: 80.0 })
+                .is_none(),
             "adjacent placement should be skipped when focused surface is off-screen"
         );
     }

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -119,8 +119,7 @@ impl HalleyWlState {
         self.spawn_last_pan_ms = now_ms;
         self.spawn_pan_start_center
             .get_or_insert(self.viewport.center);
-        if self.tuning.restore_last_active_on_pan_return
-            && self.pan_restore_active_focus.is_none()
+        if self.tuning.restore_last_active_on_pan_return && self.pan_restore_active_focus.is_none()
         {
             self.pan_restore_active_focus = self.last_focused_active_surface_node();
         }

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -677,13 +677,22 @@ mod tests {
             .expect("display")
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
-        state.zoom_ref_size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        state.zoom_ref_size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let id = state.field.spawn_surface(
             "collapsed-firefox",
             Vec2 { x: 0.0, y: 0.0 },
-            Vec2 { x: 1200.0, y: 900.0 },
+            Vec2 {
+                x: 1200.0,
+                y: 900.0,
+            },
         );
         let _ = state
             .field


### PR DESCRIPTION
- add mouse button aliases for left, right, middle, back, and forward buttons in config key parsing
- expand supported XF86/media key aliases including volume, mute, stop, pause, mic mute, brightness, mail, calculator, sleep, homepage, and search
- keep generic modifier tokens like `alt` resolving to either side while preserving explicit left/right variants
- add first-class pointer binding actions for `move_window` and `resize_window`
- keep pointer bindings under `keybinds` and seed default modifier+left/move and modifier+right/resize behavior from config defaults
- route compositor pointer gesture handling through configured pointer bindings instead of hardcoded button checks
- track intercepted pointer button actions through press/release so compositor-owned drags and resizes remain paired correctly
- add tests for generic modifier parsing, mouse button aliases, XF86 aliases, and canonical reverse key names