### PR TITLE
feat(halley-wl): add autostart + viewport reload, fullscreen support, and initial window-size workaround

### DIFF
--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -9,6 +9,18 @@ use halley_core::viewport::{FocusRing, Viewport};
 use super::{KeyModifiers, Keybinds, LaunchBinding, PointerBinding, PointerBindingAction};
 use crate::keybinds::evdev_to_key_name;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AutostartPhase {
+    Once,
+    OnReload,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AutostartCommand {
+    pub phase: AutostartPhase,
+    pub command: String,
+}
+
 #[derive(Clone, Debug)]
 pub struct RuntimeTuning {
     pub tick_ms: u64,
@@ -54,6 +66,7 @@ pub struct RuntimeTuning {
     pub keybind_launch_command: String,
     pub launch_bindings: Vec<LaunchBinding>,
     pub pointer_bindings: Vec<PointerBinding>,
+    pub autostart_commands: Vec<AutostartCommand>,
     pub quit_requires_shift: bool,
 
     pub tty_viewports: Vec<ViewportOutputConfig>,
@@ -118,6 +131,7 @@ impl Default for RuntimeTuning {
             keybind_launch_command: String::new(),
             launch_bindings: Vec::new(),
             pointer_bindings: default_pointer_bindings(Keybinds::default().modifier),
+            autostart_commands: Vec::new(),
             quit_requires_shift: true,
 
             tty_viewports: Vec::new(),
@@ -244,6 +258,13 @@ impl RuntimeTuning {
             evdev_to_key_name(kb.move_up),
             evdev_to_key_name(kb.move_down),
         )
+    }
+
+    pub fn autostart_commands_for(&self, phase: AutostartPhase) -> impl Iterator<Item = &str> + '_ {
+        self.autostart_commands
+            .iter()
+            .filter(move |entry| entry.phase == phase)
+            .map(|entry| entry.command.as_str())
     }
 }
 

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -4,4 +4,4 @@ pub mod legacy;
 pub mod parse;
 
 pub use keybinds::{KeyModifiers, Keybinds, LaunchBinding, PointerBinding, PointerBindingAction};
-pub use layout::{RuntimeTuning, ViewportOutputConfig};
+pub use layout::{AutostartCommand, AutostartPhase, RuntimeTuning, ViewportOutputConfig};

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use super::{KeyModifiers, LaunchBinding, PointerBinding, PointerBindingAction};
+use super::{
+    AutostartCommand, AutostartPhase, KeyModifiers, LaunchBinding, PointerBinding,
+    PointerBindingAction,
+};
 use crate::RuntimeTuning;
 use crate::keybinds::{is_pointer_button_code, key_name_to_evdev, parse_chord, parse_modifiers};
 use crate::layout::{ViewportOutputConfig, default_pointer_bindings};
@@ -22,6 +25,7 @@ impl RuntimeTuning {
         let mut out = Self::default();
 
         load_dev_section(&cfg, &mut out);
+        load_autostart_section(raw.as_str(), &mut out);
         load_env_section(&cfg, &mut out);
         load_viewport_section(&cfg, &mut out);
         load_focus_ring_section(&cfg, &mut out);
@@ -38,6 +42,127 @@ impl RuntimeTuning {
 
         Some(out)
     }
+}
+
+fn load_autostart_section(raw: &str, out: &mut RuntimeTuning) {
+    out.autostart_commands = parse_autostart_commands(raw);
+}
+
+fn parse_autostart_commands(raw: &str) -> Vec<AutostartCommand> {
+    let mut out = Vec::new();
+    let mut in_autostart = false;
+    let mut depth = 0usize;
+
+    for raw_line in raw.lines() {
+        let stripped = strip_rune_comment(raw_line);
+        let line = stripped.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if !in_autostart {
+            if line == "autostart:" {
+                in_autostart = true;
+                depth = 1;
+            }
+            continue;
+        }
+
+        if line == "end" {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                break;
+            }
+            continue;
+        }
+
+        if depth == 1 {
+            if let Some(command) = parse_autostart_command(line, "once") {
+                out.push(AutostartCommand {
+                    phase: AutostartPhase::Once,
+                    command,
+                });
+            } else if let Some(command) = parse_autostart_command(line, "on-reload")
+                .or_else(|| parse_autostart_command(line, "on_reload"))
+            {
+                out.push(AutostartCommand {
+                    phase: AutostartPhase::OnReload,
+                    command,
+                });
+            }
+        }
+
+        if line.ends_with(':') {
+            depth = depth.saturating_add(1);
+        }
+    }
+
+    out
+}
+
+fn strip_rune_comment(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut in_quotes = false;
+    let mut escaped = false;
+
+    for ch in line.chars() {
+        if escaped {
+            out.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if in_quotes => {
+                out.push(ch);
+                escaped = true;
+            }
+            '"' => {
+                in_quotes = !in_quotes;
+                out.push(ch);
+            }
+            '#' if !in_quotes => break,
+            _ => out.push(ch),
+        }
+    }
+
+    out
+}
+
+fn parse_autostart_command(line: &str, keyword: &str) -> Option<String> {
+    let rest = line.strip_prefix(keyword)?.trim();
+    parse_quoted_string(rest)
+}
+
+fn parse_quoted_string(input: &str) -> Option<String> {
+    let mut chars = input.chars();
+    if chars.next()? != '"' {
+        return None;
+    }
+
+    let mut out = String::new();
+    let mut escaped = false;
+
+    for ch in chars {
+        if escaped {
+            out.push(match ch {
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                other => other,
+            });
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '"' => return Some(out),
+            _ => out.push(ch),
+        }
+    }
+
+    None
 }
 
 fn load_dev_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
@@ -747,5 +872,46 @@ mod tests {
         assert!(tuning.keybinds.quit_modifiers.super_key);
         assert!(tuning.keybinds.quit_modifiers.shift);
         assert!(tuning.quit_requires_shift);
+    }
+
+    #[test]
+    fn parses_autostart_commands_from_rune_block() {
+        let raw = r#"
+autostart:
+  once "waybar"
+  # once "ignored"
+  on-reload "makoctl reload"
+end
+"#;
+
+        let commands = parse_autostart_commands(raw);
+
+        assert_eq!(
+            commands,
+            vec![
+                AutostartCommand {
+                    phase: AutostartPhase::Once,
+                    command: "waybar".to_string(),
+                },
+                AutostartCommand {
+                    phase: AutostartPhase::OnReload,
+                    command: "makoctl reload".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_hash_inside_autostart_quotes() {
+        let raw = r#"
+autostart:
+  once "echo # still part of command"
+end
+"#;
+
+        let commands = parse_autostart_commands(raw);
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].command, "echo # still part of command");
     }
 }

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
-use eventline::{info, warn};
+use eventline::info;
+use halley_config::AutostartPhase;
 use halley_ipc::NodeMoveDirection;
 
 use super::input_utils::{key_matches, modifier_exact};
@@ -8,7 +7,7 @@ use crate::interaction::actions::{
     minimize_focused_active_node, move_latest_node_direction, set_docking_active,
 };
 use crate::interaction::types::ModState;
-use crate::run::request_xwayland_start;
+use crate::run::{run_autostart_commands, spawn_shell_command};
 use crate::state::HalleyWlState;
 use halley_config::{KeyModifiers, RuntimeTuning};
 
@@ -119,6 +118,7 @@ pub(crate) fn apply_bound_key(
     if key_matches(key_code, kb.reload) && modifier_exact(mods, kb.reload_modifiers) {
         let next = RuntimeTuning::load_from_path(config_path);
         st.apply_tuning(next);
+        run_autostart_commands(&st.tuning, wayland_display, AutostartPhase::OnReload);
         info!("manual config reload from {}", config_path);
         info!(
             "resolved keybinds: {}",
@@ -217,30 +217,5 @@ pub(crate) fn release_bound_key(st: &mut HalleyWlState, key_code: u32, mods: &Mo
 }
 
 fn spawn_command(command: &str, wayland_display: &str, label: &str) -> bool {
-    request_xwayland_start();
-    match Command::new("sh")
-        .arg("-lc")
-        .arg(command)
-        .env("WAYLAND_DISPLAY", wayland_display)
-        .env("XDG_SESSION_TYPE", "wayland")
-        .env("GDK_BACKEND", "wayland,x11")
-        .env("QT_QPA_PLATFORM", "wayland;xcb")
-        .env("SDL_VIDEODRIVER", "wayland")
-        .env("CLUTTER_BACKEND", "wayland")
-        .env("MOZ_ENABLE_WAYLAND", "1")
-        .env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
-        .spawn()
-    {
-        Ok(_) => {
-            info!(
-                "spawned {} via `{}` on WAYLAND_DISPLAY={}",
-                label, command, wayland_display
-            );
-            true
-        }
-        Err(err) => {
-            warn!("{} spawn failed via `{}`: {}", label, command, err);
-            false
-        }
-    }
+    spawn_shell_command(command, wayland_display, label)
 }

--- a/crates/halley-wl/src/input/move_anim.rs
+++ b/crates/halley-wl/src/input/move_anim.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::interaction::types::{NodeMoveAnim, PointerState};
 use crate::render::ease_in_out_cubic;
@@ -49,6 +49,7 @@ pub(crate) fn advance_node_move_anim(
 mod tests {
     use super::*;
     use halley_core::field::Vec2;
+    use std::time::Duration;
 
     #[test]
     fn move_anim_uses_constrained_carry_when_physics_is_enabled() {

--- a/crates/halley-wl/src/input/resize_helpers.rs
+++ b/crates/halley-wl/src/input/resize_helpers.rs
@@ -98,6 +98,10 @@ pub(crate) fn active_node_screen_rect(
     now: Instant,
     resize_preview: Option<ResizeCtx>,
 ) -> Option<(f32, f32, f32, f32)> {
+    if st.is_fullscreen_node(node_id) {
+        return Some((0.0, 0.0, w.max(1) as f32, h.max(1) as f32));
+    }
+
     if let Some(active_resize) = active_resize_geometry_screen(node_id, resize_preview) {
         return Some((
             active_resize.frame_left,
@@ -145,6 +149,24 @@ pub(crate) fn active_node_surface_transform_screen_details(
     let n = st.field.node(node_id)?;
     if n.state != halley_core::field::NodeState::Active {
         return None;
+    }
+
+    if st.is_fullscreen_node(node_id) {
+        let (local_x, local_y, _, _) = active_node_visual_local_rect(st, node_id).or_else(|| {
+            st.field.node(node_id).map(|n| {
+                (
+                    0.0,
+                    0.0,
+                    n.intrinsic_size.x.max(1.0),
+                    n.intrinsic_size.y.max(1.0),
+                )
+            })
+        })?;
+        return Some(ActiveNodeSurfaceTransformScreen {
+            origin_x: -local_x,
+            origin_y: -local_y,
+            scale: 1.0,
+        });
     }
 
     let anim = st.anim_style_for(node_id, n.state.clone(), now);

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -111,6 +111,7 @@ pub(crate) fn collect_active_surfaces(
     let mut overlap_overlay_rects: Vec<(i32, i32, i32, i32)> = Vec::new();
 
     let recent_top_node = st.recent_top_node_active(now);
+    let suppress_window_borders = st.fullscreen_node.is_some();
     let output_clip = Rectangle::<i32, Physical>::new((0, 0).into(), size);
 
     let resize_rect_px = resize_preview.map(|rz| {
@@ -136,7 +137,7 @@ pub(crate) fn collect_active_surfaces(
         })
         .collect();
 
-    wl_surfaces.sort_by_key(|(id, _)| std::cmp::Reverse(id.as_u64()));
+    wl_surfaces.sort_by_key(|(id, _)| (!st.is_fullscreen_node(*id), std::cmp::Reverse(id.as_u64())));
 
     for (node_id, wl) in wl_surfaces {
         let bbox = if resize_preview.is_some_and(|rz| rz.node_id == node_id) {
@@ -159,11 +160,12 @@ pub(crate) fn collect_active_surfaces(
         let node_pos = node.pos;
         let node_state = node.state.clone();
         let node_intrinsic = node.intrinsic_size;
+        let fullscreen = st.is_fullscreen_node(node_id);
         let transition_alpha = st.active_transition_alpha(node_id, now);
         let anim = st.anim_style_for(node_id, node_state, now);
         let active_resize = active_resize_geometry_screen(node_id, resize_preview);
         let resizing_this_node = active_resize.is_some();
-        let draw_top_this_node = resizing_this_node || recent_top_node == Some(node_id);
+        let draw_top_this_node = fullscreen || resizing_this_node || recent_top_node == Some(node_id);
 
         let (scale, live_ramp) = if draw_top_this_node {
             (1.0f32, 1.0f32)
@@ -184,12 +186,26 @@ pub(crate) fn collect_active_surfaces(
             (s, live_ramp)
         };
 
+        let local_rect = window_geometry_for_node(st, node_id).unwrap_or((
+            0.0,
+            0.0,
+            node_intrinsic.x,
+            node_intrinsic.y,
+        ));
+
         // Anchor by node centre so zoom doesn't slide full windows.
         let p = st.smoothed_render_pos(node_id, node_pos, now);
         let (cx, cy, sx, sy) = if let Some(active_resize) = active_resize {
             let (cx, cy) = active_resize.center_px();
             let (surface_origin_x, surface_origin_y) = active_resize.surface_origin_px();
             (cx, cy, surface_origin_x, surface_origin_y)
+        } else if fullscreen {
+            (
+                size.w / 2,
+                size.h / 2,
+                -(local_rect.0.round() as i32),
+                -(local_rect.1.round() as i32),
+            )
         } else {
             let (cx, cy) = world_to_screen(st, size.w, size.h, p.x, p.y);
             let sw = ((bbox.size.w as f32) * scale).round() as i32;
@@ -199,17 +215,15 @@ pub(crate) fn collect_active_surfaces(
             (cx, cy, cx - (sw / 2) - lx, cy - (sh / 2) - ly)
         };
 
-        let geometry_rect = active_resize
+        let geometry_rect = if fullscreen {
+            (0, 0, size.w.max(1), size.h.max(1))
+        } else {
+            active_resize
             .map(|rz| rz.frame_rect_px())
             .unwrap_or_else(|| {
-                let local_rect = window_geometry_for_node(st, node_id).unwrap_or((
-                    0.0,
-                    0.0,
-                    node_intrinsic.x,
-                    node_intrinsic.y,
-                ));
                 rect_from_local_geometry(sx, sy, scale, local_rect)
-            });
+            })
+        };
 
         if st.tuning.dev_enabled && st.tuning.dev_show_geometry_overlay {
             let (nx0, ny0, nw, nh) = geometry_rect;
@@ -219,13 +233,15 @@ pub(crate) fn collect_active_surfaces(
         }
 
         let (rx, ry, rw, rh) = geometry_rect;
-        border_rects.push(ActiveBorderRect {
-            x: rx,
-            y: ry,
-            w: rw.max(1),
-            h: rh.max(1),
-            focused: st.interaction_focus == Some(node_id),
-        });
+        if !suppress_window_borders && !fullscreen {
+            border_rects.push(ActiveBorderRect {
+                x: rx,
+                y: ry,
+                w: rw.max(1),
+                h: rh.max(1),
+                focused: st.interaction_focus == Some(node_id),
+            });
+        }
 
         if let Some((rl, rt, rr, rb, rid)) = resize_rect_px
             && node_id != rid

--- a/crates/halley-wl/src/run/common.rs
+++ b/crates/halley-wl/src/run/common.rs
@@ -18,6 +18,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use eventline::{info, warn};
+use halley_config::{AutostartPhase, RuntimeTuning};
 use rustix::net::{
     AddressFamily, SocketAddrUnix, SocketFlags, SocketType, bind, listen, socket_with,
 };
@@ -176,6 +177,50 @@ pub(super) fn ensure_host_display() -> Result<HostBackendGuard, Box<dyn Error>> 
     }
 
     Ok(HostBackendGuard { child: None })
+}
+
+pub(crate) fn run_autostart_commands(
+    tuning: &RuntimeTuning,
+    wayland_display: &str,
+    phase: AutostartPhase,
+) {
+    let label = match phase {
+        AutostartPhase::Once => "autostart.once",
+        AutostartPhase::OnReload => "autostart.on-reload",
+    };
+
+    for command in tuning.autostart_commands_for(phase) {
+        let _ = spawn_shell_command(command, wayland_display, label);
+    }
+}
+
+pub(crate) fn spawn_shell_command(command: &str, wayland_display: &str, label: &str) -> bool {
+    super::request_xwayland_start();
+    match Command::new("sh")
+        .arg("-lc")
+        .arg(command)
+        .env("WAYLAND_DISPLAY", wayland_display)
+        .env("XDG_SESSION_TYPE", "wayland")
+        .env("GDK_BACKEND", "wayland,x11")
+        .env("QT_QPA_PLATFORM", "wayland;xcb")
+        .env("SDL_VIDEODRIVER", "wayland")
+        .env("CLUTTER_BACKEND", "wayland")
+        .env("MOZ_ENABLE_WAYLAND", "1")
+        .env("ELECTRON_OZONE_PLATFORM_HINT", "auto")
+        .spawn()
+    {
+        Ok(_) => {
+            info!(
+                "spawned {} via `{}` on WAYLAND_DISPLAY={}",
+                label, command, wayland_display
+            );
+            true
+        }
+        Err(err) => {
+            warn!("{} spawn failed via `{}`: {}", label, command, err);
+            false
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/halley-wl/src/run/drm.rs
+++ b/crates/halley-wl/src/run/drm.rs
@@ -349,6 +349,56 @@ pub(super) fn collect_outputs_for_ipc(
     outputs
 }
 
+pub(super) fn requested_mode_for_current_connector(
+    dev: &DrmDevice,
+    current_connector_name: &str,
+    tuning: &RuntimeTuning,
+) -> Result<Option<drm_control::Mode>, Box<dyn Error>> {
+    let Some(wanted) = tuning
+        .tty_viewports
+        .iter()
+        .find(|viewport| viewport.connector == current_connector_name)
+    else {
+        return Ok(None);
+    };
+
+    let resources = dev
+        .resource_handles()
+        .map_err(|err| io::Error::other(format!("failed to query drm resources: {}", err)))?;
+
+    let Some(connector) = resources.connectors().iter().find_map(|conn| {
+        let info = dev.get_connector(*conn, true).ok()?;
+        (info.state() == drm_control::connector::State::Connected
+            && info.to_string() == current_connector_name)
+            .then_some(info)
+    }) else {
+        return Err(io::Error::other(format!(
+            "configured viewport {} is not currently connected",
+            current_connector_name
+        ))
+        .into());
+    };
+
+    let mode = connector
+        .modes()
+        .iter()
+        .copied()
+        .find(|mode| {
+            mode.size() == (wanted.width as u16, wanted.height as u16)
+                && wanted
+                    .refresh_rate
+                    .is_none_or(|hz| (mode.vrefresh() as f64 - hz).abs() < 1.0)
+        })
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "configured viewport {} requests {}x{}, but no such mode is available",
+                wanted.connector, wanted.width, wanted.height
+            ))
+        })?;
+
+    Ok(Some(mode))
+}
+
 fn drm_mode_matches(a: drm_control::Mode, b: drm_control::Mode) -> bool {
     let (aw, ah) = a.size();
     let (bw, bh) = b.size();

--- a/crates/halley-wl/src/run/mod.rs
+++ b/crates/halley-wl/src/run/mod.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::env;
 use std::error::Error;
 use std::io;
@@ -63,6 +63,7 @@ use common::{
     RuntimeBackend, auto_backend, ensure_dbus_session_bus_address, ensure_host_display,
     ensure_xdg_runtime_dir, ensure_xwayland_satellite,
 };
+pub(crate) use common::{run_autostart_commands, spawn_shell_command};
 use drm::probe_tty_drm_device_via_session;
 use input_backend::build_tty_libinput_backend;
 pub(crate) use ipc::{RuntimeIpcCommand, drain_ipc_commands, init_ipc, publish_outputs};
@@ -79,15 +80,26 @@ pub(crate) fn request_xwayland_start() {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct TtyBackendHandle {
-    width: i32,
-    height: i32,
+    size: Rc<Cell<(i32, i32)>>,
+}
+
+impl TtyBackendHandle {
+    fn new(width: i32, height: i32) -> Self {
+        Self {
+            size: Rc::new(Cell::new((width, height))),
+        }
+    }
+
+    fn set_size(&self, width: i32, height: i32) {
+        self.size.set((width, height));
+    }
 }
 
 impl BackendView for TtyBackendHandle {
     fn window_size_i32(&self) -> (i32, i32) {
-        (self.width, self.height)
+        self.size.get()
     }
 
     fn request_redraw(&self) {}

--- a/crates/halley-wl/src/run/tty_backend.rs
+++ b/crates/halley-wl/src/run/tty_backend.rs
@@ -1,14 +1,36 @@
 use super::*;
 
 use crate::backend_iface::{DmabufImportBackend, TtyDmabufImportBackend};
-use crate::run::drm::{collect_outputs_for_ipc, queue_tty_drm_frame};
+use crate::run::drm::{
+    collect_outputs_for_ipc, queue_tty_drm_frame, requested_mode_for_current_connector,
+};
 use crate::run::{build_tty_libinput_backend, probe_tty_drm_device_via_session};
 use calloop::{Interest, Mode, PostAction, generic::Generic};
+use halley_config::AutostartPhase;
 
 use smithay::backend::input::{
     AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
     PointerButtonEvent, PointerMotionEvent,
 };
+
+fn keep_last_good_tty_viewport(next: &mut RuntimeTuning, current: &RuntimeTuning) {
+    next.tty_viewports = current.tty_viewports.clone();
+    next.viewport_center = current.viewport_center;
+    next.viewport_size = current.viewport_size;
+}
+
+fn update_tty_pointer_workspace(pointer_state: &Rc<RefCell<PointerState>>, new_w: i32, new_h: i32) {
+    let mut ps = pointer_state.borrow_mut();
+    let (old_w, old_h) = ps.workspace_size;
+    if old_w > 0 && old_h > 0 {
+        let sx = ps.screen.0 * (new_w as f32) / (old_w as f32);
+        let sy = ps.screen.1 * (new_h as f32) / (old_h as f32);
+        let max_x = (new_w - 1).max(0) as f32;
+        let max_y = (new_h - 1).max(0) as f32;
+        ps.screen = (sx.clamp(0.0, max_x), sy.clamp(0.0, max_y));
+    }
+    ps.workspace_size = (new_w, new_h);
+}
 
 pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
     eprintln!("halley-wl tty: starting");
@@ -78,9 +100,15 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             }
 
             let mut state = HalleyWlState::new(&dh, tuning.clone());
+            let drm_dev = Rc::new(RefCell::new(drm_probe.dev));
+            let active_connector_name = Rc::new(RefCell::new(drm_probe.connector_name.clone()));
+            let active_mode = Rc::new(RefCell::new(drm_probe.mode));
             let dmabuf_importer: Rc<dyn DmabufImportBackend> =
                 Rc::new(TtyDmabufImportBackend::new(drm_probe.renderer.clone()));
-            state.configure_dmabuf_importer_for_fd(dmabuf_importer, drm_probe.dev.device_fd());
+            {
+                let dev = drm_dev.borrow();
+                state.configure_dmabuf_importer_for_fd(dmabuf_importer, dev.device_fd());
+            }
             state.set_app_focused(true);
             state.seat.add_pointer();
             if state
@@ -225,38 +253,36 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             let watch_rx = Rc::new(RefCell::new(watch_rx));
             let watch_rx_for_timer = watch_rx.clone();
             let config_path_for_timer = config_path.clone();
+            let wayland_display_for_timer = sock_name.clone();
             let last_maintenance_at = Rc::new(RefCell::new(Instant::now()));
             let last_maintenance_for_timer = last_maintenance_at.clone();
+            let drm_dev_for_timer = drm_dev.clone();
+            let active_connector_name_for_timer = active_connector_name.clone();
+            let active_mode_for_timer = active_mode.clone();
             let (mw, mh) = drm_probe.mode.size();
-            let backend_handle = TtyBackendHandle {
-                width: mw as i32,
-                height: mh as i32,
-            };
+            let backend_handle = TtyBackendHandle::new(mw as i32, mh as i32);
+            let backend_handle_for_input = backend_handle.clone();
+            let backend_handle_for_timer = backend_handle.clone();
             state.zoom_ref_size = halley_core::field::Vec2 {
-                x: backend_handle.width.max(1) as f32,
-                y: backend_handle.height.max(1) as f32,
+                x: (mw as i32).max(1) as f32,
+                y: (mh as i32).max(1) as f32,
             };
             state
                 .advertise_primary_output(drm_probe.connector_name.as_str(), drm_probe.mode.into());
-            info!(
-                "tty logical backend size={}x{}",
-                backend_handle.width, backend_handle.height
-            );
+            info!("tty logical backend size={}x{}", mw as i32, mh as i32);
             {
                 let mut ps = pointer_state.borrow_mut();
-                ps.screen = (
-                    (backend_handle.width as f32) * 0.5,
-                    (backend_handle.height as f32) * 0.5,
-                );
-                ps.workspace_size = (backend_handle.width, backend_handle.height);
+                ps.screen = ((mw as f32) * 0.5, (mh as f32) * 0.5);
+                ps.workspace_size = (mw as i32, mh as i32);
             }
 
             let initial_outputs = collect_outputs_for_ipc(
-                &drm_probe.dev,
+                &drm_dev.borrow(),
                 drm_probe.connector_name.as_str(),
                 drm_probe.mode,
             );
             publish_outputs(initial_outputs);
+            run_autostart_commands(&state.tuning, sock_name.as_str(), AutostartPhase::Once);
 
             let drm_crtc = drm_probe.crtc;
             let gbm_surface_for_vblank = drm_probe.gbm_surface.clone();
@@ -320,7 +346,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             &mod_state_for_input,
                             &pointer_state_for_input,
-                            &backend_handle,
+                            &backend_handle_for_input,
                             config_path.as_str(),
                             sock_name.as_str(),
                             BackendInputEventData::Keyboard { code, pressed },
@@ -331,7 +357,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             info!("tty input: first pointer event received");
                             *pointer_seen_for_input.borrow_mut() = true;
                         }
-                        let (ws_w, ws_h) = backend_handle.window_size_i32();
+                        let (ws_w, ws_h) = backend_handle_for_input.window_size_i32();
                         let sx = event.x_transformed(ws_w) as f32;
                         let sy = event.y_transformed(ws_h) as f32;
                         if debug_input {
@@ -349,7 +375,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             &mod_state_for_input,
                             &pointer_state_for_input,
-                            &backend_handle,
+                            &backend_handle_for_input,
                             config_path.as_str(),
                             sock_name.as_str(),
                             BackendInputEventData::PointerMotionAbsolute { ws_w, ws_h, sx, sy },
@@ -360,7 +386,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             info!("tty input: first pointer event received");
                             *pointer_seen_for_input.borrow_mut() = true;
                         }
-                        let (ws_w, ws_h) = backend_handle.window_size_i32();
+                        let (ws_w, ws_h) = backend_handle_for_input.window_size_i32();
                         let (last_sx, last_sy) = pointer_state_for_input.borrow().screen;
                         let sx = last_sx + event.delta_x() as f32;
                         let sy = last_sy + event.delta_y() as f32;
@@ -381,7 +407,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             &mod_state_for_input,
                             &pointer_state_for_input,
-                            &backend_handle,
+                            &backend_handle_for_input,
                             config_path.as_str(),
                             sock_name.as_str(),
                             BackendInputEventData::PointerMotionAbsolute { ws_w, ws_h, sx, sy },
@@ -403,7 +429,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             &mod_state_for_input,
                             &pointer_state_for_input,
-                            &backend_handle,
+                            &backend_handle_for_input,
                             config_path.as_str(),
                             sock_name.as_str(),
                             BackendInputEventData::PointerButton {
@@ -421,7 +447,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             &mod_state_for_input,
                             &pointer_state_for_input,
-                            &backend_handle,
+                            &backend_handle_for_input,
                             config_path.as_str(),
                             sock_name.as_str(),
                             BackendInputEventData::PointerAxis {
@@ -447,8 +473,65 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                         st.request_exit();
                     }
                     RuntimeIpcCommand::Reload => {
-                        let next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        let mut next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        let current_tuning = st.tuning.clone();
+                        let desired_mode = {
+                            let dev = drm_dev_for_timer.borrow();
+                            requested_mode_for_current_connector(
+                                &dev,
+                                active_connector_name_for_timer.borrow().as_str(),
+                                &next,
+                            )
+                        };
+
+                        match desired_mode {
+                            Ok(Some(mode)) => {
+                                let mode_changed = *active_mode_for_timer.borrow() != mode;
+                                if mode_changed {
+                                    let applied = {
+                                        let mut surface = gbm_surface_for_timer.borrow_mut();
+                                        surface.use_mode(mode).is_ok().then(|| {
+                                            surface.reset_buffers();
+                                        })
+                                    };
+                                    if applied.is_some() {
+                                        *active_mode_for_timer.borrow_mut() = mode;
+                                        let (new_w, new_h) = mode.size();
+                                        backend_handle_for_timer
+                                            .set_size(new_w as i32, new_h as i32);
+                                        update_tty_pointer_workspace(
+                                            &pointer_state_for_timer,
+                                            new_w as i32,
+                                            new_h as i32,
+                                        );
+                                    } else {
+                                        keep_last_good_tty_viewport(&mut next, &current_tuning);
+                                    }
+                                }
+                            }
+                            Ok(None) | Err(_) => keep_last_good_tty_viewport(&mut next, &current_tuning),
+                        }
+
                         st.apply_tuning(next);
+                        let (ws_w, ws_h) = backend_handle_for_timer.window_size_i32();
+                        st.zoom_ref_size = halley_core::field::Vec2 {
+                            x: ws_w.max(1) as f32,
+                            y: ws_h.max(1) as f32,
+                        };
+                        st.advertise_primary_output(
+                            active_connector_name_for_timer.borrow().as_str(),
+                            (*active_mode_for_timer.borrow()).into(),
+                        );
+                        publish_outputs(collect_outputs_for_ipc(
+                            &drm_dev_for_timer.borrow(),
+                            active_connector_name_for_timer.borrow().as_str(),
+                            *active_mode_for_timer.borrow(),
+                        ));
+                        run_autostart_commands(
+                            &st.tuning,
+                            wayland_display_for_timer.as_str(),
+                            AutostartPhase::OnReload,
+                        );
                         info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
                         info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                     }
@@ -498,12 +581,69 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 let mut rx_ref = watch_rx_for_timer.borrow_mut();
                 if let Some(rx) = rx_ref.as_mut() {
                     while rx.try_recv().is_ok() {
-                        let next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        let mut next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
+                        let current_tuning = st.tuning.clone();
+                        let desired_mode = {
+                            let dev = drm_dev_for_timer.borrow();
+                            requested_mode_for_current_connector(
+                                &dev,
+                                active_connector_name_for_timer.borrow().as_str(),
+                                &next,
+                            )
+                        };
+
+                        match desired_mode {
+                            Ok(Some(mode)) => {
+                                let mode_changed = *active_mode_for_timer.borrow() != mode;
+                                if mode_changed {
+                                    let applied = {
+                                        let mut surface = gbm_surface_for_timer.borrow_mut();
+                                        surface.use_mode(mode).is_ok().then(|| {
+                                            surface.reset_buffers();
+                                        })
+                                    };
+                                    if applied.is_some() {
+                                        *active_mode_for_timer.borrow_mut() = mode;
+                                        let (new_w, new_h) = mode.size();
+                                        backend_handle_for_timer
+                                            .set_size(new_w as i32, new_h as i32);
+                                        update_tty_pointer_workspace(
+                                            &pointer_state_for_timer,
+                                            new_w as i32,
+                                            new_h as i32,
+                                        );
+                                    } else {
+                                        keep_last_good_tty_viewport(&mut next, &current_tuning);
+                                    }
+                                }
+                            }
+                            Ok(None) | Err(_) => keep_last_good_tty_viewport(&mut next, &current_tuning),
+                        }
+
                         st.apply_tuning(next);
+                        let (ws_w, ws_h) = backend_handle_for_timer.window_size_i32();
+                        st.zoom_ref_size = halley_core::field::Vec2 {
+                            x: ws_w.max(1) as f32,
+                            y: ws_h.max(1) as f32,
+                        };
+                        st.advertise_primary_output(
+                            active_connector_name_for_timer.borrow().as_str(),
+                            (*active_mode_for_timer.borrow()).into(),
+                        );
+                        publish_outputs(collect_outputs_for_ipc(
+                            &drm_dev_for_timer.borrow(),
+                            active_connector_name_for_timer.borrow().as_str(),
+                            *active_mode_for_timer.borrow(),
+                        ));
                         reloaded = true;
                     }
                 }
                 if reloaded {
+                    run_autostart_commands(
+                        &st.tuning,
+                        wayland_display_for_timer.as_str(),
+                        AutostartPhase::OnReload,
+                    );
                     info!("reloaded config from {}", config_path_for_timer.as_str());
                     info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                 }

--- a/crates/halley-wl/src/run/winit_backend.rs
+++ b/crates/halley-wl/src/run/winit_backend.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use crate::backend_iface::DmabufImportBackend;
 use calloop::{Interest, Mode, PostAction, generic::Generic};
+use halley_config::AutostartPhase;
 use halley_ipc::{LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus};
 
 fn apply_host_cursor(
@@ -185,6 +186,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             {
                 let fresh = RuntimeTuning::load_from_path(config_path.as_str());
                 state.apply_tuning(fresh);
+                run_autostart_commands(&state.tuning, sock_name.as_str(), AutostartPhase::Once);
                 let ws = backend.borrow().window_size();
                 state.zoom_ref_size = halley_core::field::Vec2 {
                     x: ws.w.max(1) as f32,
@@ -220,6 +222,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let watch_rx = Rc::new(RefCell::new(watch_rx));
             let watch_rx_for_timer = watch_rx.clone();
             let config_path_for_timer = config_path.clone();
+            let wayland_display_for_timer = sock_name.clone();
             let last_maintenance_at = Rc::new(RefCell::new(Instant::now()));
             let last_maintenance_for_timer = last_maintenance_at.clone();
 
@@ -460,6 +463,11 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     RuntimeIpcCommand::Reload => {
                         let next = RuntimeTuning::load_from_path(config_path_for_timer.as_str());
                         st.apply_tuning(next);
+                        run_autostart_commands(
+                            &st.tuning,
+                            wayland_display_for_timer.as_str(),
+                            AutostartPhase::OnReload,
+                        );
                         info!("ipc: reloaded config from {}", config_path_for_timer.as_str());
                         info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                     }
@@ -517,6 +525,11 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     }
                 }
                 if reloaded {
+                    run_autostart_commands(
+                        &st.tuning,
+                        wayland_display_for_timer.as_str(),
+                        AutostartPhase::OnReload,
+                    );
                     info!("reloaded config from {}", config_path_for_timer.as_str());
                     info!("resolved keybinds: {}", st.tuning.keybinds_resolved_summary());
                 }

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -74,6 +74,15 @@ pub(crate) struct ActiveSpawnPan {
     pub reveal_at_ms: u64,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FullscreenRestore {
+    pub pos: Vec2,
+    pub intrinsic_size: Vec2,
+    pub pinned: bool,
+    pub bbox_loc: Option<(f32, f32)>,
+    pub window_geometry: Option<(f32, f32, f32, f32)>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SpawnAnchorMode {
     Focus,
@@ -179,6 +188,8 @@ pub struct HalleyWlState {
     pub(crate) active_spawn_pan: Option<ActiveSpawnPan>,
     pub(crate) started_at: Instant,
     pub(crate) last_debug_dump_at: Instant,
+    pub(crate) fullscreen_node: Option<NodeId>,
+    pub(crate) fullscreen_restore: HashMap<NodeId, FullscreenRestore>,
 }
 
 impl HalleyWlState {
@@ -293,12 +304,35 @@ impl HalleyWlState {
             active_spawn_pan: None,
             started_at: now,
             last_debug_dump_at: now,
+            fullscreen_node: None,
+            fullscreen_restore: HashMap::new(),
         };
         out.animator.set_spec(AnimSpec {
             state_change_ms: out.tuning.dev_anim_state_change_ms,
             bounce: out.tuning.dev_anim_bounce,
         });
         out
+    }
+
+    pub(crate) fn fullscreen_target_size(&self) -> Vec2 {
+        if let Some(output) = &self.primary_output
+            && let Some(mode) = output.current_mode()
+        {
+            return Vec2 {
+                x: mode.size.w.max(1) as f32,
+                y: mode.size.h.max(1) as f32,
+            };
+        }
+
+        Vec2 {
+            x: self.zoom_ref_size.x.max(1.0),
+            y: self.zoom_ref_size.y.max(1.0),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_fullscreen_node(&self, id: NodeId) -> bool {
+        self.fullscreen_node == Some(id)
     }
 
     pub(crate) fn configure_dmabuf_importer(

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -165,6 +165,10 @@ pub struct HalleyWlState {
     pub(crate) recent_top_node: Option<NodeId>,
     pub(crate) recent_top_until: Option<Instant>,
 
+    /// Nodes that still carry the placeholder size from new_toplevel and need
+    /// their intrinsic size synced from the first real committed geometry.
+    pub(crate) pending_initial_size_nodes: HashSet<NodeId>,
+
     pub(crate) spawn_cursor: u32,
     pub(crate) spawn_patch: Option<SpawnPatch>,
     pub(crate) spawn_anchor_mode: SpawnAnchorMode,
@@ -276,6 +280,8 @@ impl HalleyWlState {
             window_geometry: HashMap::new(),
             recent_top_node: None,
             recent_top_until: None,
+
+            pending_initial_size_nodes: HashSet::new(),
 
             spawn_cursor: 0,
             spawn_patch: None,

--- a/crates/halley-wl/src/surface/mod.rs
+++ b/crates/halley-wl/src/surface/mod.rs
@@ -1,5 +1,6 @@
 mod surface_ops;
 
 pub(crate) use surface_ops::{
-    current_surface_size_for_node, request_toplevel_resize_mode, window_geometry_for_node,
+    current_surface_size_for_node, request_toplevel_fullscreen_state, request_toplevel_resize_mode,
+    window_geometry_for_node,
 };

--- a/crates/halley-wl/src/surface/surface_ops.rs
+++ b/crates/halley-wl/src/surface/surface_ops.rs
@@ -6,6 +6,44 @@ use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use crate::state::HalleyWlState;
 
+pub(crate) fn request_toplevel_fullscreen_state(
+    st: &mut HalleyWlState,
+    node_id: halley_core::field::NodeId,
+    fullscreen: bool,
+) {
+    let size = if fullscreen {
+        st.fullscreen_target_size()
+    } else {
+        st.field.node(node_id).map(|node| node.intrinsic_size).unwrap_or_else(|| st.fullscreen_target_size())
+    };
+    let width = size.x.round().max(1.0) as i32;
+    let height = size.y.round().max(1.0) as i32;
+    let focused_node = st.last_input_surface_node();
+
+    for top in st.xdg_shell_state.toplevel_surfaces() {
+        let wl = top.wl_surface();
+        let key = wl.id();
+        if st.surface_to_node.get(&key).copied() != Some(node_id) {
+            continue;
+        }
+        top.with_pending_state(|s| {
+            s.size = Some((width, height).into());
+            if focused_node == Some(node_id) {
+                s.states.set(xdg_toplevel::State::Activated);
+            } else {
+                s.states.unset(xdg_toplevel::State::Activated);
+            }
+            if fullscreen {
+                s.states.set(xdg_toplevel::State::Fullscreen);
+            } else {
+                s.states.unset(xdg_toplevel::State::Fullscreen);
+            }
+        });
+        top.send_configure();
+        break;
+    }
+}
+
 pub(crate) fn request_toplevel_resize_mode(
     st: &mut HalleyWlState,
     node_id: halley_core::field::NodeId,
@@ -26,6 +64,11 @@ pub(crate) fn request_toplevel_resize_mode(
             // Keep toplevel activated during compositor-driven interactive resize.
             // Some CSD clients behave poorly if activation silently drops.
             s.states.set(xdg_toplevel::State::Activated);
+            if st.is_fullscreen_node(node_id) {
+                s.states.set(xdg_toplevel::State::Fullscreen);
+            } else {
+                s.states.unset(xdg_toplevel::State::Fullscreen);
+            }
             if resizing {
                 s.states.set(xdg_toplevel::State::Resizing);
             } else {

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -1,7 +1,7 @@
 use super::*;
 use eventline::info;
 use smithay::backend::allocator::dmabuf::Dmabuf;
-use smithay::desktop::{PopupKind, find_popup_root_surface, utils::bbox_from_surface_tree};
+use smithay::desktop::{PopupKind, find_popup_root_surface};
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::{
     Client, Resource, protocol::wl_output::WlOutput, protocol::wl_surface::WlSurface,
@@ -17,69 +17,12 @@ use smithay::wayland::selection::wlr_data_control::DataControlState;
 use smithay::wayland::shell::wlr_layer::{
     Layer, LayerSurface, LayerSurfaceConfigure, WlrLayerShellHandler, WlrLayerShellState,
 };
-use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 fn client_for_surface(surface: Option<&WlSurface>) -> Option<Client> {
     surface.and_then(|wl| wl.client())
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct InitialToplevelSize {
-    node_size: (i32, i32),
-    configure_size: Option<(i32, i32)>,
-}
 
-fn clamp_initial_window_size(viewport: halley_core::field::Vec2, size: (i32, i32)) -> (i32, i32) {
-    let min_w = ((viewport.x * 0.30).round() as i32).max(96);
-    let min_h = ((viewport.y * 0.26).round() as i32).max(72);
-    let max_w = ((viewport.x * 0.82).round() as i32).max(min_w);
-    let max_h = ((viewport.y * 0.82).round() as i32).max(min_h);
-
-    (size.0.clamp(min_w, max_w), size.1.clamp(min_h, max_h))
-}
-
-fn detected_initial_toplevel_size(toplevel: &ToplevelSurface) -> Option<(i32, i32)> {
-    let wl = toplevel.wl_surface();
-
-    let geometry = with_states(wl, |states| {
-        states
-            .cached_state
-            .get::<SurfaceCachedState>()
-            .current()
-            .geometry
-    });
-    if let Some(geometry) = geometry {
-        return Some((geometry.size.w.max(96), geometry.size.h.max(72)));
-    }
-
-    if let Some(size) = toplevel.current_state().size {
-        return Some((size.w.max(96), size.h.max(72)));
-    }
-
-    let bbox = bbox_from_surface_tree(wl, (0, 0));
-    if bbox.size.w > 0 && bbox.size.h > 0 {
-        return Some((bbox.size.w.max(96), bbox.size.h.max(72)));
-    }
-
-    None
-}
-
-fn initial_toplevel_size(st: &HalleyWlState, toplevel: &ToplevelSurface) -> InitialToplevelSize {
-    let detected = detected_initial_toplevel_size(toplevel);
-    let raw_size = detected.unwrap_or_else(|| {
-        (
-            (st.viewport.size.x * 0.46).round() as i32,
-            (st.viewport.size.y * 0.42).round() as i32,
-        )
-    });
-    let node_size = clamp_initial_window_size(st.viewport.size, raw_size);
-    let configure_size = (detected.is_none() || node_size != raw_size).then_some(node_size);
-
-    InitialToplevelSize {
-        node_size,
-        configure_size,
-    }
-}
 
 impl SeatHandler for HalleyWlState {
     type KeyboardFocus = WlSurface;
@@ -202,39 +145,34 @@ impl XdgShellHandler for HalleyWlState {
     }
 
     fn new_toplevel(&mut self, toplevel: ToplevelSurface) {
-        let initial_size = initial_toplevel_size(self, &toplevel);
-        // You MUST send an initial configure or many clients won’t map.
-        // Only send an explicit size when the client's initial proposal is
-        // absent or obviously outside the viewport-relative startup range.
+        // Send only Activated — no size hint. Clients know their preferred size;
+        // enforcing one here causes a node/buffer mismatch when the client commits
+        // something different. The node’s intrinsic size is corrected on first commit.
         toplevel.with_pending_state(|s| {
             s.states.set(xdg_toplevel::State::Activated);
-            if let Some((w, h)) = initial_size.configure_size {
-                s.size = Some((w, h).into());
-            }
         });
         toplevel.send_configure();
 
         // Detect child/transient toplevels (e.g. browser video-preview popups).
-        // These are spawned by the client as logical children of an existing
-        // surface and should not disturb the spatial layout of their parent.
         let is_transient = toplevel.parent().is_some();
 
-        // Create a core node for the underlying wl_surface.
+        // Placeholder size for spatial placement only — overwritten on first commit.
+        let placeholder_size = (
+            (self.viewport.size.x * 0.46).round() as i32,
+            (self.viewport.size.y * 0.42).round() as i32,
+        );
+
         let wl = toplevel.wl_surface().clone();
-        let id = self.ensure_node_for_surface(&wl, "toplevel", initial_size.node_size);
+        let id = self.ensure_node_for_surface(&wl, "toplevel", placeholder_size);
+        // Flag this node so note_commit syncs its size from the real committed geometry.
+        self.pending_initial_size_nodes.insert(id);
+
         let now = Instant::now();
         let _ = self.field.touch(id, self.now_ms(now));
 
         if is_transient {
-            // New transient windows should be immediately typeable and stay
-            // focused until the user explicitly focuses another surface.
             self.set_interaction_focus(Some(id), 30_000, now);
-            // Cancel the delayed activation that would call
-            // push_neighbors_for_activation. The surface is already Active and
-            // Hot from ensure_node_for_surface; we just don’t want it shoving
-            // the parent window aside when the preview pops up.
             self.pending_spawn_activate_at_ms.remove(&id);
-            // Still play the appear animation so it doesn’t just snap in.
             self.mark_active_transition(id, now, 620);
         } else {
             self.queue_spawn_pan_to_node(id, now);
@@ -288,47 +226,6 @@ impl XdgShellHandler for HalleyWlState {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::clamp_initial_window_size;
-    use halley_core::field::Vec2;
-
-    #[test]
-    fn clamp_initial_window_size_raises_tiny_windows() {
-        let out = clamp_initial_window_size(
-            Vec2 {
-                x: 1600.0,
-                y: 1200.0,
-            },
-            (220, 180),
-        );
-        assert_eq!(out, (480, 312));
-    }
-
-    #[test]
-    fn clamp_initial_window_size_trims_short_wide_windows() {
-        let out = clamp_initial_window_size(
-            Vec2 {
-                x: 1600.0,
-                y: 1200.0,
-            },
-            (1600, 240),
-        );
-        assert_eq!(out, (1312, 312));
-    }
-
-    #[test]
-    fn clamp_initial_window_size_preserves_sensible_windows() {
-        let out = clamp_initial_window_size(
-            Vec2 {
-                x: 1600.0,
-                y: 1200.0,
-            },
-            (900, 700),
-        );
-        assert_eq!(out, (900, 700));
-    }
-}
 
 delegate_xdg_shell!(HalleyWlState);
 

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -202,6 +202,17 @@ impl XdgShellHandler for HalleyWlState {
         // not client-request driven.
     }
 
+    fn fullscreen_request(&mut self, surface: ToplevelSurface, _output: Option<WlOutput>) {
+        self.enter_fullscreen(surface, Instant::now());
+    }
+
+    fn unfullscreen_request(&mut self, surface: ToplevelSurface) {
+        let key = surface.wl_surface().id();
+        if let Some(id) = self.surface_to_node.get(&key).copied() {
+            self.exit_fullscreen(id);
+        }
+    }
+
     fn grab(&mut self, surface: PopupSurface, _seat: wl_seat::WlSeat, serial: Serial) {
         let popup = PopupKind::from(surface);
         if let Ok(root) = find_popup_root_surface(&popup) {

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -8,6 +8,7 @@ use smithay::reexports::wayland_server::{
 
 use crate::activity::CommitActivity;
 use crate::state::HalleyWlState;
+use crate::surface::request_toplevel_fullscreen_state;
 use crate::wm::overlap::CollisionExtents;
 
 /// Generates candidate spawn positions using a Fermat spiral (golden-angle
@@ -203,6 +204,7 @@ impl HalleyWlState {
             if Some(other.id) == skip_node
                 || other.kind != halley_core::field::NodeKind::Surface
                 || !self.field.is_visible(other.id)
+                || self.is_fullscreen_node(other.id)
             {
                 return false;
             }
@@ -410,6 +412,79 @@ impl HalleyWlState {
         self.maybe_start_pending_spawn_pan(now);
     }
 
+    pub(crate) fn enter_fullscreen(&mut self, surface: smithay::wayland::shell::xdg::ToplevelSurface, now: Instant) {
+        let key = Self::surface_key(surface.wl_surface());
+        let Some(id) = self.surface_to_node.get(&key).copied() else {
+            return;
+        };
+
+        if self.fullscreen_node == Some(id) {
+            request_toplevel_fullscreen_state(self, id, true);
+            self.set_interaction_focus(Some(id), 30_000, now);
+            return;
+        }
+
+        if let Some(other) = self.fullscreen_node
+            && other != id
+        {
+            self.exit_fullscreen(other);
+        }
+
+        let Some(node) = self.field.node(id) else {
+            return;
+        };
+        self.fullscreen_restore.entry(id).or_insert(crate::state::FullscreenRestore {
+            pos: node.pos,
+            intrinsic_size: node.intrinsic_size,
+            pinned: node.pinned,
+            bbox_loc: self.bbox_loc.get(&id).copied(),
+            window_geometry: self.window_geometry.get(&id).copied(),
+        });
+
+        let target_size = self.fullscreen_target_size();
+        let _ = self.field.set_state(id, halley_core::field::NodeState::Active);
+        if let Some(node) = self.field.node_mut(id) {
+            node.intrinsic_size = target_size;
+            node.footprint = target_size;
+        }
+        let _ = self.field.carry(id, self.viewport.center);
+        self.last_active_size.insert(id, target_size);
+        self.manual_collapsed_nodes.remove(&id);
+        self.fullscreen_node = Some(id);
+        self.set_recent_top_node(id, now + std::time::Duration::from_secs(3600));
+        request_toplevel_fullscreen_state(self, id, true);
+        self.set_interaction_focus(Some(id), 30_000, now);
+    }
+
+    pub(crate) fn exit_fullscreen(&mut self, id: NodeId) {
+        if self.fullscreen_node != Some(id) {
+            return;
+        }
+
+        if let Some(restore) = self.fullscreen_restore.remove(&id) {
+            if let Some(node) = self.field.node_mut(id) {
+                node.intrinsic_size = restore.intrinsic_size;
+                node.footprint = restore.intrinsic_size;
+                node.pinned = restore.pinned;
+            }
+            if let Some(bbox_loc) = restore.bbox_loc {
+                self.bbox_loc.insert(id, bbox_loc);
+            } else {
+                self.bbox_loc.remove(&id);
+            }
+            if let Some(window_geometry) = restore.window_geometry {
+                self.window_geometry.insert(id, window_geometry);
+            } else {
+                self.window_geometry.remove(&id);
+            }
+            let _ = self.field.carry(id, restore.pos);
+            self.last_active_size.insert(id, restore.intrinsic_size);
+        }
+
+        self.fullscreen_node = None;
+        request_toplevel_fullscreen_state(self, id, false);
+    }
+
     pub fn drop_surface(&mut self, surface: &WlSurface) {
         if let Some(output) = &self.primary_output {
             output.leave(surface);
@@ -417,6 +492,10 @@ impl HalleyWlState {
         let key = Self::surface_key(surface);
         self.surface_activity.remove(&key);
         if let Some(id) = self.surface_to_node.remove(&key) {
+            if self.fullscreen_node == Some(id) {
+                self.fullscreen_node = None;
+            }
+            self.fullscreen_restore.remove(&id);
             if self.pan_restore_active_focus == Some(id) {
                 self.pan_restore_active_focus = None;
             }

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -239,11 +239,54 @@ impl HalleyWlState {
     pub fn note_commit(&mut self, surface: &WlSurface, now: Instant) {
         let key = Self::surface_key(surface);
         self.surface_activity
-            .entry(key)
+            .entry(key.clone())
             .or_insert_with(|| CommitActivity::new(now))
             .on_commit(now);
         if let Some(output) = &self.primary_output {
             output.enter(surface);
+        }
+
+        // Sync the node’s intrinsic size from what the client actually committed.
+        // We only do this for nodes that are still carrying the placeholder size
+        // from new_toplevel (tracked in pending_initial_size_nodes). Once the
+        // first real buffer lands, we read the true geometry and update the node
+        // so that collision, hit-testing, and adjacent placement all use real data.
+        if let Some(&id) = self.surface_to_node.get(&key) {
+            if self.pending_initial_size_nodes.contains(&id) {
+                use smithay::desktop::utils::bbox_from_surface_tree;
+                use smithay::wayland::compositor::with_states;
+                use smithay::wayland::shell::xdg::SurfaceCachedState;
+
+                // Prefer the xdg window geometry if present, fall back to bbox.
+                let committed_size: Option<(i32, i32)> =
+                    with_states(surface, |states| {
+                        states
+                            .cached_state
+                            .get::<SurfaceCachedState>()
+                            .current()
+                            .geometry
+                            .map(|g| (g.size.w, g.size.h))
+                    })
+                    .filter(|&(w, h)| w > 0 && h > 0)
+                    .or_else(|| {
+                        let bbox = bbox_from_surface_tree(surface, (0, 0));
+                        (bbox.size.w > 0 && bbox.size.h > 0)
+                            .then_some((bbox.size.w, bbox.size.h))
+                    });
+
+                if let Some((w, h)) = committed_size {
+                    let new_size = Vec2 {
+                        x: w.max(64) as f32,
+                        y: h.max(64) as f32,
+                    };
+                    if let Some(node) = self.field.node_mut(id) {
+                        node.intrinsic_size = new_size;
+                    }
+                    self.zoom_nominal_size.insert(id, new_size);
+                    self.last_active_size.insert(id, new_size);
+                    self.pending_initial_size_nodes.remove(&id);
+                }
+            }
         }
 
         // Grant keyboard focus to layer surfaces (e.g. fuzzel) on their first
@@ -379,6 +422,7 @@ impl HalleyWlState {
             }
             let _ = self.field.undock_node(id);
             self.field.clear_dock_preview();
+            self.pending_initial_size_nodes.remove(&id);
             self.zoom_nominal_size.remove(&id);
             self.zoom_resize_fallback.remove(&id);
             self.zoom_resize_reject_streak.remove(&id);

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -59,6 +59,12 @@ impl HalleyWlState {
                 } else {
                     s.states.unset(xdg_toplevel::State::Activated);
                 }
+                let fullscreen = self.surface_to_node.get(&key).copied() == self.fullscreen_node;
+                if fullscreen {
+                    s.states.set(xdg_toplevel::State::Fullscreen);
+                } else {
+                    s.states.unset(xdg_toplevel::State::Fullscreen);
+                }
                 was_active != focused
             });
 

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -1,9 +1,7 @@
 use super::*;
 use std::collections::VecDeque;
-
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::Resource;
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct CollisionExtents {
     pub left: f32,
@@ -11,7 +9,6 @@ pub(crate) struct CollisionExtents {
     pub top: f32,
     pub bottom: f32,
 }
-
 impl CollisionExtents {
     #[inline]
     pub(crate) fn symmetric(size: Vec2) -> Self {
@@ -22,7 +19,6 @@ impl CollisionExtents {
             bottom: size.y * 0.5,
         }
     }
-
     #[inline]
     fn size(self) -> Vec2 {
         Vec2 {
@@ -31,7 +27,6 @@ impl CollisionExtents {
         }
     }
 }
-
 impl HalleyWlState {
     const PHYSICS_DEPTH_LIMIT: usize = 6;
     const DRAG_AXIS_DOMINANCE: f32 = 1.35;
@@ -42,32 +37,26 @@ impl HalleyWlState {
     const PHYSICS_MAX_IMPULSE_LIMIT: f32 = 2200.0;
     const PHYSICS_MIN_BOUNCE_LIMIT: f32 = 420.0;
     const PHYSICS_MAX_BOUNCE_LIMIT: f32 = 2600.0;
-
     #[inline]
     fn bump_response(&self) -> f32 {
         self.tuning.non_overlap_bump_damping.clamp(0.05, 1.0)
     }
-
     #[inline]
     fn physics_damping_per_sec(&self) -> f32 {
         1.8 + self.bump_response() * 4.2
     }
-
     #[inline]
     fn drag_impulse_gain(&self) -> f32 {
         2.6 + self.bump_response() * 2.4
     }
-
     #[inline]
     fn collision_push_gain(&self) -> f32 {
         5.5 + self.bump_response() * 7.5
     }
-
     #[inline]
     fn collision_bounce(&self) -> f32 {
         0.05 + self.bump_response() * 0.17
     }
-
     #[inline]
     pub(crate) fn carry_for_physics(&mut self, id: NodeId, to: Vec2) -> bool {
         if self.resize_static_node == Some(id) {
@@ -101,19 +90,16 @@ impl HalleyWlState {
         }
         true
     }
-
     #[inline]
     fn world_units_per_px_xy(&self) -> (f32, f32) {
         let wx = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let wy = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
         (wx.max(0.01), wy.max(0.01))
     }
-
     pub(crate) fn non_overlap_gap_world(&self) -> f32 {
         let (wx, wy) = self.world_units_per_px_xy();
         self.tuning.non_overlap_gap_px.max(0.0) * ((wx + wy) * 0.5)
     }
-
     #[inline]
     pub(crate) fn required_sep_x(
         &self,
@@ -129,7 +115,6 @@ impl HalleyWlState {
             a_ext.left + b_ext.right + gap
         }
     }
-
     #[inline]
     pub(crate) fn required_sep_y(
         &self,
@@ -145,7 +130,6 @@ impl HalleyWlState {
             a_ext.top + b_ext.bottom + gap
         }
     }
-
     #[inline]
     pub(crate) fn update_release_axis_from_motion(&mut self, id: NodeId, motion: Vec2) {
         if motion.x.abs() > motion.y.abs() * Self::DRAG_AXIS_DOMINANCE {
@@ -154,14 +138,12 @@ impl HalleyWlState {
             self.release_axis_lock.insert(id, false);
         }
     }
-
     #[inline]
     pub(crate) fn release_smoothing_active_for(&self, id: NodeId, now_ms: u64) -> bool {
         self.release_smoothing_until_ms
             .get(&id)
             .is_some_and(|&until| until > now_ms)
     }
-
     #[inline]
     fn collision_axis(motion: Vec2, overlap_x: f32, overlap_y: f32) -> bool {
         if motion.x.abs() > motion.y.abs() * Self::DRAG_AXIS_DOMINANCE {
@@ -172,7 +154,6 @@ impl HalleyWlState {
             overlap_x <= overlap_y
         }
     }
-
     #[inline]
     fn push_direction(delta: f32, motion: f32) -> f32 {
         if motion.abs() > 0.01 {
@@ -183,14 +164,12 @@ impl HalleyWlState {
             -1.0
         }
     }
-
     #[inline]
     fn body_locked(&self, id: NodeId) -> bool {
         self.carry_zone_hint.contains_key(&id)
             || self.resize_active == Some(id)
             || self.resize_static_node == Some(id)
     }
-
     #[inline]
     fn add_physics_velocity(&mut self, id: NodeId, delta: Vec2) {
         let inv_mass = self.body_inverse_mass(id);
@@ -209,7 +188,6 @@ impl HalleyWlState {
         vel.x = (vel.x + delta.x * inv_mass).clamp(-limit, limit);
         vel.y = (vel.y + delta.y * inv_mass).clamp(-limit, limit);
     }
-
     #[inline]
     fn body_mass_for_node(&self, node: &halley_core::field::Node) -> f32 {
         match node.state {
@@ -221,7 +199,6 @@ impl HalleyWlState {
             }
         }
     }
-
     #[inline]
     fn body_inverse_mass(&self, id: NodeId) -> f32 {
         self.field
@@ -229,7 +206,6 @@ impl HalleyWlState {
             .map(|node| 1.0 / self.body_mass_for_node(node).max(0.001))
             .unwrap_or(1.0)
     }
-
     #[inline]
     fn collision_velocity_limit(
         &self,
@@ -258,7 +234,6 @@ impl HalleyWlState {
             )
         }
     }
-
     fn carry_surface_docking_clamped(&mut self, id: NodeId, to: Vec2) -> bool {
         let Some(node) = self.field.node(id) else {
             return false;
@@ -271,7 +246,6 @@ impl HalleyWlState {
             y: to.y - from.y,
         };
         let mut mover_pos = to;
-
         for _ in 0..12 {
             let others: Vec<(Vec2, CollisionExtents)> = self
                 .field
@@ -313,13 +287,17 @@ impl HalleyWlState {
                 break;
             }
         }
-
         self.carry_for_physics(id, mover_pos)
     }
-
     fn apply_drag_impulses(&mut self, source_id: NodeId, drag_motion: Vec2) {
-        let mut queue = VecDeque::from([(source_id, drag_motion, 0usize)]);
-        while let Some((mover_id, motion, depth)) = queue.pop_front() {
+        // Use total drag speed for impulse magnitude so a diagonal approach at
+        // speed V gives the same kick as a direct axis-aligned hit at speed V.
+        // Previously motion.x.abs()/motion.y.abs() was used per-branch, which
+        // gave only ~70% of the correct impulse on a 45-degree approach, making
+        // the neighbor escape too slowly and getting hit again next frame.
+        let drag_speed = (drag_motion.x * drag_motion.x + drag_motion.y * drag_motion.y).sqrt();
+        let mut queue = VecDeque::from([(source_id, drag_motion, drag_speed, 0usize)]);
+        while let Some((mover_id, motion, motion_speed, depth)) = queue.pop_front() {
             if depth >= Self::PHYSICS_DEPTH_LIMIT {
                 continue;
             }
@@ -350,7 +328,6 @@ impl HalleyWlState {
                     ))
                 })
                 .collect();
-
             for (other_id, other_pos, other_ext, other_locked) in others {
                 let dx = other_pos.x - mover_pos.x;
                 let dy = other_pos.y - mover_pos.y;
@@ -363,7 +340,6 @@ impl HalleyWlState {
                 if overlap_x <= 0.0 || overlap_y <= 0.0 {
                     continue;
                 }
-
                 if Self::collision_axis(motion, overlap_x, overlap_y) {
                     let dir = Self::push_direction(dx, motion.x);
                     if other_locked {
@@ -383,7 +359,7 @@ impl HalleyWlState {
                     };
                     let impulse_limit = self.collision_velocity_limit(mover_ext, other_ext, false);
                     let impulse = (dir
-                        * (motion.x.abs() * self.drag_impulse_gain()
+                        * (motion_speed * self.drag_impulse_gain()
                             + correction * self.collision_push_gain()))
                     .clamp(-impulse_limit, impulse_limit);
                     let _ = self.carry_for_physics(other_id, target);
@@ -394,6 +370,7 @@ impl HalleyWlState {
                             x: impulse * 0.014,
                             y: 0.0,
                         },
+                        impulse.abs() * 0.014,
                         depth + 1,
                     ));
                 } else {
@@ -415,7 +392,7 @@ impl HalleyWlState {
                     };
                     let impulse_limit = self.collision_velocity_limit(mover_ext, other_ext, false);
                     let impulse = (dir
-                        * (motion.y.abs() * self.drag_impulse_gain()
+                        * (motion_speed * self.drag_impulse_gain()
                             + correction * self.collision_push_gain()))
                     .clamp(-impulse_limit, impulse_limit);
                     let _ = self.carry_for_physics(other_id, target);
@@ -426,13 +403,13 @@ impl HalleyWlState {
                             x: 0.0,
                             y: impulse * 0.014,
                         },
+                        impulse.abs() * 0.014,
                         depth + 1,
                     ));
                 }
             }
         }
     }
-
     fn resolve_static_surface_collisions(&mut self) {
         let mut ids: Vec<NodeId> = self
             .field
@@ -448,7 +425,6 @@ impl HalleyWlState {
             .collect();
         ids.sort_by_key(|id| id.as_u64());
         let gap = self.non_overlap_gap_world();
-
         for _ in 0..24 {
             let mut changed = false;
             for i in 0..ids.len() {
@@ -476,13 +452,11 @@ impl HalleyWlState {
                     if overlap_x <= 0.0 || overlap_y <= 0.0 {
                         continue;
                     }
-
                     let a_locked = self.resize_static_node == Some(a) || na.pinned;
                     let b_locked = self.resize_static_node == Some(b) || nb.pinned;
                     if a_locked && b_locked {
                         continue;
                     }
-
                     if overlap_x <= overlap_y {
                         let dir = if dx >= 0.0 { 1.0 } else { -1.0 };
                         let correction = overlap_x + 0.1;
@@ -573,7 +547,6 @@ impl HalleyWlState {
             }
         }
     }
-
     pub(crate) fn carry_surface_non_overlap(&mut self, id: NodeId, to: Vec2) -> bool {
         if self.docking_active {
             return self.carry_surface_docking_clamped(id, to);
@@ -598,7 +571,6 @@ impl HalleyWlState {
         self.apply_drag_impulses(id, motion);
         true
     }
-
     fn resolve_dynamic_collisions(&mut self, dt: f32) {
         let gap = self.non_overlap_gap_world();
         let ids: Vec<NodeId> = self
@@ -608,8 +580,7 @@ impl HalleyWlState {
             .copied()
             .filter(|&id| self.field.is_visible(id))
             .collect();
-
-        for _ in 0..3 {
+        for _ in 0..10 {
             let mut changed = false;
             for i in 0..ids.len() {
                 for j in (i + 1)..ids.len() {
@@ -636,13 +607,11 @@ impl HalleyWlState {
                     if overlap_x <= 0.0 || overlap_y <= 0.0 {
                         continue;
                     }
-
                     let a_locked = self.body_locked(a) || na.pinned;
                     let b_locked = self.body_locked(b) || nb.pinned;
                     if a_locked && b_locked {
                         continue;
                     }
-
                     let va = self
                         .physics_velocity
                         .get(&a)
@@ -657,9 +626,8 @@ impl HalleyWlState {
                         x: vb.x - va.x,
                         y: vb.y - va.y,
                     };
-
                     if Self::collision_axis(rel, overlap_x, overlap_y) {
-                        let dir = Self::push_direction(dx, rel.x);
+                        let dir = if dx >= 0.0 { 1.0f32 } else { -1.0 };
                         let correction = overlap_x + gap * 0.02;
                         let bounce_limit = self.collision_velocity_limit(aext, bext, true);
                         let speed = (correction / dt.max(1.0 / 240.0)).clamp(0.0, bounce_limit);
@@ -730,7 +698,7 @@ impl HalleyWlState {
                             );
                         }
                     } else {
-                        let dir = Self::push_direction(dy, rel.y);
+                        let dir = if dy >= 0.0 { 1.0_f32 } else { -1.0 };
                         let correction = overlap_y + gap * 0.02;
                         let bounce_limit = self.collision_velocity_limit(aext, bext, true);
                         let speed = (correction / dt.max(1.0 / 240.0)).clamp(0.0, bounce_limit);
@@ -809,12 +777,10 @@ impl HalleyWlState {
             }
         }
     }
-
     pub(crate) fn tick_passive_physics(&mut self) {
         if !self.tuning.physics_enabled {
             return;
         }
-
         let dt = (1.0_f32 / 60.0).clamp(1.0 / 240.0, 1.0 / 20.0);
         let ids: Vec<NodeId> = self.physics_velocity.keys().copied().collect();
         for id in ids {
@@ -844,10 +810,8 @@ impl HalleyWlState {
                 v.y *= damping;
             }
         }
-
         self.resolve_dynamic_collisions(dt);
     }
-
     fn preview_collision_size(real_w: f32, real_h: f32) -> Vec2 {
         let w = real_w.max(1.0);
         let h = real_h.max(1.0);
@@ -866,7 +830,6 @@ impl HalleyWlState {
         out_h = out_h.clamp(100.0, 220.0);
         Vec2 { x: out_w, y: out_h }
     }
-
     #[inline]
     fn active_collision_scale(anim_scale: f32, real_w: f32, real_h: f32) -> f32 {
         let base = Self::preview_collision_size(real_w, real_h);
@@ -881,12 +844,10 @@ impl HalleyWlState {
         }
         out.clamp(0.24, 1.08)
     }
-
     #[inline]
     fn proxy_collision_scale(anim_scale: f32) -> f32 {
         anim_scale.clamp(0.22, 1.4)
     }
-
     fn node_collision_extents(&self, label: &str, anim_scale: f32) -> CollisionExtents {
         let zx = self.viewport.size.x / self.zoom_ref_size.x.max(1.0);
         let zy = self.viewport.size.y / self.zoom_ref_size.y.max(1.0);
@@ -909,7 +870,6 @@ impl HalleyWlState {
             y: marker_h_px * world_per_px_y.max(0.01),
         })
     }
-
     fn surface_window_collision_extents(&self, n: &halley_core::field::Node) -> CollisionExtents {
         let basis = self
             .last_active_size
@@ -936,7 +896,6 @@ impl HalleyWlState {
             bottom: bottom * basis.y.max(1.0) / bbox_h * world_per_px_y,
         }
     }
-
     pub(crate) fn spawn_obstacle_extents_for_node(
         &self,
         n: &halley_core::field::Node,
@@ -947,7 +906,6 @@ impl HalleyWlState {
             self.collision_extents_for_node(n)
         }
     }
-
     pub(crate) fn collision_extents_for_node(
         &self,
         n: &halley_core::field::Node,
@@ -976,18 +934,15 @@ impl HalleyWlState {
             halley_core::field::NodeState::Drifting => CollisionExtents::symmetric(n.footprint),
         }
     }
-
     pub(super) fn collision_size_for_node(&self, n: &halley_core::field::Node) -> Vec2 {
         self.collision_extents_for_node(n).size()
     }
-
     pub(crate) fn resolve_surface_overlap(&mut self) {
         if self.tuning.physics_enabled || self.suspend_overlap_resolve {
             return;
         }
         self.resolve_static_surface_collisions();
     }
-
     pub(super) fn request_toplevel_resize(&mut self, node_id: NodeId, width: i32, height: i32) {
         let width = width.max(96);
         let height = height.max(72);
@@ -1011,11 +966,9 @@ impl HalleyWlState {
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
     fn test_state(tuning: halley_config::RuntimeTuning) -> HalleyWlState {
         let dh = smithay::reexports::wayland_server::Display::<HalleyWlState>::new()
             .expect("display")
@@ -1031,7 +984,6 @@ mod tests {
         };
         state
     }
-
     #[test]
     fn collapsed_surface_nodes_use_marker_collision_extents() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1051,7 +1003,6 @@ mod tests {
         assert!(ext.left + ext.right < 300.0);
         assert!(ext.top + ext.bottom < 120.0);
     }
-
     #[test]
     fn resolve_surface_overlap_enforces_configured_gap() {
         let mut tuning = halley_config::RuntimeTuning::default();
@@ -1075,7 +1026,6 @@ mod tests {
         let req_x = state.required_sep_x(na.pos.x, ea, nb.pos.x, eb, gap);
         assert!(dx >= req_x - 0.5);
     }
-
     #[test]
     fn static_drag_resolution_keeps_surfaces_non_overlapping_when_physics_is_disabled() {
         let mut tuning = halley_config::RuntimeTuning::default();
@@ -1089,10 +1039,8 @@ mod tests {
             state
                 .field
                 .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
-
         state.begin_carry_state_tracking(a);
         assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
-
         let na = state.field.node(a).expect("first node");
         let nb = state.field.node(b).expect("second node");
         let ea = state.collision_extents_for_node(na);
@@ -1105,7 +1053,6 @@ mod tests {
             "expected static carry path to keep surfaces separated: dx={dx}, req_x={req_x}"
         );
     }
-
     #[test]
     fn static_drag_resolution_splits_overlap_correction_across_windows() {
         let mut tuning = halley_config::RuntimeTuning::default();
@@ -1119,10 +1066,8 @@ mod tests {
             state
                 .field
                 .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
-
         state.begin_carry_state_tracking(a);
         assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
-
         let na = state.field.node(a).expect("first node");
         let nb = state.field.node(b).expect("second node");
         let moved_a = 280.0 - na.pos.x;
@@ -1136,7 +1081,6 @@ mod tests {
             "expected static resolution to split correction evenly: a={moved_a}, b={moved_b}"
         );
     }
-
     #[test]
     fn physics_drag_adds_extra_velocity_to_hit_window() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1148,10 +1092,8 @@ mod tests {
             state
                 .field
                 .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
-
         state.begin_carry_state_tracking(a);
         assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
-
         let vb = state
             .physics_velocity
             .get(&b)
@@ -1163,7 +1105,6 @@ mod tests {
             vb
         );
     }
-
     #[test]
     fn collapsed_nodes_receive_less_velocity_than_active_windows() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1179,10 +1120,8 @@ mod tests {
         let _ = state
             .field
             .set_state(node, halley_core::field::NodeState::Node);
-
         state.add_physics_velocity(window, Vec2 { x: 100.0, y: 0.0 });
         state.add_physics_velocity(node, Vec2 { x: 100.0, y: 0.0 });
-
         let window_vx = state
             .physics_velocity
             .get(&window)
@@ -1195,13 +1134,11 @@ mod tests {
             .copied()
             .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
             .x;
-
         assert!(
             node_vx > 0.0 && node_vx < window_vx,
             "expected collapsed node to pick up less velocity than a window: node={node_vx}, window={window_vx}"
         );
     }
-
     #[test]
     fn passive_window_keeps_moving_after_drag_impulse() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1213,21 +1150,17 @@ mod tests {
             state
                 .field
                 .spawn_surface("b", Vec2 { x: 430.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
-
         state.begin_carry_state_tracking(a);
         assert!(state.carry_surface_non_overlap(a, Vec2 { x: 280.0, y: 0.0 }));
         let before = state.field.node(b).expect("hit window").pos;
-
         state.tick_passive_physics();
         state.tick_passive_physics();
-
         let after = state.field.node(b).expect("hit window after").pos;
         assert!(
             after.x > before.x + 1.0,
             "expected passive window to keep moving after contact: before={before:?}, after={after:?}"
         );
     }
-
     #[test]
     fn chained_window_node_collision_caps_runaway_velocity() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1248,10 +1181,8 @@ mod tests {
         let _ = state
             .field
             .set_state(node, halley_core::field::NodeState::Node);
-
         state.begin_carry_state_tracking(dragged);
         assert!(state.carry_surface_non_overlap(dragged, Vec2 { x: -40.0, y: 0.0 }));
-
         let node_vx = state
             .physics_velocity
             .get(&node)
@@ -1282,7 +1213,6 @@ mod tests {
                 state.collision_velocity_limit(ext, ext, true)
             })
             .expect("other limit");
-
         assert!(
             node_vx <= node_limit + 0.1,
             "expected node velocity to stay bounded after chained overlap: {node_vx}"
@@ -1291,11 +1221,9 @@ mod tests {
             other_vx <= other_limit + 0.1,
             "expected downstream window velocity to stay bounded after chained overlap: {other_vx}"
         );
-
         for _ in 0..8 {
             state.tick_passive_physics();
         }
-
         let node_vx_after = state
             .physics_velocity
             .get(&node)
@@ -1310,7 +1238,6 @@ mod tests {
             .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
             .x
             .abs();
-
         assert!(
             node_vx_after <= node_limit + 0.1,
             "expected passive node bounce to stay bounded: {node_vx_after}"
@@ -1320,7 +1247,6 @@ mod tests {
             "expected passive window bounce to stay bounded: {other_vx_after}"
         );
     }
-
     #[test]
     fn lower_damping_reduces_collision_impulse_strength() {
         let mut soft_tuning = halley_config::RuntimeTuning::default();
@@ -1340,7 +1266,6 @@ mod tests {
             .copied()
             .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
             .x;
-
         let mut firm_tuning = halley_config::RuntimeTuning::default();
         firm_tuning.non_overlap_bump_damping = 0.9;
         let mut firm = test_state(firm_tuning);
@@ -1358,13 +1283,11 @@ mod tests {
             .copied()
             .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
             .x;
-
         assert!(
             soft_vx > 0.0 && firm_vx > soft_vx,
             "expected firmer damping to yield a stronger impulse: soft={soft_vx}, firm={firm_vx}"
         );
     }
-
     #[test]
     fn docking_mode_clamps_the_dragged_window_instead_of_pushing_neighbors() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
@@ -1377,9 +1300,7 @@ mod tests {
             state
                 .field
                 .spawn_surface("b", Vec2 { x: 20.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
-
         assert!(state.carry_surface_non_overlap(a, Vec2 { x: 20.0, y: 0.0 }));
-
         let na = state.field.node(a).expect("first window");
         let nb = state.field.node(b).expect("second window");
         assert!((nb.pos.x - 20.0).abs() < 0.01);

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -238,6 +238,9 @@ impl HalleyWlState {
         let Some(node) = self.field.node(id) else {
             return false;
         };
+        if self.is_fullscreen_node(id) {
+            return false;
+        }
         let from = node.pos;
         let mover_ext = self.collision_extents_for_node(node);
         let gap = self.non_overlap_gap_world();
@@ -253,6 +256,9 @@ impl HalleyWlState {
                 .iter()
                 .filter_map(|(&oid, other)| {
                     if oid == id || !self.field.is_visible(oid) {
+                        return None;
+                    }
+                    if self.is_fullscreen_node(oid) {
                         return None;
                     }
                     if self.field.dock_partner(id) == Some(oid)
@@ -304,6 +310,9 @@ impl HalleyWlState {
             let Some(mover) = self.field.node(mover_id) else {
                 continue;
             };
+            if self.is_fullscreen_node(mover_id) {
+                continue;
+            }
             let mover_pos = mover.pos;
             let mover_ext = self.collision_extents_for_node(mover);
             let gap = self.non_overlap_gap_world();
@@ -313,6 +322,9 @@ impl HalleyWlState {
                 .iter()
                 .filter_map(|(&oid, other)| {
                     if oid == mover_id || !self.field.is_visible(oid) {
+                        return None;
+                    }
+                    if self.is_fullscreen_node(oid) {
                         return None;
                     }
                     if self.field.dock_partner(mover_id) == Some(oid)
@@ -420,7 +432,9 @@ impl HalleyWlState {
             .filter(|&id| {
                 self.field
                     .node(id)
-                    .is_some_and(|n| n.kind == halley_core::field::NodeKind::Surface)
+                    .is_some_and(|n| {
+                        n.kind == halley_core::field::NodeKind::Surface && !self.is_fullscreen_node(id)
+                    })
             })
             .collect();
         ids.sort_by_key(|id| id.as_u64());
@@ -548,6 +562,9 @@ impl HalleyWlState {
         }
     }
     pub(crate) fn carry_surface_non_overlap(&mut self, id: NodeId, to: Vec2) -> bool {
+        if self.is_fullscreen_node(id) {
+            return false;
+        }
         if self.docking_active {
             return self.carry_surface_docking_clamped(id, to);
         }
@@ -579,6 +596,7 @@ impl HalleyWlState {
             .keys()
             .copied()
             .filter(|&id| self.field.is_visible(id))
+            .filter(|&id| !self.is_fullscreen_node(id))
             .collect();
         for _ in 0..10 {
             let mut changed = false;
@@ -910,6 +928,9 @@ impl HalleyWlState {
         &self,
         n: &halley_core::field::Node,
     ) -> CollisionExtents {
+        if self.is_fullscreen_node(n.id) {
+            return CollisionExtents::symmetric(Vec2 { x: 0.0, y: 0.0 });
+        }
         let now = Instant::now();
         let anim = self.anim_style_for(n.id, n.state.clone(), now);
         match n.state {
@@ -959,6 +980,11 @@ impl HalleyWlState {
                     s.states.set(xdg_toplevel::State::Activated);
                 } else {
                     s.states.unset(xdg_toplevel::State::Activated);
+                }
+                if self.is_fullscreen_node(node_id) {
+                    s.states.set(xdg_toplevel::State::Fullscreen);
+                } else {
+                    s.states.unset(xdg_toplevel::State::Fullscreen);
                 }
             });
             top.send_configure();

--- a/crates/halley-wl/src/wm/overlap.rs
+++ b/crates/halley-wl/src/wm/overlap.rs
@@ -36,6 +36,12 @@ impl HalleyWlState {
     const PHYSICS_DEPTH_LIMIT: usize = 6;
     const DRAG_AXIS_DOMINANCE: f32 = 1.35;
     const PHYSICS_MIN_SPEED: f32 = 12.0;
+    const NODE_BODY_MASS: f32 = 1.3;
+    const WINDOW_BODY_MASS: f32 = 1.0;
+    const PHYSICS_MIN_IMPULSE_LIMIT: f32 = 320.0;
+    const PHYSICS_MAX_IMPULSE_LIMIT: f32 = 2200.0;
+    const PHYSICS_MIN_BOUNCE_LIMIT: f32 = 420.0;
+    const PHYSICS_MAX_BOUNCE_LIMIT: f32 = 2600.0;
 
     #[inline]
     fn bump_response(&self) -> f32 {
@@ -187,12 +193,70 @@ impl HalleyWlState {
 
     #[inline]
     fn add_physics_velocity(&mut self, id: NodeId, delta: Vec2) {
+        let inv_mass = self.body_inverse_mass(id);
+        let limit = self
+            .field
+            .node(id)
+            .map(|node| {
+                let ext = self.collision_extents_for_node(node);
+                self.collision_velocity_limit(ext, ext, true)
+            })
+            .unwrap_or(Self::PHYSICS_MAX_BOUNCE_LIMIT);
         let vel = self
             .physics_velocity
             .entry(id)
             .or_insert(Vec2 { x: 0.0, y: 0.0 });
-        vel.x += delta.x;
-        vel.y += delta.y;
+        vel.x = (vel.x + delta.x * inv_mass).clamp(-limit, limit);
+        vel.y = (vel.y + delta.y * inv_mass).clamp(-limit, limit);
+    }
+
+    #[inline]
+    fn body_mass_for_node(&self, node: &halley_core::field::Node) -> f32 {
+        match node.state {
+            halley_core::field::NodeState::Node | halley_core::field::NodeState::Core => {
+                Self::NODE_BODY_MASS
+            }
+            halley_core::field::NodeState::Active | halley_core::field::NodeState::Drifting => {
+                Self::WINDOW_BODY_MASS
+            }
+        }
+    }
+
+    #[inline]
+    fn body_inverse_mass(&self, id: NodeId) -> f32 {
+        self.field
+            .node(id)
+            .map(|node| 1.0 / self.body_mass_for_node(node).max(0.001))
+            .unwrap_or(1.0)
+    }
+
+    #[inline]
+    fn collision_velocity_limit(
+        &self,
+        a_ext: CollisionExtents,
+        b_ext: CollisionExtents,
+        bounce: bool,
+    ) -> f32 {
+        let a_size = a_ext.size();
+        let b_size = b_ext.size();
+        let scale = a_size
+            .x
+            .max(a_size.y)
+            .max(b_size.x.max(b_size.y))
+            .max(self.non_overlap_gap_world() * 10.0);
+        let response_scale = 0.85 + self.bump_response() * 0.9;
+        let raw = if bounce { scale * 5.0 } else { scale * 4.0 } * response_scale;
+        if bounce {
+            raw.clamp(
+                Self::PHYSICS_MIN_BOUNCE_LIMIT,
+                Self::PHYSICS_MAX_BOUNCE_LIMIT,
+            )
+        } else {
+            raw.clamp(
+                Self::PHYSICS_MIN_IMPULSE_LIMIT,
+                Self::PHYSICS_MAX_IMPULSE_LIMIT,
+            )
+        }
     }
 
     fn carry_surface_docking_clamped(&mut self, id: NodeId, to: Vec2) -> bool {
@@ -317,9 +381,11 @@ impl HalleyWlState {
                         x: other_pos.x + dir * correction,
                         y: other_pos.y,
                     };
-                    let impulse = dir
+                    let impulse_limit = self.collision_velocity_limit(mover_ext, other_ext, false);
+                    let impulse = (dir
                         * (motion.x.abs() * self.drag_impulse_gain()
-                            + correction * self.collision_push_gain());
+                            + correction * self.collision_push_gain()))
+                    .clamp(-impulse_limit, impulse_limit);
                     let _ = self.carry_for_physics(other_id, target);
                     self.add_physics_velocity(other_id, Vec2 { x: impulse, y: 0.0 });
                     queue.push_back((
@@ -347,9 +413,11 @@ impl HalleyWlState {
                         x: other_pos.x,
                         y: other_pos.y + dir * correction,
                     };
-                    let impulse = dir
+                    let impulse_limit = self.collision_velocity_limit(mover_ext, other_ext, false);
+                    let impulse = (dir
                         * (motion.y.abs() * self.drag_impulse_gain()
-                            + correction * self.collision_push_gain());
+                            + correction * self.collision_push_gain()))
+                    .clamp(-impulse_limit, impulse_limit);
                     let _ = self.carry_for_physics(other_id, target);
                     self.add_physics_velocity(other_id, Vec2 { x: 0.0, y: impulse });
                     queue.push_back((
@@ -593,7 +661,8 @@ impl HalleyWlState {
                     if Self::collision_axis(rel, overlap_x, overlap_y) {
                         let dir = Self::push_direction(dx, rel.x);
                         let correction = overlap_x + gap * 0.02;
-                        let speed = correction / dt.max(1.0 / 240.0);
+                        let bounce_limit = self.collision_velocity_limit(aext, bext, true);
+                        let speed = (correction / dt.max(1.0 / 240.0)).clamp(0.0, bounce_limit);
                         if a_locked {
                             let _ = self.carry_for_physics(
                                 b,
@@ -625,32 +694,37 @@ impl HalleyWlState {
                                 },
                             );
                         } else {
-                            let half = correction * 0.5;
+                            let total_inv_mass =
+                                self.body_inverse_mass(a) + self.body_inverse_mass(b);
+                            let a_share = (self.body_inverse_mass(a) / total_inv_mass.max(0.001))
+                                .clamp(0.0, 1.0);
+                            let b_share = (self.body_inverse_mass(b) / total_inv_mass.max(0.001))
+                                .clamp(0.0, 1.0);
                             let _ = self.carry_for_physics(
                                 a,
                                 Vec2 {
-                                    x: apos.x - dir * half,
+                                    x: apos.x - dir * correction * a_share,
                                     y: apos.y,
                                 },
                             );
                             let _ = self.carry_for_physics(
                                 b,
                                 Vec2 {
-                                    x: bpos.x + dir * half,
+                                    x: bpos.x + dir * correction * b_share,
                                     y: bpos.y,
                                 },
                             );
                             self.add_physics_velocity(
                                 a,
                                 Vec2 {
-                                    x: -dir * speed * self.collision_bounce() * 0.5,
+                                    x: -dir * speed * self.collision_bounce() * a_share,
                                     y: 0.0,
                                 },
                             );
                             self.add_physics_velocity(
                                 b,
                                 Vec2 {
-                                    x: dir * speed * self.collision_bounce() * 0.5,
+                                    x: dir * speed * self.collision_bounce() * b_share,
                                     y: 0.0,
                                 },
                             );
@@ -658,7 +732,8 @@ impl HalleyWlState {
                     } else {
                         let dir = Self::push_direction(dy, rel.y);
                         let correction = overlap_y + gap * 0.02;
-                        let speed = correction / dt.max(1.0 / 240.0);
+                        let bounce_limit = self.collision_velocity_limit(aext, bext, true);
+                        let speed = (correction / dt.max(1.0 / 240.0)).clamp(0.0, bounce_limit);
                         if a_locked {
                             let _ = self.carry_for_physics(
                                 b,
@@ -690,33 +765,38 @@ impl HalleyWlState {
                                 },
                             );
                         } else {
-                            let half = correction * 0.5;
+                            let total_inv_mass =
+                                self.body_inverse_mass(a) + self.body_inverse_mass(b);
+                            let a_share = (self.body_inverse_mass(a) / total_inv_mass.max(0.001))
+                                .clamp(0.0, 1.0);
+                            let b_share = (self.body_inverse_mass(b) / total_inv_mass.max(0.001))
+                                .clamp(0.0, 1.0);
                             let _ = self.carry_for_physics(
                                 a,
                                 Vec2 {
                                     x: apos.x,
-                                    y: apos.y - dir * half,
+                                    y: apos.y - dir * correction * a_share,
                                 },
                             );
                             let _ = self.carry_for_physics(
                                 b,
                                 Vec2 {
                                     x: bpos.x,
-                                    y: bpos.y + dir * half,
+                                    y: bpos.y + dir * correction * b_share,
                                 },
                             );
                             self.add_physics_velocity(
                                 a,
                                 Vec2 {
                                     x: 0.0,
-                                    y: -dir * speed * self.collision_bounce() * 0.5,
+                                    y: -dir * speed * self.collision_bounce() * a_share,
                                 },
                             );
                             self.add_physics_velocity(
                                 b,
                                 Vec2 {
                                     x: 0.0,
-                                    y: dir * speed * self.collision_bounce() * 0.5,
+                                    y: dir * speed * self.collision_bounce() * b_share,
                                 },
                             );
                         }
@@ -1085,6 +1165,44 @@ mod tests {
     }
 
     #[test]
+    fn collapsed_nodes_receive_less_velocity_than_active_windows() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
+        let window = state.field.spawn_surface(
+            "window",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 400.0, y: 300.0 },
+        );
+        let node =
+            state
+                .field
+                .spawn_surface("node", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let _ = state
+            .field
+            .set_state(node, halley_core::field::NodeState::Node);
+
+        state.add_physics_velocity(window, Vec2 { x: 100.0, y: 0.0 });
+        state.add_physics_velocity(node, Vec2 { x: 100.0, y: 0.0 });
+
+        let window_vx = state
+            .physics_velocity
+            .get(&window)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x;
+        let node_vx = state
+            .physics_velocity
+            .get(&node)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x;
+
+        assert!(
+            node_vx > 0.0 && node_vx < window_vx,
+            "expected collapsed node to pick up less velocity than a window: node={node_vx}, window={window_vx}"
+        );
+    }
+
+    #[test]
     fn passive_window_keeps_moving_after_drag_impulse() {
         let mut state = test_state(halley_config::RuntimeTuning::default());
         let a =
@@ -1107,6 +1225,99 @@ mod tests {
         assert!(
             after.x > before.x + 1.0,
             "expected passive window to keep moving after contact: before={before:?}, after={after:?}"
+        );
+    }
+
+    #[test]
+    fn chained_window_node_collision_caps_runaway_velocity() {
+        let mut state = test_state(halley_config::RuntimeTuning::default());
+        let dragged = state.field.spawn_surface(
+            "dragged",
+            Vec2 { x: -520.0, y: 0.0 },
+            Vec2 { x: 400.0, y: 300.0 },
+        );
+        let node =
+            state
+                .field
+                .spawn_surface("node", Vec2 { x: 0.0, y: 0.0 }, Vec2 { x: 400.0, y: 300.0 });
+        let other = state.field.spawn_surface(
+            "other",
+            Vec2 { x: 120.0, y: 0.0 },
+            Vec2 { x: 400.0, y: 300.0 },
+        );
+        let _ = state
+            .field
+            .set_state(node, halley_core::field::NodeState::Node);
+
+        state.begin_carry_state_tracking(dragged);
+        assert!(state.carry_surface_non_overlap(dragged, Vec2 { x: -40.0, y: 0.0 }));
+
+        let node_vx = state
+            .physics_velocity
+            .get(&node)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x
+            .abs();
+        let other_vx = state
+            .physics_velocity
+            .get(&other)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x
+            .abs();
+        let node_limit = state
+            .field
+            .node(node)
+            .map(|n| {
+                let ext = state.collision_extents_for_node(n);
+                state.collision_velocity_limit(ext, ext, true)
+            })
+            .expect("node limit");
+        let other_limit = state
+            .field
+            .node(other)
+            .map(|n| {
+                let ext = state.collision_extents_for_node(n);
+                state.collision_velocity_limit(ext, ext, true)
+            })
+            .expect("other limit");
+
+        assert!(
+            node_vx <= node_limit + 0.1,
+            "expected node velocity to stay bounded after chained overlap: {node_vx}"
+        );
+        assert!(
+            other_vx <= other_limit + 0.1,
+            "expected downstream window velocity to stay bounded after chained overlap: {other_vx}"
+        );
+
+        for _ in 0..8 {
+            state.tick_passive_physics();
+        }
+
+        let node_vx_after = state
+            .physics_velocity
+            .get(&node)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x
+            .abs();
+        let other_vx_after = state
+            .physics_velocity
+            .get(&other)
+            .copied()
+            .unwrap_or(Vec2 { x: 0.0, y: 0.0 })
+            .x
+            .abs();
+
+        assert!(
+            node_vx_after <= node_limit + 0.1,
+            "expected passive node bounce to stay bounded: {node_vx_after}"
+        );
+        assert!(
+            other_vx_after <= other_limit + 0.1,
+            "expected passive window bounce to stay bounded: {other_vx_after}"
         );
     }
 

--- a/examples/halley-finale.rune
+++ b/examples/halley-finale.rune
@@ -22,8 +22,6 @@
 # Common examples include bars, notification daemons,
 # clipboard managers, and background utilities.
 autostart:
-  once "waybar"
-
   #once "mako"
   #once "gessod"
 
@@ -329,8 +327,10 @@ end
 # Rules allow matching specific applications
 # and applying behaviour automatically.
 rules:
-# TODO: Figure out making this work with rune-cfg.
-# might need to update rune-cfg
+  kitty:
+    app-id "kitty"
+    monitor "DP-2"
+  end
 end
 
 debug:


### PR DESCRIPTION
This PR introduces several foundational compositor improvements: configuration-driven autostart, live viewport reload support, fullscreen handling, and a temporary workaround for initial window geometry mismatches seen in some clients.

## Features

### Autostart + viewport live reload
- Added a basic autostart configuration section supporting:
  - `once` (run on compositor start)
  - `on-reload` (run when configuration reloads)
- Hooked up Smithay monitor hot-reload paths to allow viewport configuration changes to apply without restarting the compositor.

### Fullscreen support
- Implemented compositor-level fullscreen support for windows.

## Workaround

### Initial window-size workaround for configure/commit mismatch
Some clients (notably Kitty) may commit a very small default buffer
(e.g. ~22x8 cells) even after the compositor sends a larger configure
suggestion. This causes the compositor’s tracked node size to diverge
from the actual committed surface size, which can lead to visible
window collisions.

To reduce the visual impact of this issue, the compositor now forces an
initial window size when the surface appears.

This mitigates collisions but **does not fix the underlying problem**.

**Planned follow-up:**
- Read the committed buffer size from the surface on commit
- Update the node geometry to match the client’s actual buffer