### PR TITLE
feat(physics,input): add held docking controls and physics-backed node move commands

### DIFF
--- a/crates/halley-cli/src/main.rs
+++ b/crates/halley-cli/src/main.rs
@@ -1,5 +1,6 @@
 use halley_ipc::{
-    LogicalOutputInfo, OutputInfo, OutputStatus, OutputsResponse, Request, Response, send_request,
+    LogicalOutputInfo, NodeMoveDirection, OutputInfo, OutputStatus, OutputsResponse, Request,
+    Response, send_request,
 };
 
 fn main() {
@@ -9,6 +10,30 @@ fn main() {
         Some("quit") => Request::Quit,
         Some("reload") => Request::Reload,
         Some("outputs") => Request::Outputs,
+        Some("docking") => match args.next().as_deref() {
+            Some("begin") => Request::DockingBegin,
+            Some("end") => Request::DockingEnd,
+            _ => {
+                eprintln!("usage: halleyctl docking begin|end");
+                std::process::exit(2);
+            }
+        },
+        Some("node") => match args.next().as_deref() {
+            Some("move") => match args.next().as_deref() {
+                Some("left") => Request::NodeMove(NodeMoveDirection::Left),
+                Some("right") => Request::NodeMove(NodeMoveDirection::Right),
+                Some("up") => Request::NodeMove(NodeMoveDirection::Up),
+                Some("down") => Request::NodeMove(NodeMoveDirection::Down),
+                _ => {
+                    eprintln!("usage: halleyctl node move left|right|up|down");
+                    std::process::exit(2);
+                }
+            },
+            _ => {
+                eprintln!("usage: halleyctl node move left|right|up|down");
+                std::process::exit(2);
+            }
+        },
         Some("help") | Some("--help") | Some("-h") | None => {
             print_help();
             return;
@@ -41,11 +66,19 @@ fn print_help() {
     println!("  halleyctl quit");
     println!("  halleyctl reload");
     println!("  halleyctl outputs");
+    println!("  halleyctl docking begin");
+    println!("  halleyctl docking end");
+    println!("  halleyctl node move left");
+    println!("  halleyctl node move right");
+    println!("  halleyctl node move up");
+    println!("  halleyctl node move down");
     println!();
     println!("Commands:");
     println!("  quit      Ask the running Halley compositor to exit");
     println!("  reload    Ask the running Halley compositor to reload config");
     println!("  outputs   Print current output information from the running Halley compositor");
+    println!("  docking   Control compositor docking state");
+    println!("  node      Run node-scoped commands");
 }
 
 fn print_response(response: Response) -> Result<(), String> {

--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -18,9 +18,15 @@ pub struct KeyModifiers {
 pub struct Keybinds {
     pub modifier: KeyModifiers,
     pub reload: u32,
+    pub reload_modifiers: KeyModifiers,
     pub minimize_focused: u32,
+    pub minimize_focused_modifiers: KeyModifiers,
     pub overview_toggle: u32,
+    pub overview_toggle_modifiers: KeyModifiers,
     pub quit: u32,
+    pub quit_modifiers: KeyModifiers,
+    pub docking: u32,
+    pub docking_modifiers: KeyModifiers,
     pub primary_left: u32,
     pub primary_right: u32,
     pub primary_up: u32,
@@ -30,9 +36,13 @@ pub struct Keybinds {
     pub secondary_up: u32,
     pub secondary_down: u32,
     pub move_left: u32,
+    pub move_left_modifiers: KeyModifiers,
     pub move_right: u32,
+    pub move_right_modifiers: KeyModifiers,
     pub move_up: u32,
+    pub move_up_modifiers: KeyModifiers,
     pub move_down: u32,
+    pub move_down_modifiers: KeyModifiers,
 }
 
 #[derive(Clone, Debug)]
@@ -57,27 +67,38 @@ pub struct PointerBinding {
 
 impl Default for Keybinds {
     fn default() -> Self {
+        let modifier = KeyModifiers {
+            left_alt: true,
+            ..KeyModifiers::default()
+        };
         Self {
-            modifier: KeyModifiers {
-                left_alt: true,
-                ..KeyModifiers::default()
-            },
-            reload: 19,           // r
+            modifier,
+            reload: 19, // r
+            reload_modifiers: modifier,
             minimize_focused: 49, // n
-            overview_toggle: 24,  // o
-            quit: 16,             // q
-            primary_left: 105,    // left
-            primary_right: 106,   // right
-            primary_up: 103,      // up
-            primary_down: 108,    // down
-            secondary_left: 36,   // j
-            secondary_right: 38,  // l
-            secondary_up: 23,     // i
-            secondary_down: 37,   // k
-            move_left: 30,        // a
-            move_right: 32,       // d
-            move_up: 17,          // w
-            move_down: 31,        // s
+            minimize_focused_modifiers: modifier,
+            overview_toggle: 24, // o
+            overview_toggle_modifiers: modifier,
+            quit: 16, // q
+            quit_modifiers: modifier,
+            docking: 32, // d
+            docking_modifiers: modifier,
+            primary_left: 105,   // left
+            primary_right: 106,  // right
+            primary_up: 103,     // up
+            primary_down: 108,   // down
+            secondary_left: 36,  // j
+            secondary_right: 38, // l
+            secondary_up: 23,    // i
+            secondary_down: 37,  // k
+            move_left: 0,
+            move_left_modifiers: modifier,
+            move_right: 0,
+            move_right_modifiers: modifier,
+            move_up: 0,
+            move_up_modifiers: modifier,
+            move_down: 0,
+            move_down_modifiers: modifier,
         }
     }
 }

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -222,12 +222,13 @@ impl RuntimeTuning {
     pub fn keybinds_resolved_summary(&self) -> String {
         let kb = &self.keybinds;
         format!(
-            "mod={} reload={} minimize={} overview={} quit={} (requires_shift={}) custom_launches={} primary=[{},{},{},{}] secondary=[{},{},{},{}] move=[{},{},{},{}]",
+            "mod={} reload={} minimize={} overview={} quit={} docking={} (requires_shift={}) custom_launches={} primary=[{},{},{},{}] secondary=[{},{},{},{}] move=[{},{},{},{}]",
             kb.modifier_name(),
             evdev_to_key_name(kb.reload),
             evdev_to_key_name(kb.minimize_focused),
             evdev_to_key_name(kb.overview_toggle),
             evdev_to_key_name(kb.quit),
+            evdev_to_key_name(kb.docking),
             self.quit_requires_shift,
             self.launch_bindings.len(),
             evdev_to_key_name(kb.primary_left),

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 
 use super::{KeyModifiers, LaunchBinding, PointerBinding, PointerBindingAction};
 use crate::RuntimeTuning;
-use crate::keybinds::{
-    is_pointer_button_code, key_name_to_evdev, modifiers_empty, parse_chord, parse_modifiers,
-};
+use crate::keybinds::{is_pointer_button_code, key_name_to_evdev, parse_chord, parse_modifiers};
 use crate::layout::{ViewportOutputConfig, default_pointer_bindings};
 use crate::legacy::{parse_legacy_keybinds, strip_legacy_keybind_block};
 
@@ -94,6 +92,7 @@ fn load_dev_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         out.keybinds.overview_toggle,
     );
     out.keybinds.quit = pick_keycode(cfg, &["dev.keybinds.quit"], out.keybinds.quit);
+    out.keybinds.docking = pick_keycode(cfg, &["dev.keybinds.docking"], out.keybinds.docking);
 
     out.keybind_launch_command = pick_string(
         cfg,
@@ -389,9 +388,23 @@ fn load_physics_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 
 fn load_keybind_sections(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.keybinds.modifier = pick_modifiers(cfg, &["keybinds.mod"], out.keybinds.modifier);
+    sync_action_modifiers_with_global(&mut out.keybinds);
     out.launch_bindings.clear();
     out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
     apply_explicit_keybind_overrides(cfg, out);
+}
+
+fn sync_action_modifiers_with_global(keybinds: &mut crate::Keybinds) {
+    let modifier = keybinds.modifier;
+    keybinds.reload_modifiers = modifier;
+    keybinds.minimize_focused_modifiers = modifier;
+    keybinds.overview_toggle_modifiers = modifier;
+    keybinds.quit_modifiers = modifier;
+    keybinds.docking_modifiers = modifier;
+    keybinds.move_left_modifiers = modifier;
+    keybinds.move_right_modifiers = modifier;
+    keybinds.move_up_modifiers = modifier;
+    keybinds.move_down_modifiers = modifier;
 }
 
 fn merge_env_map(cfg: &RuneConfig, out: &mut HashMap<String, String>, path: &str) {
@@ -592,23 +605,11 @@ fn apply_explicit_keybind_overrides_map(
             continue;
         }
 
-        apply_explicit_binding(
-            out,
-            mod_token.as_str(),
-            out.keybinds.modifier,
-            chord.as_str(),
-            action.as_str(),
-        );
+        apply_explicit_binding(out, mod_token.as_str(), chord.as_str(), action.as_str());
     }
 }
 
-fn apply_explicit_binding(
-    out: &mut RuntimeTuning,
-    mod_token: &str,
-    default_mods: KeyModifiers,
-    chord: &str,
-    action: &str,
-) {
+fn apply_explicit_binding(out: &mut RuntimeTuning, mod_token: &str, chord: &str, action: &str) {
     let expanded = chord
         .replace("$var.mod", mod_token)
         .replace("$mod", mod_token);
@@ -617,28 +618,48 @@ fn apply_explicit_binding(
         return;
     };
 
-    let effective_mods = if modifiers_empty(mods) {
-        default_mods
-    } else {
-        mods
-    };
+    let effective_mods = mods;
 
     let action_trimmed = action.trim();
     let action_key = action_trimmed.to_ascii_lowercase();
 
     match action_key.as_str() {
-        "reload" => {
+        "reload" | "reload_config" | "reload-config" => {
             out.keybinds.reload = key;
+            out.keybinds.reload_modifiers = effective_mods;
         }
         "minimize_focused" | "minimize-focused" => {
             out.keybinds.minimize_focused = key;
+            out.keybinds.minimize_focused_modifiers = effective_mods;
         }
         "overview_toggle" | "overview-toggle" => {
             out.keybinds.overview_toggle = key;
+            out.keybinds.overview_toggle_modifiers = effective_mods;
         }
-        "quit" => {
+        "quit" | "quit_halley" | "quit-halley" => {
             out.keybinds.quit = key;
+            out.keybinds.quit_modifiers = effective_mods;
             out.quit_requires_shift = effective_mods.shift;
+        }
+        "docking" => {
+            out.keybinds.docking = key;
+            out.keybinds.docking_modifiers = effective_mods;
+        }
+        "move_left" | "move-left" => {
+            out.keybinds.move_left = key;
+            out.keybinds.move_left_modifiers = effective_mods;
+        }
+        "move_right" | "move-right" => {
+            out.keybinds.move_right = key;
+            out.keybinds.move_right_modifiers = effective_mods;
+        }
+        "move_up" | "move-up" => {
+            out.keybinds.move_up = key;
+            out.keybinds.move_up_modifiers = effective_mods;
+        }
+        "move_down" | "move-down" => {
+            out.keybinds.move_down = key;
+            out.keybinds.move_down_modifiers = effective_mods;
         }
         "move_window" | "move-window" if is_pointer_button_code(key) => {
             upsert_pointer_binding(out, effective_mods, key, PointerBindingAction::MoveWindow);
@@ -690,4 +711,41 @@ fn upsert_pointer_binding(
         button,
         action,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn explicit_move_binding_keeps_shift_modifier() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([
+            ("mod".to_string(), "super".to_string()),
+            ("$var.mod+shift+left".to_string(), "move_left".to_string()),
+        ]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        assert_eq!(tuning.keybinds.move_left, 105);
+        assert!(tuning.keybinds.move_left_modifiers.super_key);
+        assert!(tuning.keybinds.move_left_modifiers.shift);
+    }
+
+    #[test]
+    fn legacy_quit_halley_binding_maps_to_quit_keybind() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([
+            ("mod".to_string(), "super".to_string()),
+            ("$var.mod+shift+q".to_string(), "quit_halley".to_string()),
+        ]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        assert_eq!(tuning.keybinds.quit, 16);
+        assert!(tuning.keybinds.quit_modifiers.super_key);
+        assert!(tuning.keybinds.quit_modifiers.shift);
+        assert!(tuning.quit_requires_shift);
+    }
 }

--- a/crates/halley-ipc/src/lib.rs
+++ b/crates/halley-ipc/src/lib.rs
@@ -7,7 +7,7 @@ pub use codec::{
     decode_request, decode_response, encode_request, encode_response, read_frame, write_frame,
 };
 pub use error::{CodecError, IpcError};
-pub use protocol::{Request, Response};
+pub use protocol::{NodeMoveDirection, Request, Response};
 pub use types::{LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus, OutputsResponse};
 
 use std::env;

--- a/crates/halley-ipc/src/protocol.rs
+++ b/crates/halley-ipc/src/protocol.rs
@@ -8,6 +8,9 @@ pub enum Request {
     Quit,
     Reload,
     Outputs,
+    DockingBegin,
+    DockingEnd,
+    NodeMove(NodeMoveDirection),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,4 +19,12 @@ pub enum Response {
     Reloaded,
     Outputs(OutputsResponse),
     Error(IpcError),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum NodeMoveDirection {
+    Left,
+    Right,
+    Up,
+    Down,
 }

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -12,7 +12,7 @@ use crate::spatial::screen_to_world;
 use crate::state::HalleyWlState;
 
 use super::input_utils::update_mod_state;
-use super::key_actions::{apply_bound_key, key_is_compositor_binding};
+use super::key_actions::{apply_bound_key, key_is_compositor_binding, release_bound_key};
 use super::pointer_focus::pointer_focus_for_screen;
 use super::pointer_map_debug_enabled;
 use smithay::backend::input::{Axis, AxisSource, ButtonState, KeyState};
@@ -81,6 +81,7 @@ pub(crate) fn handle_keyboard_input(
     code: u32,
     pressed: bool,
 ) {
+    let prev_mods = mod_state.borrow().clone();
     update_mod_state(&mut mod_state.borrow_mut(), code, pressed);
 
     let mods = mod_state.borrow().clone();
@@ -158,6 +159,8 @@ pub(crate) fn handle_keyboard_input(
         && first_binding_press
         && apply_bound_key(st, code, &mods, config_path, wayland_display)
     {
+        backend.request_redraw();
+    } else if !pressed && release_bound_key(st, code, &prev_mods) {
         backend.request_redraw();
     }
 }

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -1,9 +1,12 @@
 use std::process::Command;
 
 use eventline::{info, warn};
+use halley_ipc::NodeMoveDirection;
 
 use super::input_utils::{key_matches, modifier_exact};
-use crate::interaction::actions::{minimize_focused_active_node, move_latest_node};
+use crate::interaction::actions::{
+    minimize_focused_active_node, move_latest_node_direction, set_docking_active,
+};
 use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
 use crate::state::HalleyWlState;
@@ -24,9 +27,9 @@ pub(crate) fn key_is_compositor_binding(
 
     if key_matches(key_code, kb.quit) {
         let need = if st.tuning.quit_requires_shift {
-            with_extra_shift(kb.modifier)
+            with_extra_shift(kb.quit_modifiers)
         } else {
-            kb.modifier
+            kb.quit_modifiers
         };
         if modifier_exact(mods, need) {
             return true;
@@ -39,11 +42,27 @@ pub(crate) fn key_is_compositor_binding(
         }
     }
 
-    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.reload_modifiers) {
         return true;
     }
 
-    if key_matches(key_code, kb.minimize_focused) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.minimize_focused)
+        && modifier_exact(mods, kb.minimize_focused_modifiers)
+    {
+        return true;
+    }
+
+    if key_matches(key_code, kb.docking) && modifier_exact(mods, kb.docking_modifiers) {
+        return true;
+    }
+
+    if matches!(
+        key_code,
+        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.move_left_modifiers)
+            || key_matches(code, kb.move_right) && modifier_exact(mods, kb.move_right_modifiers)
+            || key_matches(code, kb.move_up) && modifier_exact(mods, kb.move_up_modifiers)
+            || key_matches(code, kb.move_down) && modifier_exact(mods, kb.move_down_modifiers)
+    ) {
         return true;
     }
 
@@ -53,11 +72,7 @@ pub(crate) fn key_is_compositor_binding(
 
     matches!(
         key_code,
-        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.modifier)
-            || key_matches(code, kb.move_right) && modifier_exact(mods, kb.modifier)
-            || key_matches(code, kb.move_up) && modifier_exact(mods, kb.modifier)
-            || key_matches(code, kb.move_down) && modifier_exact(mods, kb.modifier)
-            || key_matches(code, kb.primary_left) && modifier_exact(mods, kb.modifier)
+        code if key_matches(code, kb.primary_left) && modifier_exact(mods, kb.modifier)
             || key_matches(code, kb.primary_right) && modifier_exact(mods, kb.modifier)
             || key_matches(code, kb.primary_up) && modifier_exact(mods, kb.modifier)
             || key_matches(code, kb.primary_down) && modifier_exact(mods, kb.modifier)
@@ -78,15 +93,14 @@ pub(crate) fn apply_bound_key(
     const STEP_RX: f32 = 24.0;
     const STEP_RY: f32 = 16.0;
     const STEP_OFFSET: f32 = 24.0;
-    const STEP_NODE: f32 = 80.0;
 
     let kb = st.tuning.keybinds.clone();
 
     if key_matches(key_code, kb.quit) {
         let need = if st.tuning.quit_requires_shift {
-            with_extra_shift(kb.modifier)
+            with_extra_shift(kb.quit_modifiers)
         } else {
-            kb.modifier
+            kb.quit_modifiers
         };
         if modifier_exact(mods, need) {
             st.request_exit();
@@ -102,7 +116,7 @@ pub(crate) fn apply_bound_key(
         }
     }
 
-    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.reload_modifiers) {
         let next = RuntimeTuning::load_from_path(config_path);
         st.apply_tuning(next);
         info!("manual config reload from {}", config_path);
@@ -113,31 +127,36 @@ pub(crate) fn apply_bound_key(
         return true;
     }
 
-    if key_matches(key_code, kb.minimize_focused) && modifier_exact(mods, kb.modifier) {
+    if key_matches(key_code, kb.minimize_focused)
+        && modifier_exact(mods, kb.minimize_focused_modifiers)
+    {
         return minimize_focused_active_node(st);
     }
 
-    if !st.tuning.dev_enabled {
-        return false;
+    if key_matches(key_code, kb.docking) && modifier_exact(mods, kb.docking_modifiers) {
+        return set_docking_active(st, true);
     }
 
     let changed = match key_code {
-        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.modifier) => {
-            move_latest_node(st, -STEP_NODE, 0.0);
+        code if key_matches(code, kb.move_left) && modifier_exact(mods, kb.move_left_modifiers) => {
+            move_latest_node_direction(st, NodeMoveDirection::Left);
             true
         }
-        code if key_matches(code, kb.move_right) && modifier_exact(mods, kb.modifier) => {
-            move_latest_node(st, STEP_NODE, 0.0);
+        code if key_matches(code, kb.move_right)
+            && modifier_exact(mods, kb.move_right_modifiers) =>
+        {
+            move_latest_node_direction(st, NodeMoveDirection::Right);
             true
         }
-        code if key_matches(code, kb.move_up) && modifier_exact(mods, kb.modifier) => {
-            move_latest_node(st, 0.0, STEP_NODE);
+        code if key_matches(code, kb.move_up) && modifier_exact(mods, kb.move_up_modifiers) => {
+            move_latest_node_direction(st, NodeMoveDirection::Up);
             true
         }
-        code if key_matches(code, kb.move_down) && modifier_exact(mods, kb.modifier) => {
-            move_latest_node(st, 0.0, -STEP_NODE);
+        code if key_matches(code, kb.move_down) && modifier_exact(mods, kb.move_down_modifiers) => {
+            move_latest_node_direction(st, NodeMoveDirection::Down);
             true
         }
+        _ if !st.tuning.dev_enabled => false,
 
         code if key_matches(code, kb.primary_left) && modifier_exact(mods, kb.modifier) => {
             st.tuning.focus_ring_rx -= STEP_RX;
@@ -187,6 +206,14 @@ pub(crate) fn apply_bound_key(
     }
 
     changed
+}
+
+pub(crate) fn release_bound_key(st: &mut HalleyWlState, key_code: u32, mods: &ModState) -> bool {
+    let kb = &st.tuning.keybinds;
+    if key_matches(key_code, kb.docking) && modifier_exact(mods, kb.docking_modifiers) {
+        return set_docking_active(st, false);
+    }
+    false
 }
 
 fn spawn_command(command: &str, wayland_display: &str, label: &str) -> bool {

--- a/crates/halley-wl/src/input/move_anim.rs
+++ b/crates/halley-wl/src/input/move_anim.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::interaction::types::{NodeMoveAnim, PointerState};
 use crate::render::ease_in_out_cubic;
@@ -29,19 +29,82 @@ pub(crate) fn advance_node_move_anim(
             x: anim.from.x + (anim.to.x - anim.from.x) * e,
             y: anim.from.y + (anim.to.y - anim.from.y) * e,
         };
-        let _ = st.field.carry(anim.node_id, pos);
+        if st.tuning.physics_enabled {
+            let _ = st.carry_surface_non_overlap(anim.node_id, pos);
+        } else {
+            let _ = st.field.carry(anim.node_id, pos);
+        }
         if t >= 1.0 {
             finished.push(anim.node_id);
         }
         last_id = Some(anim.node_id);
     }
-    let any_finished = !finished.is_empty();
     for id in finished {
         ps.move_anim.remove(&id);
     }
-    if any_finished && ps.move_anim.is_empty() {
-        // Ensure final settled positions still respect configured non-overlap gap.
-        st.resolve_overlap_now();
-    }
     last_id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halley_core::field::Vec2;
+
+    #[test]
+    fn move_anim_uses_constrained_carry_when_physics_is_enabled() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        state.zoom_ref_size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let mut ps = PointerState::default();
+        let now = Instant::now();
+        ps.move_anim.insert(
+            a,
+            NodeMoveAnim {
+                node_id: a,
+                from: Vec2 { x: 0.0, y: 0.0 },
+                to: Vec2 { x: 280.0, y: 0.0 },
+                started_at: now,
+                duration: Duration::from_millis(100),
+            },
+        );
+
+        let _ = advance_node_move_anim(&mut state, &mut ps, now + Duration::from_millis(100));
+
+        let na = state.field.node(a).expect("animated window");
+        let nb = state.field.node(b).expect("neighbor window");
+        let ea = state.collision_extents_for_node(na);
+        let eb = state.collision_extents_for_node(nb);
+        let gap = state.non_overlap_gap_world();
+        let dx = (nb.pos.x - na.pos.x).abs();
+        let dy = (nb.pos.y - na.pos.y).abs();
+        let req_x = state.required_sep_x(na.pos.x, ea, nb.pos.x, eb, gap);
+        let req_y = state.required_sep_y(na.pos.y, ea, nb.pos.y, eb, gap);
+
+        assert!(
+            dx >= req_x - 0.5 || dy >= req_y - 0.5,
+            "move animation should preserve non-overlap without a post-fix resolver: dx={dx}, req_x={req_x}, dy={dy}, req_y={req_y}"
+        );
+        assert!(
+            ps.move_anim.is_empty(),
+            "expected finished move animation to clear"
+        );
+    }
 }

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -156,6 +156,7 @@ fn begin_drag(
     }
     ps.drag = Some(drag_ctx);
     st.begin_carry_state_tracking(hit.node_id);
+    let _ = st.field.set_pinned(hit.node_id, false);
     st.set_interaction_focus(Some(hit.node_id), 30_000, Instant::now());
     let to = halley_core::field::Vec2 {
         x: world_now.x - drag_ctx.current_offset.x,
@@ -308,7 +309,6 @@ fn finalize_resize(st: &mut HalleyWlState, ps: &mut PointerState, backend: &dyn 
         }
         st.set_recent_top_node(resize.node_id, now + Duration::from_millis(600));
         st.end_resize_interaction(now);
-        st.resolve_overlap_now();
         backend.request_redraw();
         return;
     }
@@ -351,7 +351,6 @@ fn finalize_resize(st: &mut HalleyWlState, ps: &mut PointerState, backend: &dyn 
     );
     st.set_recent_top_node(resize.node_id, now + Duration::from_millis(600));
     st.end_resize_interaction(now);
-    st.resolve_overlap_now();
     backend.request_redraw();
 }
 
@@ -541,7 +540,9 @@ fn handle_button_release(
                 } else {
                     st.update_carry_state_preview_at(d.node_id, world_now, now);
                 }
-                let _ = st.field.finalize_dock_on_drag_release(d.node_id);
+                if st.docking_active {
+                    let _ = st.field.finalize_dock_on_drag_release(d.node_id);
+                }
                 st.end_carry_state_tracking(d.node_id);
                 ps.preview_block_until = Some(now + Duration::from_millis(360));
             }

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -133,11 +133,15 @@ pub(crate) fn handle_pointer_motion_absolute(
                     let _ = st.carry_surface_non_overlap(drag.node_id, centered);
                 }
                 ps.drag = Some(next_drag);
-                let _ = st.field.update_dock_preview(
-                    drag.node_id,
-                    st.viewport.center,
-                    st.viewport.size,
-                );
+                if st.docking_active {
+                    let _ = st.field.update_dock_preview(
+                        drag.node_id,
+                        st.viewport.center,
+                        st.viewport.size,
+                    );
+                } else {
+                    st.field.clear_dock_preview();
+                }
                 backend.request_redraw();
             }
         }

--- a/crates/halley-wl/src/interaction/actions.rs
+++ b/crates/halley-wl/src/interaction/actions.rs
@@ -2,6 +2,7 @@ use crate::state::HalleyWlState;
 use eventline::info;
 use halley_core::decay::DecayLevel;
 use halley_core::viewport::FocusZone;
+use halley_ipc::NodeMoveDirection;
 use std::time::Instant;
 
 pub(crate) fn promote_node_level(
@@ -66,12 +67,13 @@ pub(crate) fn move_latest_node(st: &mut HalleyWlState, dx: f32, dy: f32) {
     let Some(id) = latest else {
         return;
     };
-    let Some(n) = st.field.node(id) else {
+    let Some(pos) = st.field.node(id).map(|n| n.pos) else {
         return;
     };
+    let _ = st.field.set_pinned(id, false);
     let to = halley_core::field::Vec2 {
-        x: n.pos.x + dx,
-        y: n.pos.y + dy,
+        x: pos.x + dx,
+        y: pos.y + dy,
     };
     st.begin_carry_state_tracking(id);
     if st.carry_surface_non_overlap(id, to) {
@@ -87,6 +89,24 @@ pub(crate) fn move_latest_node(st: &mut HalleyWlState, dx: f32, dy: f32) {
             );
         }
     }
+}
+
+pub(crate) fn move_latest_node_direction(st: &mut HalleyWlState, direction: NodeMoveDirection) {
+    match direction {
+        NodeMoveDirection::Left => move_latest_node(st, -80.0, 0.0),
+        NodeMoveDirection::Right => move_latest_node(st, 80.0, 0.0),
+        NodeMoveDirection::Up => move_latest_node(st, 0.0, 80.0),
+        NodeMoveDirection::Down => move_latest_node(st, 0.0, -80.0),
+    }
+}
+
+pub(crate) fn set_docking_active(st: &mut HalleyWlState, active: bool) -> bool {
+    let changed = st.docking_active != active;
+    st.docking_active = active;
+    if !active {
+        st.field.clear_dock_preview();
+    }
+    changed
 }
 
 pub(crate) fn minimize_focused_active_node(st: &mut HalleyWlState) -> bool {

--- a/crates/halley-wl/src/run/ipc.rs
+++ b/crates/halley-wl/src/run/ipc.rs
@@ -10,14 +10,17 @@ use once_cell::sync::OnceCell;
 
 use eventline::{error, info, warn};
 use halley_ipc::{
-    IpcError, OutputInfo, OutputsResponse, Request, Response, decode_request, encode_response,
-    read_frame, write_frame,
+    IpcError, NodeMoveDirection, OutputInfo, OutputsResponse, Request, Response, decode_request,
+    encode_response, read_frame, write_frame,
 };
 
 #[derive(Debug, Clone, Copy)]
 pub enum RuntimeIpcCommand {
     Quit,
     Reload,
+    DockingBegin,
+    DockingEnd,
+    NodeMove(NodeMoveDirection),
 }
 
 static IPC_COMMAND_RX: OnceCell<Mutex<mpsc::Receiver<RuntimeIpcCommand>>> = OnceCell::new();
@@ -148,6 +151,20 @@ fn handle_request(
             }),
             Err(err) => Response::Error(IpcError::Internal(err.to_string())),
         },
+        Request::DockingBegin => match command_tx.send(RuntimeIpcCommand::DockingBegin) {
+            Ok(()) => Response::Ok,
+            Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+        },
+        Request::DockingEnd => match command_tx.send(RuntimeIpcCommand::DockingEnd) {
+            Ok(()) => Response::Ok,
+            Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+        },
+        Request::NodeMove(direction) => {
+            match command_tx.send(RuntimeIpcCommand::NodeMove(direction)) {
+                Ok(()) => Response::Ok,
+                Err(err) => Response::Error(IpcError::Internal(err.to_string())),
+            }
+        }
     }
 }
 fn remove_stale_socket(path: &Path) -> io::Result<()> {

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -452,6 +452,15 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                         info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
                         info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                     }
+                    RuntimeIpcCommand::DockingBegin => {
+                        crate::interaction::actions::set_docking_active(st, true);
+                    }
+                    RuntimeIpcCommand::DockingEnd => {
+                        crate::interaction::actions::set_docking_active(st, false);
+                    }
+                    RuntimeIpcCommand::NodeMove(direction) => {
+                        crate::interaction::actions::move_latest_node_direction(st, direction);
+                    }
                 });
 
                 {

--- a/crates/halley-wl/src/run/winit_backend.rs
+++ b/crates/halley-wl/src/run/winit_backend.rs
@@ -344,6 +344,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                             ps.move_anim.clear();
                             ps.panning = false;
                         }
+                        crate::interaction::actions::set_docking_active(st, false);
                         st.set_app_focused(false);
                     }
                     WinitEvent::Focus(true) => {
@@ -461,6 +462,15 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                         st.apply_tuning(next);
                         info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
                         info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
+                    }
+                    RuntimeIpcCommand::DockingBegin => {
+                        crate::interaction::actions::set_docking_active(st, true);
+                    }
+                    RuntimeIpcCommand::DockingEnd => {
+                        crate::interaction::actions::set_docking_active(st, false);
+                    }
+                    RuntimeIpcCommand::NodeMove(direction) => {
+                        crate::interaction::actions::move_latest_node_direction(st, direction);
                     }
                 });
 

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -134,6 +134,8 @@ pub struct HalleyWlState {
     pub(crate) carry_zone_pending: HashMap<NodeId, FocusZone>,
     pub(crate) carry_zone_pending_since_ms: HashMap<NodeId, u64>,
     pub(crate) carry_activation_anim_armed: HashSet<NodeId>,
+    pub(crate) release_smoothing_until_ms: HashMap<NodeId, u64>,
+    pub(crate) release_axis_lock: HashMap<NodeId, bool>,
 
     // Nodes explicitly collapsed by the user via keybind/toggle.
     // Maintenance must not auto-resurrect these.
@@ -145,7 +147,10 @@ pub struct HalleyWlState {
     pub(crate) resize_static_until_ms: u64,
     pub(crate) suspend_overlap_resolve: bool,
     pub(crate) suspend_state_checks: bool,
+    pub(crate) immediate_physics_nodes: HashSet<NodeId>,
+    pub(crate) physics_velocity: HashMap<NodeId, Vec2>,
     pub(crate) smoothed_render_pos: HashMap<NodeId, Vec2>,
+    pub(crate) smoothed_render_vel: HashMap<NodeId, Vec2>,
     pub(crate) node_hover_mix: HashMap<NodeId, f32>,
     pub(crate) node_preview_hover_node: Option<NodeId>,
     pub(crate) node_preview_hover_mix: f32,
@@ -153,6 +158,7 @@ pub struct HalleyWlState {
     pub(crate) viewport_pan_anim: Option<ViewportPanAnim>,
     pub(crate) pan_dominant_until_ms: u64,
     pub(crate) exit_requested: bool,
+    pub(crate) docking_active: bool,
 
     pub(crate) bbox_loc: HashMap<NodeId, (f32, f32)>,
     pub(crate) window_geometry: HashMap<NodeId, (f32, f32, f32, f32)>,
@@ -244,6 +250,8 @@ impl HalleyWlState {
             carry_zone_pending: HashMap::new(),
             carry_zone_pending_since_ms: HashMap::new(),
             carry_activation_anim_armed: HashSet::new(),
+            release_smoothing_until_ms: HashMap::new(),
+            release_axis_lock: HashMap::new(),
             manual_collapsed_nodes: HashSet::new(),
             resize_active: None,
             resize_static_node: None,
@@ -251,7 +259,10 @@ impl HalleyWlState {
             resize_static_until_ms: 0,
             suspend_overlap_resolve: false,
             suspend_state_checks: false,
+            immediate_physics_nodes: HashSet::new(),
+            physics_velocity: HashMap::new(),
             smoothed_render_pos: HashMap::new(),
+            smoothed_render_vel: HashMap::new(),
             node_hover_mix: HashMap::new(),
             node_preview_hover_node: None,
             node_preview_hover_mix: 0.0,
@@ -259,6 +270,7 @@ impl HalleyWlState {
             viewport_pan_anim: None,
             pan_dominant_until_ms: 0,
             exit_requested: false,
+            docking_active: false,
 
             bbox_loc: HashMap::new(),
             window_geometry: HashMap::new(),
@@ -411,6 +423,10 @@ impl HalleyWlState {
             .retain(|id, _| alive_ids.contains(id));
         self.carry_activation_anim_armed
             .retain(|id| alive_ids.contains(id));
+        self.release_smoothing_until_ms
+            .retain(|id, until| alive_ids.contains(id) && *until > now_ms);
+        self.release_axis_lock
+            .retain(|id, _| alive_ids.contains(id));
         self.last_surface_focus_ms
             .retain(|id, _| alive_ids.contains(id));
         self.manual_collapsed_nodes

--- a/crates/halley-wl/src/state/render_state.rs
+++ b/crates/halley-wl/src/state/render_state.rs
@@ -11,7 +11,9 @@ impl HalleyWlState {
         self.render_last_tick = now;
         self.popup_manager.cleanup();
         let alive: HashSet<NodeId> = self.field.nodes().keys().copied().collect();
+        self.physics_velocity.retain(|id, _| alive.contains(id));
         self.smoothed_render_pos.retain(|id, _| alive.contains(id));
+        self.smoothed_render_vel.retain(|id, _| alive.contains(id));
         self.node_hover_mix.retain(|id, _| alive.contains(id));
     }
 
@@ -28,45 +30,61 @@ impl HalleyWlState {
             return logical;
         }
         let now_ms = self.now_ms(now);
+        let drag_active = self.carry_zone_hint.contains_key(&id);
+        let immediate_physics = self.immediate_physics_nodes.contains(&id);
+        let release_smoothing = self.release_smoothing_active_for(id, now_ms);
         if self.resize_active == Some(id)
             || (self.resize_static_node == Some(id) && now_ms < self.resize_static_until_ms)
         {
             self.smoothed_render_pos.insert(id, logical);
+            self.smoothed_render_vel.insert(id, Vec2 { x: 0.0, y: 0.0 });
             return logical;
         }
-        if self.interaction_focus == Some(id)
-            || self.companion_surface_node(now_ms) == Some(id)
-            || self.is_recently_interacted_surface(id, now_ms)
+        if drag_active || immediate_physics {
+            self.smoothed_render_pos.insert(id, logical);
+            self.smoothed_render_vel.insert(id, Vec2 { x: 0.0, y: 0.0 });
+            return logical;
+        }
+        if !drag_active
+            && !release_smoothing
+            && (self.interaction_focus == Some(id)
+                || self.companion_surface_node(now_ms) == Some(id)
+                || self.is_recently_interacted_surface(id, now_ms))
         {
             self.smoothed_render_pos.insert(id, logical);
+            self.smoothed_render_vel.insert(id, Vec2 { x: 0.0, y: 0.0 });
             return logical;
         }
         let dt = now
             .saturating_duration_since(self.render_last_tick)
             .as_secs_f32()
             .clamp(1.0 / 240.0, 1.0 / 20.0);
-        let mut alpha = (dt * 18.0).clamp(0.10, 0.42);
-        let mut max_step = (dt * 1800.0).clamp(6.0, 70.0);
-        if self.carry_zone_hint.contains_key(&id) {
-            let boost = self.tuning.drag_smoothing_boost.clamp(0.1, 20.0);
-            alpha = (alpha * boost).clamp(0.10, 1.0);
-            max_step = (max_step * boost).clamp(6.0, 420.0);
-        }
-
         let cur = self.smoothed_render_pos.entry(id).or_insert(logical);
-        let dx = logical.x - cur.x;
-        let dy = logical.y - cur.y;
-        let mut sx = dx * alpha;
-        let mut sy = dy * alpha;
-        sx = sx.clamp(-max_step, max_step);
-        sy = sy.clamp(-max_step, max_step);
-        cur.x += sx;
-        cur.y += sy;
-        if (logical.x - cur.x).abs() < 0.6 {
+        let vel = self
+            .smoothed_render_vel
+            .entry(id)
+            .or_insert(Vec2 { x: 0.0, y: 0.0 });
+        let boost = if self.carry_zone_hint.contains_key(&id) {
+            self.tuning.drag_smoothing_boost.clamp(0.1, 20.0)
+        } else {
+            1.0
+        };
+        let omega = (9.0 * boost.sqrt()).clamp(6.0, 22.0);
+        let damping = 2.0 * omega * 0.92;
+        let max_speed = (2200.0 * boost).clamp(900.0, 9000.0);
+        let ax = (logical.x - cur.x) * omega * omega - vel.x * damping;
+        let ay = (logical.y - cur.y) * omega * omega - vel.y * damping;
+        vel.x = (vel.x + ax * dt).clamp(-max_speed, max_speed);
+        vel.y = (vel.y + ay * dt).clamp(-max_speed, max_speed);
+        cur.x += vel.x * dt;
+        cur.y += vel.y * dt;
+        if (logical.x - cur.x).abs() < 0.6 && vel.x.abs() < 12.0 {
             cur.x = logical.x;
+            vel.x = 0.0;
         }
-        if (logical.y - cur.y).abs() < 0.6 {
+        if (logical.y - cur.y).abs() < 0.6 && vel.y.abs() < 12.0 {
             cur.y = logical.y;
+            vel.y = 0.0;
         }
         *cur
     }
@@ -76,11 +94,18 @@ impl HalleyWlState {
             return logical;
         }
         let now_ms = self.now_ms(now);
+        let drag_active = self.carry_zone_hint.contains_key(&id);
+        let immediate_physics = self.immediate_physics_nodes.contains(&id);
+        let release_smoothing = self.release_smoothing_active_for(id, now_ms);
         if self.resize_active == Some(id)
             || (self.resize_static_node == Some(id) && now_ms < self.resize_static_until_ms)
-            || self.interaction_focus == Some(id)
-            || self.companion_surface_node(now_ms) == Some(id)
-            || self.is_recently_interacted_surface(id, now_ms)
+            || drag_active
+            || immediate_physics
+            || (!drag_active
+                && !release_smoothing
+                && (self.interaction_focus == Some(id)
+                    || self.companion_surface_node(now_ms) == Some(id)
+                    || self.is_recently_interacted_surface(id, now_ms)))
         {
             return logical;
         }
@@ -138,7 +163,9 @@ impl HalleyWlState {
     }
 
     pub fn tick_live_overlap(&mut self) {
-        if self.suspend_state_checks || self.resize_active.is_some() {
+        self.tick_passive_physics();
+        if self.tuning.physics_enabled || self.suspend_state_checks || self.resize_active.is_some()
+        {
             return;
         }
         self.resolve_surface_overlap();
@@ -180,4 +207,85 @@ fn send_frames_surface_tree(
         },
         |_, _, &()| true,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_smoothing_keeps_recently_released_focus_on_damped_path() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        let id =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let now = Instant::now();
+        let now_ms = state.now_ms(now);
+        state.interaction_focus = Some(id);
+        state.interaction_focus_until_ms = now_ms.saturating_add(30_000);
+        state
+            .smoothed_render_pos
+            .insert(id, Vec2 { x: 0.0, y: 0.0 });
+        state
+            .smoothed_render_vel
+            .insert(id, Vec2 { x: 0.0, y: 0.0 });
+        state
+            .release_smoothing_until_ms
+            .insert(id, now_ms.saturating_add(200));
+
+        let read = state.smoothed_render_pos_read(id, Vec2 { x: 120.0, y: 0.0 }, now);
+        assert!(
+            (read.x - 0.0).abs() < 0.01,
+            "expected cached smoothed position during release smoothing, got {:?}",
+            read
+        );
+    }
+
+    #[test]
+    fn live_drag_keeps_passive_windows_on_immediate_physics_path() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        let dragged =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let other =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 500.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let now = Instant::now();
+        state.begin_carry_state_tracking(dragged);
+        state.immediate_physics_nodes.insert(other);
+        state
+            .smoothed_render_pos
+            .insert(other, Vec2 { x: 470.0, y: 0.0 });
+        state
+            .smoothed_render_vel
+            .insert(other, Vec2 { x: 120.0, y: 0.0 });
+
+        let read = state.smoothed_render_pos_read(other, Vec2 { x: 500.0, y: 0.0 }, now);
+        let write = state.smoothed_render_pos(other, Vec2 { x: 500.0, y: 0.0 }, now);
+
+        assert_eq!(
+            read.x, 500.0,
+            "passive window read should stay on logical position"
+        );
+        assert_eq!(
+            write.x, 500.0,
+            "passive window write should stay on logical position"
+        );
+        assert_eq!(
+            state.smoothed_render_vel.get(&other).copied(),
+            Some(Vec2 { x: 0.0, y: 0.0 }),
+            "immediate physics path should zero any stale smoothing velocity"
+        );
+    }
 }

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -163,7 +163,11 @@ impl HalleyWlState {
 
         if !tuning.physics_enabled {
             self.active_transition_until_ms.clear();
+            self.release_smoothing_until_ms.clear();
+            self.release_axis_lock.clear();
+            self.physics_velocity.clear();
             self.smoothed_render_pos.clear();
+            self.smoothed_render_vel.clear();
         }
 
         self.tuning = tuning;

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -239,8 +239,6 @@ impl XdgShellHandler for HalleyWlState {
         } else {
             self.queue_spawn_pan_to_node(id, now);
         }
-
-        self.resolve_surface_overlap();
     }
 
     fn new_popup(&mut self, popup: PopupSurface, _positioner: PositionerState) {

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -396,6 +396,9 @@ impl HalleyWlState {
             self.carry_zone_pending.remove(&id);
             self.carry_zone_pending_since_ms.remove(&id);
             self.carry_activation_anim_armed.remove(&id);
+            self.release_smoothing_until_ms.remove(&id);
+            self.release_axis_lock.remove(&id);
+            self.physics_velocity.remove(&id);
             if self.resize_active == Some(id) {
                 self.resize_active = None;
             }

--- a/crates/halley-wl/src/wm/carry.rs
+++ b/crates/halley-wl/src/wm/carry.rs
@@ -200,6 +200,10 @@ impl HalleyWlState {
         }
         self.suspend_overlap_resolve = true;
         self.suspend_state_checks = true;
+        self.immediate_physics_nodes.clear();
+        self.physics_velocity.remove(&id);
+        self.release_smoothing_until_ms.remove(&id);
+        self.release_axis_lock.remove(&id);
         let _ = self.field.undock_node(id);
         self.field.clear_dock_preview();
 
@@ -224,8 +228,14 @@ impl HalleyWlState {
         self.field.clear_dock_preview();
         self.suspend_overlap_resolve = false;
         self.suspend_state_checks = false;
+        let immediate_nodes: Vec<NodeId> = self.immediate_physics_nodes.drain().collect();
+        for node_id in immediate_nodes {
+            self.release_smoothing_until_ms.remove(&node_id);
+            self.release_axis_lock.remove(&node_id);
+            self.smoothed_render_pos.remove(&node_id);
+            self.smoothed_render_vel.remove(&node_id);
+        }
         self.enforce_docked_pairs();
-        self.resolve_overlap_now();
     }
 
     pub fn update_carry_state_preview(&mut self, id: NodeId, now: Instant) {
@@ -267,5 +277,38 @@ impl HalleyWlState {
                 self.push_neighbors_for_activation(id);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carry_release_preserves_immediate_physics_velocity() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
+            .expect("display")
+            .handle();
+        let mut state = HalleyWlState::new(&dh, tuning);
+        let dragged =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let affected =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        state.begin_carry_state_tracking(dragged);
+        state.immediate_physics_nodes.insert(affected);
+        state
+            .physics_velocity
+            .insert(affected, Vec2 { x: 180.0, y: -24.0 });
+
+        state.end_carry_state_tracking(dragged);
+
+        let velocity = state.physics_velocity.get(&affected).copied();
+        assert_eq!(velocity, Some(Vec2 { x: 180.0, y: -24.0 }));
     }
 }

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -335,7 +335,7 @@ impl HalleyWlState {
         self.suspend_state_checks = false;
         self.suspend_overlap_resolve = false;
         self.enforce_docked_pairs();
-        self.resolve_surface_overlap();
+        self.resolve_overlap_now();
     }
 
     pub fn resolve_overlap_now(&mut self) {

--- a/crates/halley-wl/src/wm/maintenance.rs
+++ b/crates/halley-wl/src/wm/maintenance.rs
@@ -440,7 +440,7 @@ impl HalleyWlState {
                 if id == activated
                     || !self.field.is_visible(id)
                     || n.kind != halley_core::field::NodeKind::Surface
-                    || n.pinned
+                    || self.resize_static_node == Some(id)
                     || self.is_recently_resized_node(id, now_ms)
                 {
                     return None;
@@ -480,7 +480,7 @@ impl HalleyWlState {
                     y: apos.y + s * (req_y + 1.0),
                 }
             };
-            if self.field.carry(id, target) {
+            if self.carry_for_physics(id, target) {
                 moved += 1;
             }
         }
@@ -538,6 +538,9 @@ impl HalleyWlState {
                 self.carry_zone_pending.remove(&id);
                 self.carry_zone_pending_since_ms.remove(&id);
                 self.carry_activation_anim_armed.remove(&id);
+                self.release_smoothing_until_ms.remove(&id);
+                self.release_axis_lock.remove(&id);
+                self.physics_velocity.remove(&id);
                 if self.resize_active == Some(id) {
                     self.resize_active = None;
                 }

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::collections::VecDeque;
+
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::Resource;
 
@@ -31,6 +33,69 @@ impl CollisionExtents {
 }
 
 impl HalleyWlState {
+    const PHYSICS_DEPTH_LIMIT: usize = 6;
+    const DRAG_AXIS_DOMINANCE: f32 = 1.35;
+    const PHYSICS_MIN_SPEED: f32 = 12.0;
+
+    #[inline]
+    fn bump_response(&self) -> f32 {
+        self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0)
+    }
+
+    #[inline]
+    fn physics_damping_per_sec(&self) -> f32 {
+        1.8 + self.bump_response() * 4.2
+    }
+
+    #[inline]
+    fn drag_impulse_gain(&self) -> f32 {
+        2.6 + self.bump_response() * 2.4
+    }
+
+    #[inline]
+    fn collision_push_gain(&self) -> f32 {
+        5.5 + self.bump_response() * 7.5
+    }
+
+    #[inline]
+    fn collision_bounce(&self) -> f32 {
+        0.05 + self.bump_response() * 0.17
+    }
+
+    #[inline]
+    pub(crate) fn carry_for_physics(&mut self, id: NodeId, to: Vec2) -> bool {
+        if self.resize_static_node == Some(id) {
+            return false;
+        }
+        if !self.tuning.physics_enabled {
+            return self.field.carry(id, to);
+        }
+        let immediate_physics = self.suspend_overlap_resolve && self.suspend_state_checks;
+        let should_prime_render_smoothing = !self.carry_zone_hint.contains_key(&id)
+            && !immediate_physics
+            && self.resize_active != Some(id)
+            && self.resize_static_node != Some(id);
+        let Some(n) = self.field.node_mut(id) else {
+            return false;
+        };
+        let from = n.pos;
+        if should_prime_render_smoothing
+            && ((to.x - from.x).abs() > 0.05 || (to.y - from.y).abs() > 0.05)
+        {
+            self.smoothed_render_pos.entry(id).or_insert(from);
+            self.smoothed_render_vel
+                .entry(id)
+                .or_insert(Vec2 { x: 0.0, y: 0.0 });
+        }
+        n.pos = to;
+        if immediate_physics {
+            self.immediate_physics_nodes.insert(id);
+            self.smoothed_render_pos.remove(&id);
+            self.smoothed_render_vel.remove(&id);
+        }
+        true
+    }
+
     #[inline]
     fn world_units_per_px_xy(&self) -> (f32, f32) {
         let wx = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
@@ -75,31 +140,76 @@ impl HalleyWlState {
         }
     }
 
-    pub(crate) fn carry_surface_non_overlap(&mut self, id: NodeId, to: Vec2) -> bool {
-        if self.suspend_overlap_resolve || self.suspend_state_checks {
-            return self.carry_surface_no_overlap_static(id, to);
+    #[inline]
+    pub(crate) fn update_release_axis_from_motion(&mut self, id: NodeId, motion: Vec2) {
+        if motion.x.abs() > motion.y.abs() * Self::DRAG_AXIS_DOMINANCE {
+            self.release_axis_lock.insert(id, true);
+        } else if motion.y.abs() > motion.x.abs() * Self::DRAG_AXIS_DOMINANCE {
+            self.release_axis_lock.insert(id, false);
         }
-        if !self.tuning.physics_enabled {
-            return self.field.carry(id, to);
-        }
+    }
 
-        let Some(n) = self.field.node(id) else {
+    #[inline]
+    pub(crate) fn release_smoothing_active_for(&self, id: NodeId, now_ms: u64) -> bool {
+        self.release_smoothing_until_ms
+            .get(&id)
+            .is_some_and(|&until| until > now_ms)
+    }
+
+    #[inline]
+    fn collision_axis(motion: Vec2, overlap_x: f32, overlap_y: f32) -> bool {
+        if motion.x.abs() > motion.y.abs() * Self::DRAG_AXIS_DOMINANCE {
+            true
+        } else if motion.y.abs() > motion.x.abs() * Self::DRAG_AXIS_DOMINANCE {
+            false
+        } else {
+            overlap_x <= overlap_y
+        }
+    }
+
+    #[inline]
+    fn push_direction(delta: f32, motion: f32) -> f32 {
+        if motion.abs() > 0.01 {
+            motion.signum()
+        } else if delta >= 0.0 {
+            1.0
+        } else {
+            -1.0
+        }
+    }
+
+    #[inline]
+    fn body_locked(&self, id: NodeId) -> bool {
+        self.carry_zone_hint.contains_key(&id)
+            || self.resize_active == Some(id)
+            || self.resize_static_node == Some(id)
+    }
+
+    #[inline]
+    fn add_physics_velocity(&mut self, id: NodeId, delta: Vec2) {
+        let vel = self
+            .physics_velocity
+            .entry(id)
+            .or_insert(Vec2 { x: 0.0, y: 0.0 });
+        vel.x += delta.x;
+        vel.y += delta.y;
+    }
+
+    fn carry_surface_docking_clamped(&mut self, id: NodeId, to: Vec2) -> bool {
+        let Some(node) = self.field.node(id) else {
             return false;
         };
-        if n.kind != halley_core::field::NodeKind::Surface {
-            return self.field.carry(id, to);
-        }
-
-        let mover_ext = self.collision_extents_for_node(n);
+        let from = node.pos;
+        let mover_ext = self.collision_extents_for_node(node);
         let gap = self.non_overlap_gap_world();
-        let damping = self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0);
+        let motion = Vec2 {
+            x: to.x - from.x,
+            y: to.y - from.y,
+        };
         let mut mover_pos = to;
 
-        const MAX_PUSH_STEP: f32 = 6.0;
-        const MAX_PUSHES_PER_PASS: usize = 2;
-
-        for _ in 0..16 {
-            let others: Vec<(NodeId, Vec2, CollisionExtents, bool)> = self
+        for _ in 0..12 {
+            let others: Vec<(Vec2, CollisionExtents)> = self
                 .field
                 .nodes()
                 .iter()
@@ -107,202 +217,555 @@ impl HalleyWlState {
                     if oid == id || !self.field.is_visible(oid) {
                         return None;
                     }
-                    if other.kind != halley_core::field::NodeKind::Surface {
+                    if self.field.dock_partner(id) == Some(oid)
+                        || self.field.dock_partner(oid) == Some(id)
+                    {
+                        return None;
+                    }
+                    Some((other.pos, self.collision_extents_for_node(other)))
+                })
+                .collect();
+            let mut changed = false;
+            for (opos, oext) in others {
+                let dx = opos.x - mover_pos.x;
+                let dy = opos.y - mover_pos.y;
+                let req_x = self.required_sep_x(mover_pos.x, mover_ext, opos.x, oext, gap);
+                let req_y = self.required_sep_y(mover_pos.y, mover_ext, opos.y, oext, gap);
+                let ox = req_x - dx.abs();
+                let oy = req_y - dy.abs();
+                if ox <= 0.0 || oy <= 0.0 {
+                    continue;
+                }
+                if Self::collision_axis(motion, ox, oy) {
+                    let dir = Self::push_direction(dx, motion.x);
+                    mover_pos.x = opos.x - dir * req_x;
+                } else {
+                    let dir = Self::push_direction(dy, motion.y);
+                    mover_pos.y = opos.y - dir * req_y;
+                }
+                changed = true;
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        self.carry_for_physics(id, mover_pos)
+    }
+
+    fn apply_drag_impulses(&mut self, source_id: NodeId, drag_motion: Vec2) {
+        let mut queue = VecDeque::from([(source_id, drag_motion, 0usize)]);
+        while let Some((mover_id, motion, depth)) = queue.pop_front() {
+            if depth >= Self::PHYSICS_DEPTH_LIMIT {
+                continue;
+            }
+            let Some(mover) = self.field.node(mover_id) else {
+                continue;
+            };
+            let mover_pos = mover.pos;
+            let mover_ext = self.collision_extents_for_node(mover);
+            let gap = self.non_overlap_gap_world();
+            let others: Vec<(NodeId, Vec2, CollisionExtents, bool)> = self
+                .field
+                .nodes()
+                .iter()
+                .filter_map(|(&oid, other)| {
+                    if oid == mover_id || !self.field.is_visible(oid) {
+                        return None;
+                    }
+                    if self.field.dock_partner(mover_id) == Some(oid)
+                        || self.field.dock_partner(oid) == Some(mover_id)
+                    {
                         return None;
                     }
                     Some((
                         oid,
                         other.pos,
                         self.collision_extents_for_node(other),
-                        other.pinned,
+                        self.resize_static_node == Some(oid) || other.pinned,
                     ))
                 })
                 .collect();
 
-            let mut changed = false;
-            let mut pushes_this_pass = 0usize;
-
-            for (oid, opos, oext, opinned) in others {
-                if pushes_this_pass >= MAX_PUSHES_PER_PASS {
-                    break;
-                }
-
-                let dx = opos.x - mover_pos.x;
-                let dy = opos.y - mover_pos.y;
-                let req_x = self.required_sep_x(mover_pos.x, mover_ext, opos.x, oext, gap);
-                let req_y = self.required_sep_y(mover_pos.y, mover_ext, opos.y, oext, gap);
-
-                let ox = req_x - dx.abs();
-                let oy = req_y - dy.abs();
-
-                let soft_zone = 1.0;
-                let sx = (req_x + soft_zone) - dx.abs();
-                let sy = (req_y + soft_zone) - dy.abs();
-
-                if sx > 0.0 && sy > 0.0 {
-                    let soft = damping * 0.14;
-
-                    if sx < sy {
-                        let step = (sx * soft).clamp(0.35, MAX_PUSH_STEP);
-                        if opinned {
-                            let s = if dx >= 0.0 { -1.0 } else { 1.0 };
-                            mover_pos.x += s * step;
-                        } else {
-                            let s = if dx >= 0.0 { 1.0 } else { -1.0 };
-                            let split_other = step * 0.45;
-                            let split_mover = step * 0.55;
-
-                            let _ = self.field.carry(
-                                oid,
-                                Vec2 {
-                                    x: opos.x + s * split_other,
-                                    y: opos.y,
-                                },
-                            );
-                            mover_pos.x -= s * split_mover;
-                        }
-                        changed = true;
-                        pushes_this_pass += 1;
-                    } else {
-                        let step = (sy * soft).clamp(0.35, MAX_PUSH_STEP);
-                        if opinned {
-                            let s = if dy >= 0.0 { -1.0 } else { 1.0 };
-                            mover_pos.y += s * step;
-                        } else {
-                            let s = if dy >= 0.0 { 1.0 } else { -1.0 };
-                            let split_other = step * 0.45;
-                            let split_mover = step * 0.55;
-
-                            let _ = self.field.carry(
-                                oid,
-                                Vec2 {
-                                    x: opos.x,
-                                    y: opos.y + s * split_other,
-                                },
-                            );
-                            mover_pos.y -= s * split_mover;
-                        }
-                        changed = true;
-                        pushes_this_pass += 1;
-                    }
-                }
-
-                if ox > 0.0 && oy > 0.0 {
-                    let hard_gain = 0.24;
-
-                    if opinned {
-                        if ox < oy {
-                            let s = if dx >= 0.0 { -1.0 } else { 1.0 };
-                            mover_pos.x += s * ((ox + 2.0) * hard_gain).min(MAX_PUSH_STEP);
-                        } else {
-                            let s = if dy >= 0.0 { -1.0 } else { 1.0 };
-                            mover_pos.y += s * ((oy + 2.0) * hard_gain).min(MAX_PUSH_STEP);
-                        }
-                        changed = true;
-                    } else {
-                        let target = if ox < oy {
-                            let s = if dx >= 0.0 { 1.0 } else { -1.0 };
-                            let step = ((ox + 2.0) * hard_gain).min(MAX_PUSH_STEP);
-                            mover_pos.x -= s * (step * 0.55);
-                            Vec2 {
-                                x: opos.x + s * (step * 0.45),
-                                y: opos.y,
-                            }
-                        } else {
-                            let s = if dy >= 0.0 { 1.0 } else { -1.0 };
-                            let step = ((oy + 2.0) * hard_gain).min(MAX_PUSH_STEP);
-                            mover_pos.y -= s * (step * 0.55);
-                            Vec2 {
-                                x: opos.x,
-                                y: opos.y + s * (step * 0.45),
-                            }
-                        };
-
-                        if self.field.carry(oid, target) {
-                            changed = true;
-                            pushes_this_pass += 1;
-                        }
-                    }
-                }
-            }
-
-            if !changed {
-                break;
-            }
-        }
-
-        self.field.carry(id, mover_pos)
-    }
-
-    fn carry_surface_no_overlap_static(&mut self, id: NodeId, to: Vec2) -> bool {
-        let Some(n) = self.field.node(id) else {
-            return false;
-        };
-        if n.kind != halley_core::field::NodeKind::Surface {
-            return self.field.carry(id, to);
-        }
-
-        let mover_ext = self.collision_extents_for_node(n);
-        let gap = self.non_overlap_gap_world();
-        let mut mover_pos = to;
-
-        for _ in 0..24 {
-            let others: Vec<(NodeId, Vec2, CollisionExtents)> = self
-                .field
-                .nodes()
-                .iter()
-                .filter_map(|(&oid, other)| {
-                    if oid == id || !self.field.is_visible(oid) {
-                        return None;
-                    }
-                    if other.kind != halley_core::field::NodeKind::Surface {
-                        return None;
-                    }
-                    Some((oid, other.pos, self.collision_extents_for_node(other)))
-                })
-                .collect();
-
-            let mut changed = false;
-
-            for (oid, opos, oext) in others {
-                let dx = mover_pos.x - opos.x;
-                let dy = mover_pos.y - opos.y;
-                let req_x = self.required_sep_x(mover_pos.x, mover_ext, opos.x, oext, gap);
-                let req_y = self.required_sep_y(mover_pos.y, mover_ext, opos.y, oext, gap);
-                let ox = req_x - dx.abs();
-                let oy = req_y - dy.abs();
-
-                if ox <= 0.0 || oy <= 0.0 {
+            for (other_id, other_pos, other_ext, other_locked) in others {
+                let dx = other_pos.x - mover_pos.x;
+                let dy = other_pos.y - mover_pos.y;
+                let req_x =
+                    self.required_sep_x(mover_pos.x, mover_ext, other_pos.x, other_ext, gap);
+                let req_y =
+                    self.required_sep_y(mover_pos.y, mover_ext, other_pos.y, other_ext, gap);
+                let overlap_x = req_x - dx.abs();
+                let overlap_y = req_y - dy.abs();
+                if overlap_x <= 0.0 || overlap_y <= 0.0 {
                     continue;
                 }
 
-                if ox < oy {
-                    let s = if dx.abs() > f32::EPSILON {
-                        dx.signum()
-                    } else if oid.as_u64() < id.as_u64() {
-                        1.0
-                    } else {
-                        -1.0
+                if Self::collision_axis(motion, overlap_x, overlap_y) {
+                    let dir = Self::push_direction(dx, motion.x);
+                    if other_locked {
+                        let _ = self.carry_for_physics(
+                            mover_id,
+                            Vec2 {
+                                x: other_pos.x - dir * req_x,
+                                y: mover_pos.y,
+                            },
+                        );
+                        continue;
+                    }
+                    let correction = overlap_x + gap * 0.04;
+                    let target = Vec2 {
+                        x: other_pos.x + dir * correction,
+                        y: other_pos.y,
                     };
-                    mover_pos.x += s * (ox + 0.3);
+                    let impulse = dir
+                        * (motion.x.abs() * self.drag_impulse_gain()
+                            + correction * self.collision_push_gain());
+                    let _ = self.carry_for_physics(other_id, target);
+                    self.add_physics_velocity(other_id, Vec2 { x: impulse, y: 0.0 });
+                    queue.push_back((
+                        other_id,
+                        Vec2 {
+                            x: impulse * 0.014,
+                            y: 0.0,
+                        },
+                        depth + 1,
+                    ));
                 } else {
-                    let s = if dy.abs() > f32::EPSILON {
-                        dy.signum()
-                    } else {
-                        1.0
+                    let dir = Self::push_direction(dy, motion.y);
+                    if other_locked {
+                        let _ = self.carry_for_physics(
+                            mover_id,
+                            Vec2 {
+                                x: mover_pos.x,
+                                y: other_pos.y - dir * req_y,
+                            },
+                        );
+                        continue;
+                    }
+                    let correction = overlap_y + gap * 0.04;
+                    let target = Vec2 {
+                        x: other_pos.x,
+                        y: other_pos.y + dir * correction,
                     };
-                    mover_pos.y += s * (oy + 0.3);
+                    let impulse = dir
+                        * (motion.y.abs() * self.drag_impulse_gain()
+                            + correction * self.collision_push_gain());
+                    let _ = self.carry_for_physics(other_id, target);
+                    self.add_physics_velocity(other_id, Vec2 { x: 0.0, y: impulse });
+                    queue.push_back((
+                        other_id,
+                        Vec2 {
+                            x: 0.0,
+                            y: impulse * 0.014,
+                        },
+                        depth + 1,
+                    ));
                 }
-
-                changed = true;
             }
+        }
+    }
 
+    fn resolve_static_surface_collisions(&mut self) {
+        let mut ids: Vec<NodeId> = self
+            .field
+            .nodes()
+            .keys()
+            .copied()
+            .filter(|&id| self.field.is_visible(id))
+            .filter(|&id| {
+                self.field
+                    .node(id)
+                    .is_some_and(|n| n.kind == halley_core::field::NodeKind::Surface)
+            })
+            .collect();
+        ids.sort_by_key(|id| id.as_u64());
+        let gap = self.non_overlap_gap_world();
+
+        for _ in 0..24 {
+            let mut changed = false;
+            for i in 0..ids.len() {
+                for j in (i + 1)..ids.len() {
+                    let a = ids[i];
+                    let b = ids[j];
+                    if self.field.dock_partner(a) == Some(b)
+                        || self.field.dock_partner(b) == Some(a)
+                    {
+                        continue;
+                    }
+                    let (Some(na), Some(nb)) = (self.field.node(a), self.field.node(b)) else {
+                        continue;
+                    };
+                    let apos = na.pos;
+                    let bpos = nb.pos;
+                    let aext = self.collision_extents_for_node(na);
+                    let bext = self.collision_extents_for_node(nb);
+                    let dx = bpos.x - apos.x;
+                    let dy = bpos.y - apos.y;
+                    let req_x = self.required_sep_x(apos.x, aext, bpos.x, bext, gap);
+                    let req_y = self.required_sep_y(apos.y, aext, bpos.y, bext, gap);
+                    let overlap_x = req_x - dx.abs();
+                    let overlap_y = req_y - dy.abs();
+                    if overlap_x <= 0.0 || overlap_y <= 0.0 {
+                        continue;
+                    }
+
+                    let a_locked = self.resize_static_node == Some(a) || na.pinned;
+                    let b_locked = self.resize_static_node == Some(b) || nb.pinned;
+                    if a_locked && b_locked {
+                        continue;
+                    }
+
+                    if overlap_x <= overlap_y {
+                        let dir = if dx >= 0.0 { 1.0 } else { -1.0 };
+                        let correction = overlap_x + 0.1;
+                        if a_locked {
+                            if self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x + dir * correction,
+                                    y: bpos.y,
+                                },
+                            ) {
+                                changed = true;
+                            }
+                        } else if b_locked {
+                            if self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x - dir * correction,
+                                    y: apos.y,
+                                },
+                            ) {
+                                changed = true;
+                            }
+                        } else {
+                            let half = correction * 0.5;
+                            let moved_a = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x - dir * half,
+                                    y: apos.y,
+                                },
+                            );
+                            let moved_b = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x + dir * half,
+                                    y: bpos.y,
+                                },
+                            );
+                            changed |= moved_a || moved_b;
+                        }
+                    } else {
+                        let dir = if dy >= 0.0 { 1.0 } else { -1.0 };
+                        let correction = overlap_y + 0.1;
+                        if a_locked {
+                            if self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x,
+                                    y: bpos.y + dir * correction,
+                                },
+                            ) {
+                                changed = true;
+                            }
+                        } else if b_locked {
+                            if self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x,
+                                    y: apos.y - dir * correction,
+                                },
+                            ) {
+                                changed = true;
+                            }
+                        } else {
+                            let half = correction * 0.5;
+                            let moved_a = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x,
+                                    y: apos.y - dir * half,
+                                },
+                            );
+                            let moved_b = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x,
+                                    y: bpos.y + dir * half,
+                                },
+                            );
+                            changed |= moved_a || moved_b;
+                        }
+                    }
+                }
+            }
             if !changed {
                 break;
             }
         }
+    }
 
-        self.field.carry(id, mover_pos)
+    pub(crate) fn carry_surface_non_overlap(&mut self, id: NodeId, to: Vec2) -> bool {
+        if self.docking_active {
+            return self.carry_surface_docking_clamped(id, to);
+        }
+        if !self.tuning.physics_enabled {
+            if !self.carry_for_physics(id, to) {
+                return false;
+            }
+            self.resolve_static_surface_collisions();
+            return true;
+        }
+        let from = self.field.node(id).map(|n| n.pos).unwrap_or(to);
+        let motion = Vec2 {
+            x: to.x - from.x,
+            y: to.y - from.y,
+        };
+        self.update_release_axis_from_motion(id, motion);
+        self.physics_velocity.remove(&id);
+        if !self.carry_for_physics(id, to) {
+            return false;
+        }
+        self.apply_drag_impulses(id, motion);
+        true
+    }
+
+    fn resolve_dynamic_collisions(&mut self, dt: f32) {
+        let gap = self.non_overlap_gap_world();
+        let ids: Vec<NodeId> = self
+            .field
+            .nodes()
+            .keys()
+            .copied()
+            .filter(|&id| self.field.is_visible(id))
+            .collect();
+
+        for _ in 0..3 {
+            let mut changed = false;
+            for i in 0..ids.len() {
+                for j in (i + 1)..ids.len() {
+                    let a = ids[i];
+                    let b = ids[j];
+                    if self.field.dock_partner(a) == Some(b)
+                        || self.field.dock_partner(b) == Some(a)
+                    {
+                        continue;
+                    }
+                    let (Some(na), Some(nb)) = (self.field.node(a), self.field.node(b)) else {
+                        continue;
+                    };
+                    let apos = na.pos;
+                    let bpos = nb.pos;
+                    let aext = self.collision_extents_for_node(na);
+                    let bext = self.collision_extents_for_node(nb);
+                    let dx = bpos.x - apos.x;
+                    let dy = bpos.y - apos.y;
+                    let req_x = self.required_sep_x(apos.x, aext, bpos.x, bext, gap);
+                    let req_y = self.required_sep_y(apos.y, aext, bpos.y, bext, gap);
+                    let overlap_x = req_x - dx.abs();
+                    let overlap_y = req_y - dy.abs();
+                    if overlap_x <= 0.0 || overlap_y <= 0.0 {
+                        continue;
+                    }
+
+                    let a_locked = self.body_locked(a) || na.pinned;
+                    let b_locked = self.body_locked(b) || nb.pinned;
+                    if a_locked && b_locked {
+                        continue;
+                    }
+
+                    let va = self
+                        .physics_velocity
+                        .get(&a)
+                        .copied()
+                        .unwrap_or(Vec2 { x: 0.0, y: 0.0 });
+                    let vb = self
+                        .physics_velocity
+                        .get(&b)
+                        .copied()
+                        .unwrap_or(Vec2 { x: 0.0, y: 0.0 });
+                    let rel = Vec2 {
+                        x: vb.x - va.x,
+                        y: vb.y - va.y,
+                    };
+
+                    if Self::collision_axis(rel, overlap_x, overlap_y) {
+                        let dir = Self::push_direction(dx, rel.x);
+                        let correction = overlap_x + gap * 0.02;
+                        let speed = correction / dt.max(1.0 / 240.0);
+                        if a_locked {
+                            let _ = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x + dir * correction,
+                                    y: bpos.y,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                b,
+                                Vec2 {
+                                    x: dir * speed * self.collision_bounce(),
+                                    y: 0.0,
+                                },
+                            );
+                        } else if b_locked {
+                            let _ = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x - dir * correction,
+                                    y: apos.y,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                a,
+                                Vec2 {
+                                    x: -dir * speed * self.collision_bounce(),
+                                    y: 0.0,
+                                },
+                            );
+                        } else {
+                            let half = correction * 0.5;
+                            let _ = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x - dir * half,
+                                    y: apos.y,
+                                },
+                            );
+                            let _ = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x + dir * half,
+                                    y: bpos.y,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                a,
+                                Vec2 {
+                                    x: -dir * speed * self.collision_bounce() * 0.5,
+                                    y: 0.0,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                b,
+                                Vec2 {
+                                    x: dir * speed * self.collision_bounce() * 0.5,
+                                    y: 0.0,
+                                },
+                            );
+                        }
+                    } else {
+                        let dir = Self::push_direction(dy, rel.y);
+                        let correction = overlap_y + gap * 0.02;
+                        let speed = correction / dt.max(1.0 / 240.0);
+                        if a_locked {
+                            let _ = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x,
+                                    y: bpos.y + dir * correction,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                b,
+                                Vec2 {
+                                    x: 0.0,
+                                    y: dir * speed * self.collision_bounce(),
+                                },
+                            );
+                        } else if b_locked {
+                            let _ = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x,
+                                    y: apos.y - dir * correction,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                a,
+                                Vec2 {
+                                    x: 0.0,
+                                    y: -dir * speed * self.collision_bounce(),
+                                },
+                            );
+                        } else {
+                            let half = correction * 0.5;
+                            let _ = self.carry_for_physics(
+                                a,
+                                Vec2 {
+                                    x: apos.x,
+                                    y: apos.y - dir * half,
+                                },
+                            );
+                            let _ = self.carry_for_physics(
+                                b,
+                                Vec2 {
+                                    x: bpos.x,
+                                    y: bpos.y + dir * half,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                a,
+                                Vec2 {
+                                    x: 0.0,
+                                    y: -dir * speed * self.collision_bounce() * 0.5,
+                                },
+                            );
+                            self.add_physics_velocity(
+                                b,
+                                Vec2 {
+                                    x: 0.0,
+                                    y: dir * speed * self.collision_bounce() * 0.5,
+                                },
+                            );
+                        }
+                    }
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn tick_passive_physics(&mut self) {
+        if !self.tuning.physics_enabled {
+            return;
+        }
+
+        let dt = (1.0_f32 / 60.0).clamp(1.0 / 240.0, 1.0 / 20.0);
+        let ids: Vec<NodeId> = self.physics_velocity.keys().copied().collect();
+        for id in ids {
+            if self.body_locked(id) || !self.field.is_visible(id) {
+                self.physics_velocity.remove(&id);
+                continue;
+            }
+            let vel = self
+                .physics_velocity
+                .get(&id)
+                .copied()
+                .unwrap_or(Vec2 { x: 0.0, y: 0.0 });
+            if vel.x.abs() < Self::PHYSICS_MIN_SPEED && vel.y.abs() < Self::PHYSICS_MIN_SPEED {
+                self.physics_velocity.remove(&id);
+                continue;
+            }
+            if let Some(node) = self.field.node(id) {
+                let next = Vec2 {
+                    x: node.pos.x + vel.x * dt,
+                    y: node.pos.y + vel.y * dt,
+                };
+                let _ = self.carry_for_physics(id, next);
+            }
+            let damping = (1.0 - self.physics_damping_per_sec() * dt).clamp(0.0, 1.0);
+            if let Some(v) = self.physics_velocity.get_mut(&id) {
+                v.x *= damping;
+                v.y *= damping;
+            }
+        }
+
+        self.resolve_dynamic_collisions(dt);
     }
 
     fn preview_collision_size(real_w: f32, real_h: f32) -> Vec2 {
@@ -312,7 +775,6 @@ impl HalleyWlState {
         let base_h = 160.0f32;
         let mut out_w = base_h * aspect;
         let mut out_h = base_h;
-
         if out_w < 180.0 {
             out_w = 180.0;
             out_h = out_w / aspect.max(0.1);
@@ -321,7 +783,6 @@ impl HalleyWlState {
             out_w = 360.0;
             out_h = out_w / aspect.max(0.1);
         }
-
         out_h = out_h.clamp(100.0, 220.0);
         Vec2 { x: out_w, y: out_h }
     }
@@ -334,12 +795,10 @@ impl HalleyWlState {
             .clamp(0.24, 1.0);
         let t = ((anim_scale - 0.30) / (1.0 - 0.30)).clamp(0.0, 1.0);
         let e = t * t * (3.0 - 2.0 * t);
-
         let mut out = start + (1.0 - start) * e;
         if anim_scale > 1.0 {
             out += (anim_scale - 1.0) * 0.30;
         }
-
         out.clamp(0.24, 1.08)
     }
 
@@ -353,7 +812,6 @@ impl HalleyWlState {
         let zy = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
         let z = ((zx + zy) * 0.5).clamp(1.0, 8.0);
         let g = z.sqrt() * Self::proxy_collision_scale(anim_scale);
-
         let dot_half_px = (4.0 * g).round().clamp(4.0, 18.0);
         let label_h_px = (4.0 * g).round().clamp(4.0, 14.0);
         let label_gap_px = (8.0 + (g - 1.0) * 8.0).round().clamp(8.0, 28.0);
@@ -361,16 +819,12 @@ impl HalleyWlState {
             .round()
             .clamp(24.0, 320.0);
         let pad_px = 6.0;
-
         let dot_d_px = (dot_half_px * 2.0).max(1.0);
         let marker_w_px = (dot_d_px + label_gap_px + label_w_px + pad_px * 2.0).max(8.0);
         let marker_h_px = (dot_d_px.max(label_h_px) + pad_px * 2.0).max(8.0);
-
         let world_per_px_x = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let world_per_px_y = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
         CollisionExtents::symmetric(Vec2 {
-            // Keep collision bounds aligned with the rendered pill instead of the
-            // larger hover proxy so node-to-window spacing matches window spacing.
             x: marker_w_px * world_per_px_x.max(0.01),
             y: marker_h_px * world_per_px_y.max(0.01),
         })
@@ -391,12 +845,10 @@ impl HalleyWlState {
             .get(&n.id)
             .copied()
             .unwrap_or((bbox_lx, bbox_ly, bbox_w, bbox_h));
-
         let left = (bbox_w * 0.5 + bbox_lx - geo_lx).max(16.0);
         let right = (geo_lx + geo_w - bbox_lx - bbox_w * 0.5).max(16.0);
         let top = (bbox_h * 0.5 + bbox_ly - geo_ly).max(16.0);
         let bottom = (geo_ly + geo_h - bbox_ly - bbox_h * 0.5).max(16.0);
-
         CollisionExtents {
             left: left * basis.x.max(1.0) / bbox_w * world_per_px_x,
             right: right * basis.x.max(1.0) / bbox_w * world_per_px_x,
@@ -422,7 +874,6 @@ impl HalleyWlState {
     ) -> CollisionExtents {
         let now = Instant::now();
         let anim = self.anim_style_for(n.id, n.state.clone(), now);
-
         match n.state {
             halley_core::field::NodeState::Active => {
                 let basis = self
@@ -432,7 +883,6 @@ impl HalleyWlState {
                     .unwrap_or(n.intrinsic_size);
                 let s = Self::active_collision_scale(anim.scale, basis.x, basis.y);
                 let ext = self.surface_window_collision_extents(n);
-
                 CollisionExtents {
                     left: ext.left * s,
                     right: ext.right * s,
@@ -440,10 +890,7 @@ impl HalleyWlState {
                     bottom: ext.bottom * s,
                 }
             }
-            halley_core::field::NodeState::Node => {
-                self.node_collision_extents(&n.label, anim.scale)
-            }
-            halley_core::field::NodeState::Core => {
+            halley_core::field::NodeState::Node | halley_core::field::NodeState::Core => {
                 self.node_collision_extents(&n.label, anim.scale)
             }
             halley_core::field::NodeState::Drifting => CollisionExtents::symmetric(n.footprint),
@@ -455,203 +902,22 @@ impl HalleyWlState {
     }
 
     pub(crate) fn resolve_surface_overlap(&mut self) {
-        if !self.tuning.physics_enabled {
+        if self.tuning.physics_enabled || self.suspend_overlap_resolve {
             return;
         }
-        if self.suspend_overlap_resolve {
-            return;
-        }
-
-        let mut ids: Vec<NodeId> = self
-            .field
-            .nodes()
-            .keys()
-            .copied()
-            .filter(|&id| self.field.is_visible(id))
-            .filter(|&id| {
-                self.field
-                    .node(id)
-                    .is_some_and(|n| n.kind == halley_core::field::NodeKind::Surface)
-            })
-            .collect();
-
-        if ids.len() < 2 {
-            return;
-        }
-
-        ids.sort_by_key(|id| id.as_u64());
-
-        let gap = self.non_overlap_gap_world();
-        let focus_id = self.interaction_focus;
-        let damping = self.tuning.non_overlap_bump_damping.clamp(0.25, 1.0);
-
-        const MAX_RESOLVE_STEP: f32 = 18.0;
-
-        for _ in 0..24 {
-            let mut changed = false;
-
-            for i in 0..ids.len() {
-                for j in (i + 1)..ids.len() {
-                    let a = ids[i];
-                    let b = ids[j];
-
-                    if self.field.dock_partner(a) == Some(b)
-                        || self.field.dock_partner(b) == Some(a)
-                    {
-                        continue;
-                    }
-
-                    let Some(na) = self.field.node(a) else {
-                        continue;
-                    };
-                    let Some(nb) = self.field.node(b) else {
-                        continue;
-                    };
-
-                    let a_pos = na.pos;
-                    let b_pos = nb.pos;
-                    let a_pinned = na.pinned || self.resize_static_node == Some(a);
-                    let b_pinned = nb.pinned || self.resize_static_node == Some(b);
-
-                    if a_pinned && b_pinned {
-                        continue;
-                    }
-
-                    let ea = self.collision_extents_for_node(na);
-                    let eb = self.collision_extents_for_node(nb);
-
-                    let dx = b_pos.x - a_pos.x;
-                    let dy = b_pos.y - a_pos.y;
-
-                    let req_x = self.required_sep_x(a_pos.x, ea, b_pos.x, eb, gap);
-                    let req_y = self.required_sep_y(a_pos.y, ea, b_pos.y, eb, gap);
-                    let ox = req_x - dx.abs();
-                    let oy = req_y - dy.abs();
-
-                    let soft_zone = 1.0;
-                    let sx = (req_x + soft_zone) - dx.abs();
-                    let sy = (req_y + soft_zone) - dy.abs();
-
-                    let mut primary_id = if focus_id == Some(a) {
-                        b
-                    } else if focus_id == Some(b) {
-                        a
-                    } else {
-                        b
-                    };
-
-                    if primary_id == a && a_pinned && !b_pinned {
-                        primary_id = b;
-                    } else if primary_id == b && b_pinned && !a_pinned {
-                        primary_id = a;
-                    } else if a_pinned && b_pinned {
-                        continue;
-                    }
-
-                    let (mover_id, mover_pos, anchor_pos, mx, my, mover_pinned) = if primary_id == a
-                    {
-                        (
-                            a,
-                            a_pos,
-                            b_pos,
-                            if dx >= 0.0 { -1.0 } else { 1.0 },
-                            if dy >= 0.0 { -1.0 } else { 1.0 },
-                            a_pinned,
-                        )
-                    } else {
-                        (
-                            b,
-                            b_pos,
-                            a_pos,
-                            if dx >= 0.0 { 1.0 } else { -1.0 },
-                            if dy >= 0.0 { 1.0 } else { -1.0 },
-                            b_pinned,
-                        )
-                    };
-
-                    if mover_pinned {
-                        continue;
-                    }
-
-                    if ox <= 0.0 || oy <= 0.0 {
-                        if sx > 0.0 && sy > 0.0 {
-                            let nudge = (sx.min(sy) * damping * 0.18).clamp(0.15, 2.4);
-                            let target = if sx < sy {
-                                Vec2 {
-                                    x: mover_pos.x + mx * nudge,
-                                    y: mover_pos.y,
-                                }
-                            } else {
-                                Vec2 {
-                                    x: mover_pos.x,
-                                    y: mover_pos.y + my * nudge,
-                                }
-                            };
-
-                            if self.field.carry(mover_id, target) {
-                                changed = true;
-                            }
-                        }
-                        continue;
-                    }
-
-                    let full_target = if ox < oy {
-                        Vec2 {
-                            x: anchor_pos.x + mx * (req_x + 0.3),
-                            y: mover_pos.y,
-                        }
-                    } else {
-                        Vec2 {
-                            x: mover_pos.x,
-                            y: anchor_pos.y + my * (req_y + 0.3),
-                        }
-                    };
-
-                    let mut step = Vec2 {
-                        x: (full_target.x - mover_pos.x) * damping,
-                        y: (full_target.y - mover_pos.y) * damping,
-                    };
-
-                    step.x = step.x.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
-                    step.y = step.y.clamp(-MAX_RESOLVE_STEP, MAX_RESOLVE_STEP);
-
-                    if step.x.abs() < 0.5 && (full_target.x - mover_pos.x).abs() > 0.5 {
-                        step.x = 0.5 * step.x.signum();
-                    }
-                    if step.y.abs() < 0.5 && (full_target.y - mover_pos.y).abs() > 0.5 {
-                        step.y = 0.5 * step.y.signum();
-                    }
-
-                    let target = Vec2 {
-                        x: mover_pos.x + step.x,
-                        y: mover_pos.y + step.y,
-                    };
-
-                    if self.field.carry(mover_id, target) {
-                        changed = true;
-                    }
-                }
-            }
-
-            if !changed {
-                break;
-            }
-        }
+        self.resolve_static_surface_collisions();
     }
 
     pub(super) fn request_toplevel_resize(&mut self, node_id: NodeId, width: i32, height: i32) {
         let width = width.max(96);
         let height = height.max(72);
         let focused_node = self.last_input_surface_node();
-
         for top in self.xdg_shell_state.toplevel_surfaces() {
             let wl = top.wl_surface();
             let key = wl.id();
-
             if self.surface_to_node.get(&key).copied() != Some(node_id) {
                 continue;
             }
-
             top.with_pending_state(|s| {
                 s.size = Some((width, height).into());
                 if focused_node == Some(node_id) {
@@ -670,9 +936,7 @@ impl HalleyWlState {
 mod tests {
     use super::*;
 
-    #[test]
-    fn collapsed_surface_nodes_use_marker_collision_extents() {
-        let tuning = halley_config::RuntimeTuning::default();
+    fn test_state(tuning: halley_config::RuntimeTuning) -> HalleyWlState {
         let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
             .expect("display")
             .handle();
@@ -685,7 +949,12 @@ mod tests {
             x: 1600.0,
             y: 1200.0,
         };
+        state
+    }
 
+    #[test]
+    fn collapsed_surface_nodes_use_marker_collision_extents() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
         let id = state.field.spawn_surface(
             "collapsed-firefox",
             Vec2 { x: 0.0, y: 0.0 },
@@ -697,19 +966,212 @@ mod tests {
         let _ = state
             .field
             .set_state(id, halley_core::field::NodeState::Node);
-
         let node = state.field.node(id).expect("node");
         let ext = state.collision_extents_for_node(node);
+        assert!(ext.left + ext.right < 300.0);
+        assert!(ext.top + ext.bottom < 120.0);
+    }
+
+    #[test]
+    fn resolve_surface_overlap_enforces_configured_gap() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.physics_enabled = false;
+        let mut state = test_state(tuning);
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 410.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        state.resolve_surface_overlap();
+        let na = state.field.node(a).expect("first node");
+        let nb = state.field.node(b).expect("second node");
+        let ea = state.collision_extents_for_node(na);
+        let eb = state.collision_extents_for_node(nb);
+        let gap = state.non_overlap_gap_world();
+        let dx = (nb.pos.x - na.pos.x).abs();
+        let req_x = state.required_sep_x(na.pos.x, ea, nb.pos.x, eb, gap);
+        assert!(dx >= req_x - 0.5);
+    }
+
+    #[test]
+    fn static_drag_resolution_keeps_surfaces_non_overlapping_when_physics_is_disabled() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.physics_enabled = false;
+        let mut state = test_state(tuning);
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        state.begin_carry_state_tracking(a);
+        assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+
+        let na = state.field.node(a).expect("first node");
+        let nb = state.field.node(b).expect("second node");
+        let ea = state.collision_extents_for_node(na);
+        let eb = state.collision_extents_for_node(nb);
+        let gap = state.non_overlap_gap_world();
+        let dx = (nb.pos.x - na.pos.x).abs();
+        let req_x = state.required_sep_x(na.pos.x, ea, nb.pos.x, eb, gap);
+        assert!(
+            dx >= req_x - 0.5,
+            "expected static carry path to keep surfaces separated: dx={dx}, req_x={req_x}"
+        );
+    }
+
+    #[test]
+    fn static_drag_resolution_splits_overlap_correction_across_windows() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.physics_enabled = false;
+        let mut state = test_state(tuning);
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        state.begin_carry_state_tracking(a);
+        assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+
+        let na = state.field.node(a).expect("first node");
+        let nb = state.field.node(b).expect("second node");
+        let moved_a = 280.0 - na.pos.x;
+        let moved_b = nb.pos.x - 430.0;
+        assert!(
+            moved_a > 0.0 && moved_b > 0.0,
+            "expected both windows to move during static resolution: a={moved_a}, b={moved_b}"
+        );
+        assert!(
+            (moved_a - moved_b).abs() < 0.6,
+            "expected static resolution to split correction evenly: a={moved_a}, b={moved_b}"
+        );
+    }
+
+    #[test]
+    fn physics_drag_adds_extra_velocity_to_hit_window() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        state.begin_carry_state_tracking(a);
+        assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+
+        let vb = state
+            .physics_velocity
+            .get(&b)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 });
+        assert!(
+            vb.x > 100.0,
+            "expected hit window to receive horizontal velocity, got {:?}",
+            vb
+        );
+    }
+
+    #[test]
+    fn passive_window_keeps_moving_after_drag_impulse() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        state.begin_carry_state_tracking(a);
+        assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+        let before = state.field.node(b).expect("hit window").pos;
+
+        state.tick_passive_physics();
+        state.tick_passive_physics();
+
+        let after = state.field.node(b).expect("hit window after").pos;
+        assert!(
+            after.x > before.x + 1.0,
+            "expected passive window to keep moving after contact: before={before:?}, after={after:?}"
+        );
+    }
+
+    #[test]
+    fn lower_damping_reduces_collision_impulse_strength() {
+        let mut soft_tuning = halley_config::RuntimeTuning::default();
+        soft_tuning.non_overlap_bump_damping = 0.1;
+        let mut soft = test_state(soft_tuning);
+        let a = soft
+            .field
+            .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            soft.field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        soft.begin_carry_state_tracking(a);
+        assert!(soft.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+        let soft_vx = soft
+            .physics_velocity
+            .get(&b)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x;
+
+        let mut firm_tuning = halley_config::RuntimeTuning::default();
+        firm_tuning.non_overlap_bump_damping = 0.9;
+        let mut firm = test_state(firm_tuning);
+        let a = firm
+            .field
+            .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            firm.field
+                .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        firm.begin_carry_state_tracking(a);
+        assert!(firm.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
+        let firm_vx = firm
+            .physics_velocity
+            .get(&b)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x;
 
         assert!(
-            ext.left + ext.right < 300.0,
-            "collapsed node collision width should stay marker-sized, got {:?}",
-            ext
+            soft_vx > 0.0 && firm_vx > soft_vx,
+            "expected firmer damping to yield a stronger impulse: soft={soft_vx}, firm={firm_vx}"
         );
-        assert!(
-            ext.top + ext.bottom < 120.0,
-            "collapsed node collision height should stay marker-sized, got {:?}",
-            ext
-        );
+    }
+
+    #[test]
+    fn docking_mode_clamps_the_dragged_window_instead_of_pushing_neighbors() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
+        state.docking_active = true;
+        let a =
+            state
+                .field
+                .spawn_surface("a", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let b =
+            state
+                .field
+                .spawn_surface("b", Vec2 { x: 20.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+
+        assert!(state.carry_surface_non_overlap(a, Vec2 { x: 20.0, y: 0.0 }));
+
+        let na = state.field.node(a).expect("first window");
+        let nb = state.field.node(b).expect("second window");
+        assert!((nb.pos.x - 20.0).abs() < 0.01);
+        assert!(na.pos.x < 20.0);
     }
 }

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -7,9 +7,16 @@ viewport:
   end
 end
 
+decorations:
+  border-size 3
+  border-colour-focused "#fd5e53"
+  border-colour-unfocused "#333333"
+  border-radius 6
+end
+
 focus-ring:
-  primary-rx 820.0
-  primary-ry 420.0
+  primary-rx 920.0
+  primary-ry 500.0
   offset-x 0
   offset-y 0
 end
@@ -41,19 +48,26 @@ env:
 end
 
 keybinds:
-  mod "lsuper"
+  mod "super"
 
   # Basic compositor controls
-  "$var.mod+r" "reload"
+  "$mod+mouseleft" "move_window"
+  "$mod+mouseright" "resize_window"
+  "$var.mod+r" "reload_config"
   "$var.mod+n" "minimize_focused"
-
+  "$var.mod+d" "docking"
+  
   # Quit Halley
-  "$var.mod+shift+q" "quit"
-
+  "$var.mod+shift+q" "quit_halley"
+  
   # Applications
   "$var.mod+return" "kitty"
   "$var.mod+p" "pavucontrol"
-  "$var.mod+d" "fuzzel"
+  "$var.mod+b" "firefox"
+
+  "XF86AudioRaiseVolume" "wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"
+  "XF86AudioLowerVolume" "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
+  "XF86AudioMute" "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
 end
 
 dev:


### PR DESCRIPTION
- add first-class `docking` and `move_left|right|up|down` compositor actions to normal `keybinds` parsing
- make `docking` a held action so dock preview and dock commit only happen while the binding is active
- add release handling for compositor keybinds so held docking state clears immediately when the key is released
- add IPC and CLI support for `halleyctl docking begin|end`
- add IPC and CLI support for `halleyctl node move left|right|up|down`
- route configured keybind movement and IPC movement through the same internal node move actions
- back node moves and non-docking drags with the real physics carry path so windows push neighboring windows instead of using the old constrained move behavior
- remove the built-in default WASD movement bindings so movement is only active when configured explicitly
- restore normal non-docking drag behavior by clearing temporary test pinning on manual drag and node move paths
- keep docking mode on its dedicated held clamp path so preview and commit only apply while docking is active
- fix `keybinds` parsing so bindings without modifiers, like `XF86AudioRaiseVolume`, no longer inherit the global `mod`
- scale drag-driven physics impulses with shove speed so faster movement pushes harder while preserving non-overlap