### PR TITLE
feat(compositor): introduce first-class zoom bindings, default keybinds, and event-driven backends

### DIFF
--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -37,11 +37,13 @@ pub enum DirectionalAction {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompositorBindingAction {
     Reload,
-    MinimizeFocused,
-    OverviewToggle,
+    ToggleState,
     Quit { requires_shift: bool },
     Docking,
     MoveNode(DirectionalAction),
+    ZoomIn,
+    ZoomOut,
+    ZoomReset,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -41,6 +41,7 @@ pub enum DirectionalAction {
 pub enum CompositorBindingAction {
     Reload,
     ToggleState,
+    CloseFocusedWindow,
     Quit { requires_shift: bool },
     Docking,
     MoveNode(DirectionalAction),

--- a/crates/halley-config/src/keybinds.rs
+++ b/crates/halley-config/src/keybinds.rs
@@ -26,6 +26,9 @@ pub struct LaunchBinding {
     pub command: String,
 }
 
+pub const WHEEL_UP_CODE: u32 = 0x2000;
+pub const WHEEL_DOWN_CODE: u32 = 0x2001;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DirectionalAction {
     Left,
@@ -381,6 +384,8 @@ pub fn key_name_to_evdev(name: &str) -> Option<u32> {
         "mousemiddle" | "middlemouse" | "middlebutton" | "btnmiddle" | "btn_middle" => Some(274),
         "mouse4" | "mouseback" | "sidebutton" | "btnside" | "btn_side" => Some(275),
         "mouse5" | "mouseforward" | "extrabutton" | "btnextra" | "btn_extra" => Some(276),
+        "mousewheelup" | "wheelup" | "scrollup" => Some(WHEEL_UP_CODE),
+        "mousewheeldown" | "wheeldown" | "scrolldown" => Some(WHEEL_DOWN_CODE),
 
         "xf86audiomute" | "audiomute" | "mute" => Some(113),
         "xf86audiolowervolume" | "audiolowervolume" | "volumedown" => Some(114),
@@ -408,6 +413,11 @@ pub fn key_name_to_evdev(name: &str) -> Option<u32> {
 #[inline]
 pub fn is_pointer_button_code(code: u32) -> bool {
     matches!(code, 272..=276)
+}
+
+#[inline]
+pub fn is_wheel_code(code: u32) -> bool {
+    matches!(code, WHEEL_UP_CODE | WHEEL_DOWN_CODE)
 }
 
 pub fn evdev_to_key_name(code: u32) -> &'static str {
@@ -510,13 +520,18 @@ pub fn evdev_to_key_name(code: u32) -> &'static str {
         274 => "MouseMiddle",
         275 => "MouseBack",
         276 => "MouseForward",
+        WHEEL_UP_CODE => "MouseWheelUp",
+        WHEEL_DOWN_CODE => "MouseWheelDown",
         _ => "?",
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{evdev_to_key_name, key_name_to_evdev, parse_chord, parse_modifiers};
+    use super::{
+        WHEEL_DOWN_CODE, WHEEL_UP_CODE, evdev_to_key_name, key_name_to_evdev, parse_chord,
+        parse_modifiers,
+    };
 
     #[test]
     fn generic_alt_modifier_matches_either_side_in_config() {
@@ -537,6 +552,8 @@ mod tests {
         assert_eq!(key_name_to_evdev("middlemouse"), Some(274));
         assert_eq!(key_name_to_evdev("mouseback"), Some(275));
         assert_eq!(key_name_to_evdev("mouseforward"), Some(276));
+        assert_eq!(key_name_to_evdev("mousewheelup"), Some(WHEEL_UP_CODE));
+        assert_eq!(key_name_to_evdev("mousewheeldown"), Some(WHEEL_DOWN_CODE));
     }
 
     #[test]
@@ -552,6 +569,8 @@ mod tests {
     fn reverse_lookup_uses_canonical_names_for_new_codes() {
         assert_eq!(evdev_to_key_name(272), "MouseLeft");
         assert_eq!(evdev_to_key_name(275), "MouseBack");
+        assert_eq!(evdev_to_key_name(WHEEL_UP_CODE), "MouseWheelUp");
+        assert_eq!(evdev_to_key_name(WHEEL_DOWN_CODE), "MouseWheelDown");
         assert_eq!(evdev_to_key_name(166), "XF86AudioStop");
         assert_eq!(evdev_to_key_name(248), "XF86AudioMicMute");
     }

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -14,7 +14,6 @@ use super::{
 
 #[derive(Clone, Debug)]
 pub struct RuntimeTuning {
-    pub tick_ms: u64,
     pub debug_tick_dump: bool,
     pub debug_dump_every_ms: u64,
 
@@ -77,7 +76,6 @@ pub struct ViewportOutputConfig {
 impl Default for RuntimeTuning {
     fn default() -> Self {
         Self {
-            tick_ms: 200,
             debug_tick_dump: false,
             debug_dump_every_ms: 1000,
             viewport_center: Vec2 { x: 0.0, y: 0.0 },
@@ -167,7 +165,6 @@ impl RuntimeTuning {
     }
 
     fn clamp_values(&mut self) {
-        self.tick_ms = self.tick_ms.clamp(16, 5000);
         self.debug_dump_every_ms = self.debug_dump_every_ms.clamp(100, 60_000);
 
         self.viewport_center.x = self.viewport_center.x.clamp(-100_000.0, 100_000.0);

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 
-use crate::keybinds::key_name_to_evdev;
+use crate::keybinds::{WHEEL_DOWN_CODE, WHEEL_UP_CODE, key_name_to_evdev};
 use halley_core::decay::FocusRingDecayPolicy;
 use halley_core::field::Vec2;
 use halley_core::viewport::{FocusRing, Viewport};
@@ -57,7 +57,6 @@ pub struct RuntimeTuning {
     pub compositor_bindings: Vec<CompositorBinding>,
     pub launch_bindings: Vec<LaunchBinding>,
     pub pointer_bindings: Vec<PointerBinding>,
-    pub scroll_zoom_enabled: bool,
 
     pub tty_viewports: Vec<ViewportOutputConfig>,
     pub autostart_once: Vec<String>,
@@ -123,7 +122,6 @@ impl Default for RuntimeTuning {
             compositor_bindings: default_compositor_bindings(Keybinds::default().modifier),
             launch_bindings: Vec::new(),
             pointer_bindings: default_pointer_bindings(Keybinds::default().modifier),
-            scroll_zoom_enabled: true,
 
             tty_viewports: Vec::new(),
             autostart_once: Vec::new(),
@@ -268,17 +266,17 @@ pub(crate) fn default_compositor_bindings(modifier: KeyModifiers) -> Vec<Composi
         },
         CompositorBinding {
             modifiers: modifier,
-            key: key("equal"),
+            key: WHEEL_UP_CODE,
             action: CompositorBindingAction::ZoomIn,
         },
         CompositorBinding {
             modifiers: modifier,
-            key: key("minus"),
+            key: WHEEL_DOWN_CODE,
             action: CompositorBindingAction::ZoomOut,
         },
         CompositorBinding {
             modifiers: modifier,
-            key: key("0"),
+            key: key("mousemiddle"),
             action: CompositorBindingAction::ZoomReset,
         },
         CompositorBinding {

--- a/crates/halley-config/src/layout.rs
+++ b/crates/halley-config/src/layout.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 
+use crate::keybinds::key_name_to_evdev;
 use halley_core::decay::FocusRingDecayPolicy;
 use halley_core::field::Vec2;
 use halley_core::viewport::{FocusRing, Viewport};
 
 use super::{
-    CompositorBinding, KeyModifiers, Keybinds, LaunchBinding, PointerBinding, PointerBindingAction,
+    CompositorBinding, CompositorBindingAction, DirectionalAction, KeyModifiers, Keybinds,
+    LaunchBinding, PointerBinding, PointerBindingAction,
 };
 
 #[derive(Clone, Debug)]
@@ -55,6 +57,7 @@ pub struct RuntimeTuning {
     pub compositor_bindings: Vec<CompositorBinding>,
     pub launch_bindings: Vec<LaunchBinding>,
     pub pointer_bindings: Vec<PointerBinding>,
+    pub scroll_zoom_enabled: bool,
 
     pub tty_viewports: Vec<ViewportOutputConfig>,
     pub autostart_once: Vec<String>,
@@ -117,9 +120,10 @@ impl Default for RuntimeTuning {
             physics_enabled: true,
 
             keybinds: Keybinds::default(),
-            compositor_bindings: Vec::new(),
+            compositor_bindings: default_compositor_bindings(Keybinds::default().modifier),
             launch_bindings: Vec::new(),
             pointer_bindings: default_pointer_bindings(Keybinds::default().modifier),
+            scroll_zoom_enabled: true,
 
             tty_viewports: Vec::new(),
             autostart_once: Vec::new(),
@@ -244,6 +248,68 @@ pub(crate) fn default_pointer_bindings(modifier: KeyModifiers) -> Vec<PointerBin
             modifiers: modifier,
             button: 273,
             action: PointerBindingAction::ResizeWindow,
+        },
+    ]
+}
+
+pub(crate) fn default_compositor_bindings(modifier: KeyModifiers) -> Vec<CompositorBinding> {
+    let key = |name: &str| key_name_to_evdev(name).expect("default compositor key should exist");
+
+    vec![
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("r"),
+            action: CompositorBindingAction::Reload,
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("n"),
+            action: CompositorBindingAction::ToggleState,
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("equal"),
+            action: CompositorBindingAction::ZoomIn,
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("minus"),
+            action: CompositorBindingAction::ZoomOut,
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("0"),
+            action: CompositorBindingAction::ZoomReset,
+        },
+        CompositorBinding {
+            modifiers: KeyModifiers {
+                shift: true,
+                ..modifier
+            },
+            key: key("q"),
+            action: CompositorBindingAction::Quit {
+                requires_shift: true,
+            },
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("h"),
+            action: CompositorBindingAction::MoveNode(DirectionalAction::Left),
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("k"),
+            action: CompositorBindingAction::MoveNode(DirectionalAction::Up),
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("l"),
+            action: CompositorBindingAction::MoveNode(DirectionalAction::Right),
+        },
+        CompositorBinding {
+            modifiers: modifier,
+            key: key("j"),
+            action: CompositorBindingAction::MoveNode(DirectionalAction::Down),
         },
     ]
 }

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -4,6 +4,6 @@ pub mod parse;
 
 pub use keybinds::{
     CompositorBinding, CompositorBindingAction, DirectionalAction, KeyModifiers, Keybinds,
-    LaunchBinding, PointerBinding, PointerBindingAction,
+    LaunchBinding, PointerBinding, PointerBindingAction, WHEEL_DOWN_CODE, WHEEL_UP_CODE,
 };
 pub use layout::{RuntimeTuning, ViewportOutputConfig};

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -663,11 +663,8 @@ fn apply_explicit_binding(out: &mut RuntimeTuning, mod_token: &str, chord: &str,
         "reload" => {
             upsert_compositor_binding(out, mods, key, CompositorBindingAction::Reload);
         }
-        "minimize_focused" | "minimize-focused" => {
-            upsert_compositor_binding(out, mods, key, CompositorBindingAction::MinimizeFocused);
-        }
-        "overview_toggle" | "overview-toggle" => {
-            upsert_compositor_binding(out, mods, key, CompositorBindingAction::OverviewToggle);
+        "toggle_state" | "toggle-state" | "minimize_focused" | "minimize-focused" => {
+            upsert_compositor_binding(out, mods, key, CompositorBindingAction::ToggleState);
         }
         "quit" => {
             upsert_compositor_binding(
@@ -713,6 +710,15 @@ fn apply_explicit_binding(out: &mut RuntimeTuning, mod_token: &str, chord: &str,
                 key,
                 CompositorBindingAction::MoveNode(DirectionalAction::Down),
             );
+        }
+        "zoom_in" | "zoom-in" => {
+            upsert_compositor_binding(out, mods, key, CompositorBindingAction::ZoomIn);
+        }
+        "zoom_out" | "zoom-out" => {
+            upsert_compositor_binding(out, mods, key, CompositorBindingAction::ZoomOut);
+        }
+        "zoom_reset" | "zoom-reset" => {
+            upsert_compositor_binding(out, mods, key, CompositorBindingAction::ZoomReset);
         }
         "move_window" | "move-window" if is_pointer_button_code(key) => {
             upsert_pointer_binding(out, mods, key, PointerBindingAction::MoveWindow);
@@ -827,7 +833,7 @@ mod tests {
         let mut tuning = RuntimeTuning::default();
         let bindings = HashMap::from([
             ("$mod+x".to_string(), "docking".to_string()),
-            ("shift+h".to_string(), "move_left".to_string()),
+            ("shift+h".to_string(), "move-left".to_string()),
         ]);
 
         apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
@@ -841,6 +847,44 @@ mod tests {
         assert!(tuning.compositor_bindings.iter().any(|binding| {
             binding.action == CompositorBindingAction::MoveNode(DirectionalAction::Left)
         }));
+    }
+
+    #[test]
+    fn toggle_state_and_zoom_aliases_parse_as_compositor_bindings() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([
+            ("$mod+n".to_string(), "toggle-state".to_string()),
+            ("$mod+equal".to_string(), "zoom_in".to_string()),
+            ("$mod+minus".to_string(), "zoom-out".to_string()),
+            ("$mod+0".to_string(), "zoom-reset".to_string()),
+        ]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ToggleState)
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomIn)
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomOut)
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomReset)
+        );
     }
 
     #[test]

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -231,12 +231,6 @@ fn strip_inline_keybind_block(content: &str) -> String {
 }
 
 fn load_dev_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.tick_ms = pick_u64(
-        cfg,
-        &["dev.runtime.tick-ms", "dev.runtime.tick_ms"],
-        out.tick_ms,
-    );
-
     out.debug_tick_dump = pick_bool(cfg, &["dev.debug_tick_dump"], out.debug_tick_dump);
     out.debug_dump_every_ms = pick_u64(cfg, &["dev.debug_dump_every_ms"], out.debug_dump_every_ms);
 

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::RuntimeTuning;
 use crate::keybinds::{is_pointer_button_code, parse_chord, parse_modifiers};
-use crate::layout::{ViewportOutputConfig, default_pointer_bindings};
+use crate::layout::{ViewportOutputConfig, default_compositor_bindings, default_pointer_bindings};
 
 use rune_cfg::RuneConfig;
 
@@ -441,11 +441,7 @@ fn load_decay_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 }
 
 fn load_field_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
-    out.non_overlap_gap_px = pick_f32(
-        cfg,
-        &["field.gap", "field.gap-px"],
-        out.non_overlap_gap_px,
-    );
+    out.non_overlap_gap_px = pick_f32(cfg, &["field.gap", "field.gap-px"], out.non_overlap_gap_px);
 }
 
 fn load_physics_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
@@ -464,9 +460,14 @@ fn load_physics_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
 
 fn load_keybind_sections(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.keybinds.modifier = pick_modifiers(cfg, &["keybinds.mod"], out.keybinds.modifier);
-    out.compositor_bindings.clear();
+    out.compositor_bindings = default_compositor_bindings(out.keybinds.modifier);
     out.launch_bindings.clear();
     out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
+    out.scroll_zoom_enabled = pick_bool(
+        cfg,
+        &["keybinds.scroll-zoom", "keybinds.scroll_zoom"],
+        out.scroll_zoom_enabled,
+    );
     apply_explicit_keybind_overrides(cfg, out);
 }
 
@@ -635,6 +636,7 @@ fn apply_explicit_keybind_overrides_map(
 
     if let Some(m) = parse_modifiers(mod_token.as_str()) {
         out.keybinds.modifier = m;
+        out.compositor_bindings = default_compositor_bindings(out.keybinds.modifier);
         out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
     }
 
@@ -888,6 +890,46 @@ mod tests {
     }
 
     #[test]
+    fn runtime_tuning_has_default_zoom_bindings() {
+        let tuning = RuntimeTuning::default();
+
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomIn)
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomOut)
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomReset)
+        );
+    }
+
+    #[test]
+    fn changing_mod_reseeds_default_compositor_bindings() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([("mod".to_string(), "super".to_string())]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        let zoom_in = tuning
+            .compositor_bindings
+            .iter()
+            .find(|binding| binding.action == CompositorBindingAction::ZoomIn)
+            .expect("zoom-in binding");
+        assert!(zoom_in.modifiers.super_key);
+        assert!(!zoom_in.modifiers.left_alt);
+    }
+
+    #[test]
     fn autostart_section_loads_once_and_on_reload_commands() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -972,6 +1014,42 @@ end
         assert_eq!(tuning.autostart_once, vec!["waybar"]);
         assert_eq!(tuning.non_overlap_gap_px, 24.0);
         assert_eq!(tuning.launch_bindings.len(), 1);
-        assert_eq!(tuning.compositor_bindings.len(), 1);
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| matches!(binding.action, CompositorBindingAction::Quit { .. }))
+        );
+        assert!(
+            tuning
+                .compositor_bindings
+                .iter()
+                .any(|binding| binding.action == CompositorBindingAction::ZoomIn)
+        );
+    }
+
+    #[test]
+    fn scroll_zoom_can_be_disabled_in_config() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("halley-scroll-zoom-{unique}.rune"));
+        fs::write(
+            &path,
+            r#"
+keybinds:
+  mod "super"
+  scroll-zoom false
+end
+"#,
+        )
+        .expect("write temp config");
+
+        let tuning = RuntimeTuning::from_rune_file(path.to_str().expect("utf8 path"))
+            .expect("config should parse");
+        let _ = fs::remove_file(&path);
+
+        assert!(!tuning.scroll_zoom_enabled);
     }
 }

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -657,6 +657,9 @@ fn apply_explicit_binding(out: &mut RuntimeTuning, mod_token: &str, chord: &str,
         "toggle_state" | "toggle-state" | "minimize_focused" | "minimize-focused" => {
             upsert_compositor_binding(out, mods, key, CompositorBindingAction::ToggleState);
         }
+        "close_focused" | "close-focused" | "close_window" | "close-window" => {
+            upsert_compositor_binding(out, mods, key, CompositorBindingAction::CloseFocusedWindow);
+        }
         "quit" => {
             upsert_compositor_binding(
                 out,
@@ -877,6 +880,21 @@ mod tests {
                 .iter()
                 .any(|binding| binding.action == CompositorBindingAction::ZoomReset)
         );
+    }
+
+    #[test]
+    fn close_focused_aliases_parse_as_compositor_bindings() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([
+            ("$mod+q".to_string(), "close-focused".to_string()),
+            ("$mod+w".to_string(), "close_window".to_string()),
+        ]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        assert!(tuning.compositor_bindings.iter().any(|binding| {
+            binding.action == CompositorBindingAction::CloseFocusedWindow
+        }));
     }
 
     #[test]

--- a/crates/halley-config/src/parse.rs
+++ b/crates/halley-config/src/parse.rs
@@ -463,11 +463,6 @@ fn load_keybind_sections(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.compositor_bindings = default_compositor_bindings(out.keybinds.modifier);
     out.launch_bindings.clear();
     out.pointer_bindings = default_pointer_bindings(out.keybinds.modifier);
-    out.scroll_zoom_enabled = pick_bool(
-        cfg,
-        &["keybinds.scroll-zoom", "keybinds.scroll_zoom"],
-        out.scroll_zoom_enabled,
-    );
     apply_explicit_keybind_overrides(cfg, out);
 }
 
@@ -801,7 +796,8 @@ mod tests {
 
     use super::apply_explicit_keybind_overrides_map;
     use crate::{
-        CompositorBindingAction, DirectionalAction, RuntimeTuning, keybinds::key_name_to_evdev,
+        CompositorBindingAction, DirectionalAction, RuntimeTuning, WHEEL_DOWN_CODE,
+        WHEEL_UP_CODE, keybinds::key_name_to_evdev,
     };
 
     #[test]
@@ -893,23 +889,20 @@ mod tests {
     fn runtime_tuning_has_default_zoom_bindings() {
         let tuning = RuntimeTuning::default();
 
+        assert!(tuning.compositor_bindings.iter().any(|binding| {
+            binding.action == CompositorBindingAction::ZoomIn && binding.key == WHEEL_UP_CODE
+        }));
+        assert!(tuning.compositor_bindings.iter().any(|binding| {
+            binding.action == CompositorBindingAction::ZoomOut && binding.key == WHEEL_DOWN_CODE
+        }));
         assert!(
             tuning
                 .compositor_bindings
                 .iter()
-                .any(|binding| binding.action == CompositorBindingAction::ZoomIn)
-        );
-        assert!(
-            tuning
-                .compositor_bindings
-                .iter()
-                .any(|binding| binding.action == CompositorBindingAction::ZoomOut)
-        );
-        assert!(
-            tuning
-                .compositor_bindings
-                .iter()
-                .any(|binding| binding.action == CompositorBindingAction::ZoomReset)
+                .any(|binding| {
+                    binding.action == CompositorBindingAction::ZoomReset
+                        && binding.key == key_name_to_evdev("mousemiddle").expect("middle mouse")
+                })
         );
     }
 
@@ -927,6 +920,25 @@ mod tests {
             .expect("zoom-in binding");
         assert!(zoom_in.modifiers.super_key);
         assert!(!zoom_in.modifiers.left_alt);
+        assert_eq!(zoom_in.key, WHEEL_UP_CODE);
+    }
+
+    #[test]
+    fn wheel_zoom_aliases_parse_as_compositor_bindings() {
+        let mut tuning = RuntimeTuning::default();
+        let bindings = HashMap::from([
+            ("$mod+mousewheelup".to_string(), "zoom_in".to_string()),
+            ("$mod+mousewheeldown".to_string(), "zoom-out".to_string()),
+        ]);
+
+        apply_explicit_keybind_overrides_map(&bindings, &mut tuning);
+
+        assert!(tuning.compositor_bindings.iter().any(|binding| {
+            binding.key == WHEEL_UP_CODE && binding.action == CompositorBindingAction::ZoomIn
+        }));
+        assert!(tuning.compositor_bindings.iter().any(|binding| {
+            binding.key == WHEEL_DOWN_CODE && binding.action == CompositorBindingAction::ZoomOut
+        }));
     }
 
     #[test]
@@ -1028,28 +1040,4 @@ end
         );
     }
 
-    #[test]
-    fn scroll_zoom_can_be_disabled_in_config() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!("halley-scroll-zoom-{unique}.rune"));
-        fs::write(
-            &path,
-            r#"
-keybinds:
-  mod "super"
-  scroll-zoom false
-end
-"#,
-        )
-        .expect("write temp config");
-
-        let tuning = RuntimeTuning::from_rune_file(path.to_str().expect("utf8 path"))
-            .expect("config should parse");
-        let _ = fs::remove_file(&path);
-
-        assert!(!tuning.scroll_zoom_enabled);
-    }
 }

--- a/crates/halley-wl/src/animation/curves.rs
+++ b/crates/halley-wl/src/animation/curves.rs
@@ -1,0 +1,12 @@
+pub(crate) fn ease_in_out_cubic(t: f32) -> f32 {
+    if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
+    }
+}
+
+pub(crate) fn ease_out_back(t: f32, s: f32) -> f32 {
+    let u = t - 1.0;
+    1.0 + u * u * ((s + 1.0) * u + s)
+}

--- a/crates/halley-wl/src/animation/mod.rs
+++ b/crates/halley-wl/src/animation/mod.rs
@@ -1,0 +1,9 @@
+mod curves;
+mod movement;
+mod nodes;
+mod surface;
+
+pub(crate) use curves::{ease_in_out_cubic, ease_out_back};
+pub(crate) use movement::advance_node_move_anim;
+pub use nodes::{AnimSpec, AnimStyle, Animator};
+pub(crate) use surface::{active_surface_render_scale, proxy_anim_scale};

--- a/crates/halley-wl/src/animation/movement.rs
+++ b/crates/halley-wl/src/animation/movement.rs
@@ -1,8 +1,9 @@
 use std::time::Instant;
 
 use crate::interaction::types::{NodeMoveAnim, PointerState};
-use crate::render::ease_in_out_cubic;
 use crate::state::HalleyWlState;
+
+use super::curves::ease_in_out_cubic;
 
 pub(crate) fn advance_node_move_anim(
     st: &mut HalleyWlState,

--- a/crates/halley-wl/src/animation/nodes.rs
+++ b/crates/halley-wl/src/animation/nodes.rs
@@ -3,6 +3,8 @@ use std::time::{Duration, Instant};
 
 use halley_core::field::{Field, NodeId, NodeState};
 
+use super::curves::ease_out_back;
+
 #[derive(Clone, Copy, Debug)]
 pub struct AnimSpec {
     pub state_change_ms: u64,
@@ -146,11 +148,6 @@ fn base_style(state: NodeState) -> AnimStyle {
         },
         _ => AnimStyle::default(),
     }
-}
-
-fn ease_out_back(t: f32, s: f32) -> f32 {
-    let u = t - 1.0;
-    1.0 + u * u * ((s + 1.0) * u + s)
 }
 
 fn ease_out_cubic(t: f32) -> f32 {

--- a/crates/halley-wl/src/animation/surface.rs
+++ b/crates/halley-wl/src/animation/surface.rs
@@ -1,4 +1,5 @@
-use super::render_utils::preview_proxy_size;
+use super::curves::{ease_in_out_cubic, ease_out_back};
+use crate::render::preview_proxy_size;
 
 #[inline]
 pub(crate) fn active_surface_scale(anim_scale: f32, zoom_lock_scale: f32) -> f32 {
@@ -63,17 +64,4 @@ pub(crate) fn active_surface_render_scale(
 pub(crate) fn proxy_anim_scale(anim_scale: f32) -> f32 {
     // Allow much more of the Active/Preview/Node transition range to be visible.
     anim_scale.clamp(0.22, 1.4)
-}
-
-pub(crate) fn ease_in_out_cubic(t: f32) -> f32 {
-    if t < 0.5 {
-        4.0 * t * t * t
-    } else {
-        1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
-    }
-}
-
-pub(crate) fn ease_out_back(t: f32, s: f32) -> f32 {
-    let u = t - 1.0;
-    1.0 + u * u * ((s + 1.0) * u + s)
 }

--- a/crates/halley-wl/src/backend/interface.rs
+++ b/crates/halley-wl/src/backend/interface.rs
@@ -10,6 +10,7 @@ use smithay::backend::{allocator::Format, allocator::dmabuf::Dmabuf};
 use crate::interaction::types::ResizeCtx;
 use crate::render::draw_debug_frame;
 use crate::state::HalleyWlState;
+use std::cell::Cell;
 
 pub(crate) trait BackendView {
     fn window_size_i32(&self) -> (i32, i32);
@@ -29,6 +30,31 @@ pub(crate) trait RenderBackend: BackendView {
 pub(crate) trait DmabufImportBackend {
     fn dmabuf_formats(&self) -> Vec<Format>;
     fn import_dmabuf(&self, dmabuf: &Dmabuf) -> Result<(), Box<dyn Error>>;
+}
+
+#[derive(Clone)]
+pub(crate) struct TtyBackendHandle {
+    size: Rc<Cell<(i32, i32)>>,
+}
+
+impl TtyBackendHandle {
+    pub(crate) fn new(width: i32, height: i32) -> Self {
+        Self {
+            size: Rc::new(Cell::new((width, height))),
+        }
+    }
+
+    pub(crate) fn set_size(&self, width: i32, height: i32) {
+        self.size.set((width, height));
+    }
+}
+
+impl BackendView for TtyBackendHandle {
+    fn window_size_i32(&self) -> (i32, i32) {
+        self.size.get()
+    }
+
+    fn request_redraw(&self) {}
 }
 
 pub(crate) struct TtyDmabufImportBackend {

--- a/crates/halley-wl/src/backend/mod.rs
+++ b/crates/halley-wl/src/backend/mod.rs
@@ -1,0 +1,61 @@
+use std::cell::RefCell;
+use std::env;
+use std::error::Error;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use calloop::EventLoop;
+use calloop::timer::{TimeoutAction, Timer};
+
+use eventline::{debug, info, scope, warn};
+use halley_config::RuntimeTuning;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+
+use smithay::reexports::drm::control::{self as drm_control, Device as DrmControlDevice};
+use smithay::{
+    backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice},
+    backend::allocator::{Format, Fourcc},
+    backend::drm::DrmEvent,
+    backend::drm::GbmBufferedSurface,
+    backend::drm::{DrmDevice, DrmDeviceFd},
+    backend::egl::{EGLContext, EGLDisplay},
+    backend::input::{
+        AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
+        PointerButtonEvent,
+    },
+    backend::libinput::LibinputInputBackend,
+    backend::libinput::LibinputSessionInterface,
+    backend::renderer::gles::GlesRenderer,
+    backend::renderer::{Bind, ImportDma},
+    backend::session::libseat::LibSeatSession,
+    backend::session::{Event as SessionEvent, Session},
+    backend::udev::{all_gpus, primary_gpu},
+    backend::winit::{self as smithay_winit, WinitEvent},
+    reexports::input::Libinput,
+    reexports::wayland_server::Display,
+    utils::{DeviceFd, Transform},
+    wayland::socket::ListeningSocketSource,
+};
+
+use crate::activity::VisualState;
+use crate::input::{BackendInputEventData, advance_node_move_anim, handle_backend_input_event};
+use crate::interaction::types::{ModState, PointerState};
+use crate::render::draw_debug_frame_to_target;
+use crate::run::{
+    RuntimeIpcCommand, drain_ipc_commands, ensure_dbus_session_bus_address,
+    ensure_host_display, ensure_xdg_runtime_dir, ensure_xwayland_satellite, init_logging,
+    publish_outputs, register_xwayland_request_channel, run_autostart_commands,
+    shutdown_requested,
+};
+use crate::state::{ClientState, HalleyWlState};
+use crate::surface::current_surface_size_for_node;
+
+pub(crate) mod interface;
+pub(crate) mod tty;
+pub(crate) mod tty_drm;
+pub(crate) mod tty_input;
+pub(crate) mod winit;

--- a/crates/halley-wl/src/backend/mod.rs
+++ b/crates/halley-wl/src/backend/mod.rs
@@ -42,7 +42,8 @@ use smithay::{
 };
 
 use crate::activity::VisualState;
-use crate::input::{BackendInputEventData, advance_node_move_anim, handle_backend_input_event};
+use crate::animation::advance_node_move_anim;
+use crate::input::{BackendInputEventData, handle_backend_input_event};
 use crate::interaction::types::{ModState, PointerState};
 use crate::render::draw_debug_frame_to_target;
 use crate::run::{

--- a/crates/halley-wl/src/backend/mod.rs
+++ b/crates/halley-wl/src/backend/mod.rs
@@ -59,3 +59,8 @@ pub(crate) mod tty;
 pub(crate) mod tty_drm;
 pub(crate) mod tty_input;
 pub(crate) mod winit;
+
+pub(crate) fn frame_interval_for_refresh_hz(refresh_hz: Option<f64>) -> Duration {
+    let hz = refresh_hz.unwrap_or(60.0).clamp(30.0, 360.0);
+    Duration::from_secs_f64(1.0 / hz)
+}

--- a/crates/halley-wl/src/backend/tty.rs
+++ b/crates/halley-wl/src/backend/tty.rs
@@ -325,8 +325,6 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             let watch_rx_for_timer = watch_rx.clone();
             let config_path_for_timer = config_path.clone();
             let wayland_display_for_timer = sock_name.clone();
-            let last_maintenance_at = Rc::new(RefCell::new(Instant::now()));
-            let last_maintenance_for_timer = last_maintenance_at.clone();
             let (mw, mh) = drm_probe.mode.size();
             let backend_handle = TtyBackendHandle::new(mw as i32, mh as i32);
             state.zoom_ref_size = halley_core::field::Vec2 {
@@ -532,7 +530,9 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 })?;
             info!("libinput event source enabled for tty backend");
 
-            let timer = Timer::from_duration(Duration::from_millis(16));
+            let initial_frame_interval =
+                frame_interval_for_refresh_hz(Some(current_mode.borrow().vrefresh() as f64));
+            let timer = Timer::from_duration(initial_frame_interval);
             let gbm_surface_for_timer = drm_probe.gbm_surface.clone();
             let renderer_for_timer = drm_probe.renderer.clone();
 
@@ -608,14 +608,8 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                         let _ = advance_node_move_anim(st, &mut ps, now);
                     }
                     st.tick_live_overlap();
-                    {
-                        let mut last = last_maintenance_for_timer.borrow_mut();
-                        if !resize_active
-                            && now.duration_since(*last).as_millis() as u64 >= st.tuning.tick_ms
-                        {
-                            st.tick_maintenance(now);
-                            *last = now;
-                        }
+                    if !resize_active {
+                        st.run_maintenance_if_needed(now);
                     }
                 }
 
@@ -686,7 +680,9 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     *warned_pointer_missing_for_timer.borrow_mut() = true;
                 }
 
-                TimeoutAction::ToDuration(Duration::from_millis(16))
+                let frame_interval =
+                    frame_interval_for_refresh_hz(Some(current_mode_for_timer.borrow().vrefresh() as f64));
+                TimeoutAction::ToDuration(frame_interval)
             })?;
 
             info!("entering tty main loop");

--- a/crates/halley-wl/src/backend/tty.rs
+++ b/crates/halley-wl/src/backend/tty.rs
@@ -1,8 +1,11 @@
 use super::*;
 
-use crate::backend_iface::{DmabufImportBackend, TtyDmabufImportBackend};
-use crate::run::drm::{collect_outputs_for_ipc, find_tty_scanout_for_reload, queue_tty_drm_frame};
-use crate::run::{build_tty_libinput_backend, probe_tty_drm_device_via_session};
+use crate::backend::interface::{BackendView, DmabufImportBackend, TtyBackendHandle, TtyDmabufImportBackend};
+use crate::backend::tty_drm::{
+    collect_outputs_for_ipc, find_tty_scanout_for_reload, probe_tty_drm_device_via_session,
+    queue_tty_drm_frame,
+};
+use crate::backend::tty_input::build_tty_libinput_backend;
 use calloop::{Interest, Mode, PostAction, generic::Generic};
 
 use smithay::backend::input::{
@@ -107,7 +110,7 @@ fn apply_tty_reload(
     );
 }
 
-pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
+pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
     eprintln!("halley-wl tty: starting");
     scope!(
         "halley-wl-tty",
@@ -689,7 +692,7 @@ pub(super) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             info!("entering tty main loop");
             loop {
                 ev.dispatch(None, &mut state)?;
-                if state.exit_requested() || crate::run::shutdown_requested() {
+                if state.exit_requested() || shutdown_requested() {
                     info!("exit requested, shutting down tty main loop");
                     break Ok(());
                 }

--- a/crates/halley-wl/src/backend/tty_drm.rs
+++ b/crates/halley-wl/src/backend/tty_drm.rs
@@ -3,18 +3,18 @@ use super::*;
 use crate::interaction::types::ResizeCtx;
 use halley_ipc::{ModeInfo, OutputInfo, OutputStatus};
 
-pub(super) struct TtyDrmProbe {
-    pub(super) _card_path: std::path::PathBuf,
-    pub(super) dev: DrmDevice,
-    pub(super) notifier: smithay::backend::drm::DrmDeviceNotifier,
-    pub(super) crtc: drm_control::crtc::Handle,
-    pub(super) connector_name: String,
-    pub(super) mode: drm_control::Mode,
-    pub(super) gbm_surface: Rc<RefCell<GbmBufferedSurface<GbmAllocator<DeviceFd>, ()>>>,
-    pub(super) renderer: Rc<RefCell<GlesRenderer>>,
+pub(crate) struct TtyDrmProbe {
+    pub(crate) _card_path: std::path::PathBuf,
+    pub(crate) dev: DrmDevice,
+    pub(crate) notifier: smithay::backend::drm::DrmDeviceNotifier,
+    pub(crate) crtc: drm_control::crtc::Handle,
+    pub(crate) connector_name: String,
+    pub(crate) mode: drm_control::Mode,
+    pub(crate) gbm_surface: Rc<RefCell<GbmBufferedSurface<GbmAllocator<DeviceFd>, ()>>>,
+    pub(crate) renderer: Rc<RefCell<GlesRenderer>>,
 }
 
-pub(super) fn probe_tty_drm_device_via_session(
+pub(crate) fn probe_tty_drm_device_via_session(
     seat: &str,
     session: Rc<RefCell<LibSeatSession>>,
     tuning: &RuntimeTuning,
@@ -59,7 +59,7 @@ pub(super) fn probe_tty_drm_device_via_session(
     .into())
 }
 
-pub(super) fn probe_tty_drm_device_path_via_session(
+pub(crate) fn probe_tty_drm_device_path_via_session(
     card_path: &Path,
     mut session: Rc<RefCell<LibSeatSession>>,
     tuning: &RuntimeTuning,
@@ -156,7 +156,7 @@ pub(super) fn probe_tty_drm_device_path_via_session(
     })
 }
 
-pub(super) fn select_tty_scanout(
+pub(crate) fn select_tty_scanout(
     dev: &mut DrmDevice,
     tuning: &RuntimeTuning,
 ) -> Result<
@@ -292,7 +292,7 @@ pub(super) fn select_tty_scanout(
     ))
 }
 
-pub(super) fn find_tty_scanout_for_reload(
+pub(crate) fn find_tty_scanout_for_reload(
     dev: &mut DrmDevice,
     tuning: &RuntimeTuning,
 ) -> Result<
@@ -307,7 +307,7 @@ pub(super) fn find_tty_scanout_for_reload(
     select_tty_scanout(dev, tuning)
 }
 
-pub(super) fn collect_outputs_for_ipc(
+pub(crate) fn collect_outputs_for_ipc(
     dev: &DrmDevice,
     active_connector_name: &str,
     active_mode: drm_control::Mode,
@@ -381,7 +381,7 @@ fn mode_info_from_drm_mode(mode: drm_control::Mode, current: bool, preferred: bo
     }
 }
 
-pub(super) fn queue_tty_drm_frame(
+pub(crate) fn queue_tty_drm_frame(
     gbm_surface: &Rc<RefCell<GbmBufferedSurface<GbmAllocator<DeviceFd>, ()>>>,
     renderer: &Rc<RefCell<GlesRenderer>>,
     st: &mut HalleyWlState,

--- a/crates/halley-wl/src/backend/tty_input.rs
+++ b/crates/halley-wl/src/backend/tty_input.rs
@@ -1,6 +1,6 @@
 use super::*;
 #[allow(clippy::type_complexity)]
-pub(super) fn build_tty_libinput_backend(
+pub(crate) fn build_tty_libinput_backend(
     session: Rc<RefCell<LibSeatSession>>,
     seat: &str,
 ) -> Result<(LibinputInputBackend, Rc<RefCell<Libinput>>), Box<dyn Error>> {

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -283,9 +283,6 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let watch_rx = Rc::new(RefCell::new(watch_rx));
             let watch_rx_for_timer = watch_rx.clone();
             let config_path_for_timer = config_path.clone();
-            let last_maintenance_at = Rc::new(RefCell::new(Instant::now()));
-            let last_maintenance_for_timer = last_maintenance_at.clone();
-
             {
                 let ws = backend.borrow().window_size();
                 publish_winit_output_snapshot(ws.w, ws.h, true, 0, 0);
@@ -510,7 +507,14 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     _ => {}
                 })?;
 
-            let timer = Timer::from_duration(Duration::from_millis(16));
+            let initial_frame_interval = frame_interval_for_refresh_hz(
+                state
+                    .tuning
+                    .tty_viewports
+                    .first()
+                    .and_then(|vp| vp.refresh_rate),
+            );
+            let timer = Timer::from_duration(initial_frame_interval);
             ev.handle().insert_source(timer, move |_tick, _, st| {
                 let now = Instant::now();
 
@@ -580,14 +584,8 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     let _ = advance_node_move_anim(st, &mut ps, now);
                 }
                 st.tick_live_overlap();
-                {
-                    let mut last = last_maintenance_for_timer.borrow_mut();
-                    if !resize_active
-                        && now.duration_since(*last).as_millis() as u64 >= st.tuning.tick_ms
-                    {
-                        st.tick_maintenance(now);
-                        *last = now;
-                    }
+                if !resize_active {
+                    st.run_maintenance_if_needed(now);
                 }
 
                 let mut reloaded = false;
@@ -660,7 +658,12 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
 
                 apply_host_cursor(&backend_for_cursor_timer, &st.cursor_image_status);
                 backend_handle_for_timer.request_redraw();
-                TimeoutAction::ToDuration(Duration::from_millis(16))
+                TimeoutAction::ToDuration(frame_interval_for_refresh_hz(
+                    st.tuning
+                        .tty_viewports
+                        .first()
+                        .and_then(|vp| vp.refresh_rate),
+                ))
             })?;
 
             info!("entering main loop");

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -1,6 +1,8 @@
 use super::*;
 
-use crate::backend_iface::DmabufImportBackend;
+use crate::backend::interface::{
+    BackendView, DmabufImportBackend, RenderBackend, WinitBackendHandle,
+};
 use calloop::{Interest, Mode, PostAction, generic::Generic};
 use halley_ipc::{LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus};
 use smithay::reexports::winit::dpi::PhysicalSize;
@@ -122,7 +124,7 @@ fn apply_winit_reload(
     );
 }
 
-pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
+pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
     scope!(
         "halley-wl",
         success = "compositor exited",
@@ -220,7 +222,7 @@ pub(super) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let sock_name = listening.socket_name().to_string_lossy().to_string();
             info!("WAYLAND_DISPLAY={}", sock_name);
 
-            let (backend, winit_source) = winit::init::<GlesRenderer>().map_err(|err| {
+            let (backend, winit_source) = smithay_winit::init::<GlesRenderer>().map_err(|err| {
                 let wayland_display =
                     env::var("WAYLAND_DISPLAY").unwrap_or_else(|_| "<unset>".to_string());
                 let x11_display = env::var("DISPLAY").unwrap_or_else(|_| "<unset>".to_string());

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -11,7 +11,7 @@ use crate::interaction::types::{ModState, PointerState};
 use crate::spatial::screen_to_world;
 use crate::state::HalleyWlState;
 
-use super::input_utils::update_mod_state;
+use super::input_utils::{modifier_active, update_mod_state};
 use super::key_actions::{
     apply_bound_key, apply_compositor_action_release, compositor_binding_action,
     key_is_compositor_binding,
@@ -99,7 +99,7 @@ pub(crate) fn handle_keyboard_input(
         || (pressed && !is_mod_key && key_is_compositor_binding(st, code, &mods));
 
     // Refresh interaction focus only for keys that are going to clients.
-    // Compositor bindings like minimize should not first re-focus / re-heat
+    // Compositor bindings like toggle-state should not first re-focus / re-heat
     // the surface they are about to collapse.
     if pressed
         && !matched_binding
@@ -114,7 +114,7 @@ pub(crate) fn handle_keyboard_input(
     //
     // Also: execute compositor bindings only on the first physical press.
     // Ignore repeated press events while the key remains held, otherwise a
-    // toggle binding like minimize_focused will collapse and then immediately
+    // toggle binding like toggle-state will collapse and then immediately
     // reopen on key repeat.
     let mut first_binding_press = false;
 
@@ -181,6 +181,7 @@ pub(crate) fn handle_keyboard_input(
 
 pub(crate) fn handle_pointer_axis_input(
     st: &mut HalleyWlState,
+    mod_state: &std::rc::Rc<std::cell::RefCell<ModState>>,
     pointer_state: &std::rc::Rc<std::cell::RefCell<PointerState>>,
     backend: &impl BackendView,
     amount_v120_vertical: Option<f64>,
@@ -247,16 +248,25 @@ pub(crate) fn handle_pointer_axis_input(
     }
 
     let steps = steps.clamp(-4.0, 4.0);
-    pointer_state.borrow_mut().panning = false;
+    let mods = mod_state.borrow().clone();
+    let modifier_held = modifier_active(&mods, st.tuning.keybinds.modifier);
 
-    let zoom_per_step = 1.10_f32;
-    let factor = zoom_per_step.powf(steps);
-    let next = st.clamp_camera_view_size(halley_core::field::Vec2 {
-        x: st.camera_view_size().x / factor,
-        y: st.camera_view_size().y / factor,
-    });
+    if modifier_held {
+        pointer_state.borrow_mut().panning = false;
+        st.zoom_by_steps(steps);
+        backend.request_redraw();
+        return;
+    }
 
-    st.zoom_ref_size = next;
+    let camera = st.camera_view_size();
+    let pan_y = camera.y * (steps / 18.0);
+    {
+        let mut ps = pointer_state.borrow_mut();
+        ps.panning = false;
+    }
+    st.note_pan_activity(now);
+    st.viewport.pan(halley_core::field::Vec2 { x: 0.0, y: pan_y });
+    st.note_pan_viewport_change(now);
     backend.request_redraw();
 }
 
@@ -309,6 +319,7 @@ pub(crate) fn handle_backend_input_event(
         } => {
             handle_pointer_axis_input(
                 st,
+                mod_state,
                 pointer_state,
                 backend,
                 amount_v120_vertical,

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -347,4 +347,5 @@ pub(crate) fn handle_backend_input_event(
             );
         }
     }
+    st.run_maintenance_if_needed(Instant::now());
 }

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -251,7 +251,7 @@ pub(crate) fn handle_pointer_axis_input(
     let mods = mod_state.borrow().clone();
     let modifier_held = modifier_active(&mods, st.tuning.keybinds.modifier);
 
-    if modifier_held {
+    if st.tuning.scroll_zoom_enabled && modifier_held {
         pointer_state.borrow_mut().panning = false;
         st.zoom_by_steps(steps);
         backend.request_redraw();
@@ -265,7 +265,8 @@ pub(crate) fn handle_pointer_axis_input(
         ps.panning = false;
     }
     st.note_pan_activity(now);
-    st.viewport.pan(halley_core::field::Vec2 { x: 0.0, y: pan_y });
+    st.viewport
+        .pan(halley_core::field::Vec2 { x: 0.0, y: pan_y });
     st.note_pan_viewport_change(now);
     backend.request_redraw();
 }

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -249,12 +249,17 @@ pub(crate) fn handle_pointer_axis_input(
     let resize_preview = pointer_state.borrow().resize;
     if let Some(focus) = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now, resize_preview) {
         if let Some(pointer) = st.seat.get_pointer() {
-            let cam_scale = st.camera_render_scale() as f64;
+            let location = if st.is_layer_surface(&focus.0) {
+                (sx as f64, sy as f64).into()
+            } else {
+                let cam_scale = st.camera_render_scale() as f64;
+                (sx as f64 / cam_scale, sy as f64 / cam_scale).into()
+            };
             pointer.motion(
                 st,
                 Some(focus),
                 &MotionEvent {
-                    location: (sx as f64 / cam_scale, sy as f64 / cam_scale).into(),
+                    location,
                     serial: SERIAL_COUNTER.next_serial(),
                     time: now_millis_u32(),
                 },

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -6,7 +6,7 @@ use smithay::input::pointer::AxisFrame;
 use smithay::input::pointer::MotionEvent;
 use smithay::utils::SERIAL_COUNTER;
 
-use crate::backend_iface::BackendView;
+use crate::backend::interface::BackendView;
 use crate::interaction::types::{ModState, PointerState};
 use crate::spatial::screen_to_world;
 use crate::state::HalleyWlState;

--- a/crates/halley-wl/src/input/input_events.rs
+++ b/crates/halley-wl/src/input/input_events.rs
@@ -11,13 +11,14 @@ use crate::interaction::types::{ModState, PointerState};
 use crate::spatial::screen_to_world;
 use crate::state::HalleyWlState;
 
-use super::input_utils::{modifier_active, update_mod_state};
+use super::input_utils::update_mod_state;
 use super::key_actions::{
-    apply_bound_key, apply_compositor_action_release, compositor_binding_action,
-    key_is_compositor_binding,
+    apply_bound_key, apply_compositor_action_press, apply_compositor_action_release,
+    compositor_binding_action, key_is_compositor_binding,
 };
 use super::pointer_focus::pointer_focus_for_screen;
 use super::pointer_map_debug_enabled;
+use halley_config::{WHEEL_DOWN_CODE, WHEEL_UP_CODE};
 use smithay::backend::input::{Axis, AxisSource, ButtonState, KeyState};
 
 #[inline]
@@ -184,12 +185,48 @@ pub(crate) fn handle_pointer_axis_input(
     mod_state: &std::rc::Rc<std::cell::RefCell<ModState>>,
     pointer_state: &std::rc::Rc<std::cell::RefCell<PointerState>>,
     backend: &impl BackendView,
+    config_path: &str,
+    wayland_display: &str,
     amount_v120_vertical: Option<f64>,
     amount_vertical: Option<f64>,
 ) {
     if st.has_active_cluster_workspace() {
         return;
     }
+
+    let mut steps = (amount_v120_vertical.unwrap_or(0.0) as f32) / 120.0;
+    if steps.abs() < f32::EPSILON {
+        let px = amount_vertical.unwrap_or(0.0) as f32;
+        if px.abs() > f32::EPSILON {
+            steps = px / 40.0;
+        }
+    }
+    if steps.abs() < f32::EPSILON {
+        return;
+    }
+
+    let steps = steps.clamp(-4.0, 4.0);
+    let mods = mod_state.borrow().clone();
+    let wheel_code = if steps > 0.0 {
+        WHEEL_UP_CODE
+    } else {
+        WHEEL_DOWN_CODE
+    };
+
+    if let Some(action) = compositor_binding_action(st, wheel_code, &mods) {
+        pointer_state.borrow_mut().panning = false;
+        if apply_compositor_action_press(st, action, config_path, wayland_display) {
+            backend.request_redraw();
+        }
+        return;
+    }
+
+    if apply_bound_key(st, wheel_code, &mods, config_path, wayland_display) {
+        pointer_state.borrow_mut().panning = false;
+        backend.request_redraw();
+        return;
+    }
+
     let (sx, sy, ws_w, ws_h) = {
         let ps = pointer_state.borrow();
         let (ws_w, ws_h) = backend.window_size_i32();
@@ -233,28 +270,6 @@ pub(crate) fn handle_pointer_axis_input(
                 pointer.frame(st);
             }
         }
-        return;
-    }
-
-    let mut steps = (amount_v120_vertical.unwrap_or(0.0) as f32) / 120.0;
-    if steps.abs() < f32::EPSILON {
-        let px = amount_vertical.unwrap_or(0.0) as f32;
-        if px.abs() > f32::EPSILON {
-            steps = px / 40.0;
-        }
-    }
-    if steps.abs() < f32::EPSILON {
-        return;
-    }
-
-    let steps = steps.clamp(-4.0, 4.0);
-    let mods = mod_state.borrow().clone();
-    let modifier_held = modifier_active(&mods, st.tuning.keybinds.modifier);
-
-    if st.tuning.scroll_zoom_enabled && modifier_held {
-        pointer_state.borrow_mut().panning = false;
-        st.zoom_by_steps(steps);
-        backend.request_redraw();
         return;
     }
 
@@ -310,6 +325,8 @@ pub(crate) fn handle_backend_input_event(
                 backend,
                 mod_state,
                 pointer_state,
+                config_path,
+                wayland_display,
                 button_code,
                 state,
             );
@@ -323,6 +340,8 @@ pub(crate) fn handle_backend_input_event(
                 mod_state,
                 pointer_state,
                 backend,
+                config_path,
+                wayland_display,
                 amount_v120_vertical,
                 amount_vertical,
             );

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -12,6 +12,7 @@ use crate::interaction::actions::{
 use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
 use crate::state::HalleyWlState;
+use crate::surface::request_close_focused_toplevel;
 use halley_config::{CompositorBindingAction, DirectionalAction, RuntimeTuning};
 use halley_config::keybinds::{is_pointer_button_code, is_wheel_code};
 use halley_ipc::NodeMoveDirection;
@@ -81,6 +82,7 @@ pub(crate) fn apply_compositor_action_press(
             true
         }
         CompositorBindingAction::ToggleState => toggle_focused_active_node_state(st),
+        CompositorBindingAction::CloseFocusedWindow => request_close_focused_toplevel(st),
         CompositorBindingAction::Docking => set_docking_mode(st, true),
         CompositorBindingAction::MoveNode(direction) => {
             move_latest_node_direction(st, from_directional_action(direction))
@@ -130,6 +132,7 @@ pub(crate) fn apply_bound_key(
             | CompositorBindingAction::Docking
             | CompositorBindingAction::Reload
             | CompositorBindingAction::ToggleState
+            | CompositorBindingAction::CloseFocusedWindow
             | CompositorBindingAction::Quit { .. }
             | CompositorBindingAction::ZoomIn
             | CompositorBindingAction::ZoomOut

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
 use std::os::unix::process::CommandExt;
 use std::process::Child;
+use std::process::Command;
 
 use eventline::{info, warn};
 
@@ -174,7 +174,10 @@ pub(crate) fn spawn_command(command: &str, wayland_display: &str, label: &str) -
         Ok(child) => {
             info!(
                 "spawned {} via `{}` on WAYLAND_DISPLAY={} (pid={})",
-                label, command, wayland_display, child.id()
+                label,
+                command,
+                wayland_display,
+                child.id()
             );
             Some(child)
         }

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -6,7 +6,8 @@ use eventline::{info, warn};
 
 use super::input_utils::{key_matches, modifier_exact};
 use crate::interaction::actions::{
-    docking_mode_active, minimize_focused_active_node, move_latest_node_direction, set_docking_mode,
+    docking_mode_active, move_latest_node_direction, set_docking_mode,
+    toggle_focused_active_node_state,
 };
 use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
@@ -70,11 +71,22 @@ pub(crate) fn apply_compositor_action_press(
             );
             true
         }
-        CompositorBindingAction::MinimizeFocused => minimize_focused_active_node(st),
-        CompositorBindingAction::OverviewToggle => false,
+        CompositorBindingAction::ToggleState => toggle_focused_active_node_state(st),
         CompositorBindingAction::Docking => set_docking_mode(st, true),
         CompositorBindingAction::MoveNode(direction) => {
             move_latest_node_direction(st, from_directional_action(direction))
+        }
+        CompositorBindingAction::ZoomIn => {
+            st.zoom_by_steps(1.0);
+            true
+        }
+        CompositorBindingAction::ZoomOut => {
+            st.zoom_by_steps(-1.0);
+            true
+        }
+        CompositorBindingAction::ZoomReset => {
+            st.reset_zoom();
+            true
         }
     }
 }
@@ -108,9 +120,11 @@ pub(crate) fn apply_bound_key(
             CompositorBindingAction::MoveNode(_)
             | CompositorBindingAction::Docking
             | CompositorBindingAction::Reload
-            | CompositorBindingAction::MinimizeFocused
+            | CompositorBindingAction::ToggleState
             | CompositorBindingAction::Quit { .. }
-            | CompositorBindingAction::OverviewToggle => {
+            | CompositorBindingAction::ZoomIn
+            | CompositorBindingAction::ZoomOut
+            | CompositorBindingAction::ZoomReset => {
                 apply_compositor_action_press(st, action, config_path, wayland_display)
             }
         };

--- a/crates/halley-wl/src/input/key_actions.rs
+++ b/crates/halley-wl/src/input/key_actions.rs
@@ -13,7 +13,16 @@ use crate::interaction::types::ModState;
 use crate::run::request_xwayland_start;
 use crate::state::HalleyWlState;
 use halley_config::{CompositorBindingAction, DirectionalAction, RuntimeTuning};
+use halley_config::keybinds::{is_pointer_button_code, is_wheel_code};
 use halley_ipc::NodeMoveDirection;
+
+pub(crate) fn input_matches_binding(actual: u32, binding_key: u32) -> bool {
+    if is_pointer_button_code(binding_key) || is_wheel_code(binding_key) {
+        actual == binding_key
+    } else {
+        key_matches(actual, binding_key)
+    }
+}
 
 fn from_directional_action(direction: DirectionalAction) -> NodeMoveDirection {
     match direction {
@@ -30,7 +39,7 @@ pub(crate) fn compositor_binding_action(
     mods: &ModState,
 ) -> Option<CompositorBindingAction> {
     for binding in &st.tuning.compositor_bindings {
-        if key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
+        if input_matches_binding(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
             return Some(binding.action);
         }
     }
@@ -45,7 +54,7 @@ pub(crate) fn key_is_compositor_binding(
 ) -> bool {
     compositor_binding_action(st, key_code, mods).is_some()
         || st.tuning.launch_bindings.iter().any(|binding| {
-            key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers)
+            input_matches_binding(key_code, binding.key) && modifier_exact(mods, binding.modifiers)
         })
 }
 
@@ -131,7 +140,7 @@ pub(crate) fn apply_bound_key(
     }
 
     for binding in st.tuning.launch_bindings.clone() {
-        if key_matches(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
+        if input_matches_binding(key_code, binding.key) && modifier_exact(mods, binding.modifiers) {
             // FIX: store the child so it's tracked for cleanup on WM exit,
             // rather than dropping it immediately (which orphaned the process).
             let ok = match spawn_command(binding.command.as_str(), wayland_display, "command") {
@@ -185,5 +194,29 @@ pub(crate) fn spawn_command(command: &str, wayland_display: &str, label: &str) -
             warn!("{} spawn failed via `{}`: {}", label, command, err);
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::input_matches_binding;
+    use halley_config::WHEEL_UP_CODE;
+    use halley_config::keybinds::key_name_to_evdev;
+
+    #[test]
+    fn matcher_accepts_direct_wheel_codes() {
+        assert!(input_matches_binding(WHEEL_UP_CODE, WHEEL_UP_CODE));
+    }
+
+    #[test]
+    fn matcher_keeps_keyboard_xkb_translation() {
+        assert!(input_matches_binding(13 + 8, 13));
+    }
+
+    #[test]
+    fn matcher_does_not_confuse_return_with_j() {
+        let return_xkb = key_name_to_evdev("return").expect("return") + 8;
+        let j_evdev = key_name_to_evdev("j").expect("j");
+        assert!(!input_matches_binding(return_xkb, j_evdev));
     }
 }

--- a/crates/halley-wl/src/input/mod.rs
+++ b/crates/halley-wl/src/input/mod.rs
@@ -4,7 +4,6 @@ use std::sync::OnceLock;
 mod input_events;
 mod input_utils;
 mod key_actions;
-mod move_anim;
 mod pointer_button;
 mod pointer_focus;
 mod pointer_motion;
@@ -12,7 +11,6 @@ mod resize_helpers;
 
 pub(crate) use input_events::{BackendInputEventData, handle_backend_input_event};
 pub(crate) use key_actions::spawn_command;
-pub(crate) use move_anim::advance_node_move_anim;
 pub(crate) use resize_helpers::{active_node_screen_rect, active_resize_geometry_screen};
 
 pub(crate) fn pointer_map_debug_enabled() -> bool {

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -22,6 +22,7 @@ use crate::surface::{
 use smithay::backend::input::ButtonState;
 
 use super::input_utils::modifier_active;
+use super::key_actions::{apply_bound_key, apply_compositor_action_press, compositor_binding_action};
 use super::pointer_focus::{layer_surface_focus_for_screen, pointer_focus_for_screen};
 use super::pointer_map_debug_enabled;
 use super::resize_helpers::{active_node_screen_rect, pick_resize_handle_from_screen};
@@ -567,6 +568,8 @@ pub(crate) fn handle_pointer_button_input(
     backend: &impl BackendView,
     mod_state: &Rc<RefCell<ModState>>,
     pointer_state: &Rc<RefCell<PointerState>>,
+    config_path: &str,
+    wayland_display: &str,
     button_code: u32,
     button_state: ButtonState,
 ) {
@@ -588,11 +591,30 @@ pub(crate) fn handle_pointer_button_input(
         workspace_active: st.has_active_cluster_workspace(),
     };
     let mods = mod_state.borrow().clone();
+    let intercepted_binding = match button_state {
+        ButtonState::Pressed => {
+            if let Some(action) = compositor_binding_action(st, button_code, &mods) {
+                ps.intercepted_binding_buttons.insert(button_code);
+                ps.panning = false;
+                let _ = apply_compositor_action_press(st, action, config_path, wayland_display);
+                backend.request_redraw();
+                true
+            } else if apply_bound_key(st, button_code, &mods, config_path, wayland_display) {
+                ps.intercepted_binding_buttons.insert(button_code);
+                ps.panning = false;
+                backend.request_redraw();
+                true
+            } else {
+                false
+            }
+        }
+        ButtonState::Released => ps.intercepted_binding_buttons.remove(&button_code),
+    };
     let matched_action = match button_state {
         ButtonState::Pressed => matching_pointer_binding(st, &mods, button_code),
         ButtonState::Released => ps.intercepted_buttons.remove(&button_code),
     };
-    let intercepted = matched_action.is_some();
+    let intercepted = intercepted_binding || matched_action.is_some();
     if matches!(button_state, ButtonState::Pressed)
         && let Some(action) = matched_action
     {
@@ -612,6 +634,9 @@ pub(crate) fn handle_pointer_button_input(
     }
     match button_state {
         ButtonState::Pressed => {
+            if intercepted_binding {
+                return;
+            }
             let hit = pick_hit_node_at(st, ws_w, ws_h, sx, sy, Instant::now(), ps.resize);
             if pointer_map_debug_enabled() {
                 info!(
@@ -657,6 +682,9 @@ pub(crate) fn handle_pointer_button_input(
             }
         }
         ButtonState::Released => {
+            if intercepted_binding {
+                return;
+            }
             if pointer_map_debug_enabled() {
                 info!(
                     "ptr-map button-release code=0x{:x} ws={}x{} screen=({:.2},{:.2}) world=({:.2},{:.2}) drag={} resize={} panning={}",

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -253,10 +253,6 @@ fn begin_resize(
         press_off_bottom_px: frame.sy - start_bottom,
         drag_started: true,
         resize_mode_sent: false,
-        live_geo_lx: 0.0,
-        live_geo_ly: 0.0,
-        live_geo_w: 0.0,
-        live_geo_h: 0.0,
     };
     if st.tuning.debug_tick_dump {
         info!(

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -74,12 +74,20 @@ fn dispatch_pointer_button(
     );
     let motion_serial = SERIAL_COUNTER.next_serial();
     let button_serial = SERIAL_COUNTER.next_serial();
-    let cam_scale = st.camera_render_scale() as f64;
+    let location = if focus
+        .as_ref()
+        .is_some_and(|(surface, _)| st.is_layer_surface(surface))
+    {
+        (frame.sx as f64, frame.sy as f64).into()
+    } else {
+        let cam_scale = st.camera_render_scale() as f64;
+        (frame.sx as f64 / cam_scale, frame.sy as f64 / cam_scale).into()
+    };
     pointer.motion(
         st,
         focus,
         &MotionEvent {
-            location: (frame.sx as f64 / cam_scale, frame.sy as f64 / cam_scale).into(),
+            location,
             serial: motion_serial,
             time: now_millis_u32(),
         },

--- a/crates/halley-wl/src/input/pointer_button.rs
+++ b/crates/halley-wl/src/input/pointer_button.rs
@@ -7,7 +7,7 @@ use halley_config::PointerBindingAction;
 use smithay::input::pointer::{ButtonEvent, MotionEvent};
 use smithay::utils::SERIAL_COUNTER;
 
-use crate::backend_iface::BackendView;
+use crate::backend::interface::BackendView;
 use crate::interaction::actions::docking_mode_active;
 use crate::interaction::actions::promote_node_level;
 use crate::interaction::types::{

--- a/crates/halley-wl/src/input/pointer_focus.rs
+++ b/crates/halley-wl/src/input/pointer_focus.rs
@@ -289,8 +289,10 @@ pub(crate) fn pointer_focus_for_screen(
             }
 
             let cam_scale_f = st.camera_render_scale() as f64;
-            let focus_origin =
-                Point::<f64, Logical>::from((xform.origin_x as f64 / cam_scale_f, xform.origin_y as f64 / cam_scale_f));
+            let focus_origin = Point::<f64, Logical>::from((
+                xform.origin_x as f64 / cam_scale_f,
+                xform.origin_y as f64 / cam_scale_f,
+            ));
 
             if pointer_map_debug_enabled() {
                 info!(

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -6,7 +6,7 @@ use eventline::info;
 use smithay::input::pointer::MotionEvent;
 use smithay::utils::SERIAL_COUNTER;
 
-use crate::backend_iface::BackendView;
+use crate::backend::interface::BackendView;
 use crate::interaction::actions::docking_mode_active;
 use crate::interaction::types::{ModState, PointerState, ResizeHandle};
 use crate::spatial::{pick_hit_node_at, screen_to_world};

--- a/crates/halley-wl/src/input/pointer_motion.rs
+++ b/crates/halley-wl/src/input/pointer_motion.rs
@@ -57,12 +57,20 @@ pub(crate) fn handle_pointer_motion_absolute(
     if let Some(pointer) = st.seat.get_pointer() {
         let resize_preview = pointer_state.borrow().resize;
         let focus = pointer_focus_for_screen(st, ws_w, ws_h, sx, sy, now, resize_preview);
-        let cam_scale = st.camera_render_scale() as f64;
+        let location = if focus
+            .as_ref()
+            .is_some_and(|(surface, _)| st.is_layer_surface(surface))
+        {
+            (sx as f64, sy as f64).into()
+        } else {
+            let cam_scale = st.camera_render_scale() as f64;
+            (sx as f64 / cam_scale, sy as f64 / cam_scale).into()
+        };
         pointer.motion(
             st,
             focus,
             &MotionEvent {
-                location: (sx as f64 / cam_scale, sy as f64 / cam_scale).into(),
+                location,
                 serial: SERIAL_COUNTER.next_serial(),
                 time: now_millis_u32(),
             },

--- a/crates/halley-wl/src/input/resize_helpers.rs
+++ b/crates/halley-wl/src/input/resize_helpers.rs
@@ -240,8 +240,11 @@ pub(crate) fn active_resize_geometry_screen(
     // Read live committed geo from window_geometry — updated on every client
     // commit during resize via note_commit. Zero = not yet committed, callers
     // fall back to frozen local_geo in that case.
-    let (live_geo_lx, live_geo_ly, live_geo_w, live_geo_h) =
-        st.window_geometry.get(&node_id).copied().unwrap_or((0.0, 0.0, 0.0, 0.0));
+    let (live_geo_lx, live_geo_ly, live_geo_w, live_geo_h) = st
+        .window_geometry
+        .get(&node_id)
+        .copied()
+        .unwrap_or((0.0, 0.0, 0.0, 0.0));
     Some(ActiveResizeGeometryScreen {
         frame_left,
         frame_top,

--- a/crates/halley-wl/src/input/resize_helpers.rs
+++ b/crates/halley-wl/src/input/resize_helpers.rs
@@ -5,8 +5,9 @@ use smithay::reexports::wayland_server::Resource;
 use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::SurfaceCachedState;
 
+use crate::animation::active_surface_render_scale;
 use crate::interaction::types::{ResizeCtx, ResizeHandle};
-use crate::render::{active_surface_render_scale, world_to_screen};
+use crate::render::world_to_screen;
 use crate::state::HalleyWlState;
 
 #[derive(Clone, Copy)]

--- a/crates/halley-wl/src/interaction/actions.rs
+++ b/crates/halley-wl/src/interaction/actions.rs
@@ -125,7 +125,6 @@ pub(crate) fn toggle_focused_active_node_state(st: &mut HalleyWlState) -> bool {
         return false;
     }
 
-
     match n.state {
         halley_core::field::NodeState::Active => {
             let _ = st.field.set_state(id, halley_core::field::NodeState::Node);

--- a/crates/halley-wl/src/interaction/actions.rs
+++ b/crates/halley-wl/src/interaction/actions.rs
@@ -110,7 +110,7 @@ pub(crate) fn move_latest_node_direction(
     }
 }
 
-pub(crate) fn minimize_focused_active_node(st: &mut HalleyWlState) -> bool {
+pub(crate) fn toggle_focused_active_node_state(st: &mut HalleyWlState) -> bool {
     let now = Instant::now();
 
     let Some(id) = st.last_focused_surface_node() else {

--- a/crates/halley-wl/src/interaction/types.rs
+++ b/crates/halley-wl/src/interaction/types.rs
@@ -76,12 +76,6 @@ pub(crate) struct ResizeCtx {
     pub(crate) press_off_bottom_px: f32,
     pub(crate) drag_started: bool,
     pub(crate) resize_mode_sent: bool,
-    // Updated on every client commit so the render path always has a
-    // single source of truth for what's actually been painted.
-    pub(crate) live_geo_lx: f32,
-    pub(crate) live_geo_ly: f32,
-    pub(crate) live_geo_w: f32,
-    pub(crate) live_geo_h: f32,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/halley-wl/src/interaction/types.rs
+++ b/crates/halley-wl/src/interaction/types.rs
@@ -118,6 +118,10 @@ pub(crate) struct PointerState {
     /// matching release must also be intercepted so clients do not receive a
     /// stray release after a compositor-owned drag/resize gesture.
     pub(crate) intercepted_buttons: HashMap<u32, PointerBindingAction>,
+    /// Non-pointer-binding buttons intercepted by compositor/launch bindings.
+    /// Their releases must also be intercepted so clients never see an
+    /// unpaired button release.
+    pub(crate) intercepted_binding_buttons: HashSet<u32>,
     pub(crate) drag: Option<DragCtx>,
     pub(crate) resize: Option<ResizeCtx>,
     pub(crate) move_anim: HashMap<halley_core::field::NodeId, NodeMoveAnim>,
@@ -139,6 +143,7 @@ impl Default for PointerState {
             workspace_size: (1, 1),
             hover_node: None,
             intercepted_buttons: HashMap::new(),
+            intercepted_binding_buttons: HashSet::new(),
             drag: None,
             resize: None,
             move_anim: HashMap::new(),

--- a/crates/halley-wl/src/lib.rs
+++ b/crates/halley-wl/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod activity;
-pub mod anim;
+pub mod animation;
 pub(crate) mod backend;
 pub(crate) mod input;
 pub(crate) mod interaction;

--- a/crates/halley-wl/src/lib.rs
+++ b/crates/halley-wl/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod activity;
 pub mod anim;
-pub(crate) mod backend_iface;
+pub(crate) mod backend;
 pub(crate) mod input;
 pub(crate) mod interaction;
 pub mod render;

--- a/crates/halley-wl/src/render/frame_render.rs
+++ b/crates/halley-wl/src/render/frame_render.rs
@@ -387,7 +387,7 @@ fn draw_offscreen_textures(
             &[damage],
             &[clip],
             Transform::Normal,
-            1.0,
+            tex.alpha,
             None,
             &[],
         )?;

--- a/crates/halley-wl/src/render/frame_render.rs
+++ b/crates/halley-wl/src/render/frame_render.rs
@@ -360,12 +360,14 @@ fn draw_offscreen_textures(
 ) -> Result<(), smithay::backend::renderer::gles::GlesError> {
     for tex in offscreen_textures {
         let tex_size = tex.texture.size();
+        let max_src_w = (tex_size.w - tex.src_x).max(1);
+        let max_src_h = (tex_size.h - tex.src_y).max(1);
 
         let src = Rectangle::<f64, Buffer>::new(
             (tex.src_x as f64, tex.src_y as f64).into(),
             (
-                tex.src_w.min(tex_size.w).max(1) as f64,
-                tex.src_h.min(tex_size.h).max(1) as f64,
+                tex.src_w.min(max_src_w).max(1) as f64,
+                tex.src_h.min(max_src_h).max(1) as f64,
             )
                 .into(),
         );
@@ -375,17 +377,26 @@ fn draw_offscreen_textures(
             (tex.dst_w.max(1), tex.dst_h.max(1)).into(),
         );
 
-        let clip = Rectangle::<i32, Physical>::new(
+        let visible = Rectangle::<i32, Physical>::new(
             (tex.clip_x, tex.clip_y).into(),
             (tex.clip_w.max(1), tex.clip_h.max(1)).into(),
+        )
+        .intersection(damage)
+        .unwrap_or_else(|| Rectangle::<i32, Physical>::new((0, 0).into(), (0, 0).into()));
+        if visible.size.w <= 0 || visible.size.h <= 0 {
+            continue;
+        }
+        let local_damage = Rectangle::<i32, Physical>::new(
+            (visible.loc.x - dst.loc.x, visible.loc.y - dst.loc.y).into(),
+            visible.size,
         );
 
         frame.render_texture_from_to(
             &tex.texture,
             src,
             dst,
-            &[damage],
-            &[clip],
+            &[local_damage],
+            &[],
             Transform::Normal,
             tex.alpha,
             None,

--- a/crates/halley-wl/src/render/frame_render.rs
+++ b/crates/halley-wl/src/render/frame_render.rs
@@ -310,7 +310,6 @@ fn draw_debug_frame_scene(
 
     draw_offscreen_textures(frame, prepared.damage, &scene.offscreen_textures)?;
 
-
     if !scene.popup_elements.is_empty() {
         let _ = draw_render_elements(frame, 1.0, &scene.popup_elements, &[prepared.damage]);
     }

--- a/crates/halley-wl/src/render/mod.rs
+++ b/crates/halley-wl/src/render/mod.rs
@@ -2,7 +2,6 @@ use glam::{Vec2, Vec4};
 use halley_core::field::Field;
 use halley_core::viewport::{FocusRing, FocusZone, Viewport};
 
-mod anim_utils;
 mod cursor_render;
 mod cursor_theme;
 mod frame_render;
@@ -11,9 +10,9 @@ mod node_render;
 mod offscreen;
 mod render_utils;
 
-pub(crate) use anim_utils::{active_surface_render_scale, ease_in_out_cubic};
 pub(crate) use frame_render::{draw_debug_frame, draw_debug_frame_to_target};
 pub(crate) use render_utils::{node_marker_bounds, node_marker_metrics, world_to_screen};
+pub(crate) use render_utils::preview_proxy_size;
 
 #[derive(Clone, Copy, Debug)]
 pub struct DebugPalette {

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -18,7 +18,7 @@ use crate::interaction::types::ResizeCtx;
 use crate::state::HalleyWlState;
 use crate::surface::window_geometry_for_node;
 
-use super::anim_utils::{
+use crate::animation::{
     active_surface_render_scale, ease_in_out_cubic, ease_out_back, proxy_anim_scale,
 };
 use super::offscreen::render_surface_tree_to_texture;

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -283,56 +283,97 @@ pub(crate) fn collect_active_surfaces(
 
                     // src = full bbox, dst = bbox scaled to screen positioned so geo
                     // lands on frame, clip = frame rect to discard CSD shadow bleed.
-                    let (src_x, src_y, src_w, src_h, dst_x, dst_y, dst_w, dst_h, clip_x, clip_y, clip_w, clip_h) =
-                        if let Some(active_resize) = active_resize {
-                            let (fx, fy, fw, fh) = active_resize.frame_rect_px();
-                            // Use live committed geo (updated on every client commit)
-                            // as the single source of truth. Falls back to frozen
-                            // local_geo before the first commit after resize starts.
-                            let (live_lx, live_ly, live_gw, live_gh): (f32, f32, f32, f32) =
-                                if active_resize.live_geo_w > 0.0 {
-                                    (
-                                        active_resize.live_geo_lx,
-                                        active_resize.live_geo_ly,
-                                        active_resize.live_geo_w,
-                                        active_resize.live_geo_h,
-                                    )
-                                } else {
-                                    // Before first commit: use frozen start geo from ResizeCtx.
-                                    // local_geo may have stale data; start_geo_lx/ly is reliable.
-                                    let rz = resize_preview.unwrap();
-                                    (rz.start_geo_lx, rz.start_geo_ly,
-                                     local_geo.2, local_geo.3)
-                                };
-                            // Crop src to just the geo region — excludes the CSD
-                            // shadow pixels (transparent black) at bbox edges which
-                            // would otherwise blit over the border strips.
-                            // src coords are in logical texture pixels (1:1 with surface).
-                            let src_x = (live_lx.round() as i32) - ob.loc.x;
-                            let src_y = (live_ly.round() as i32) - ob.loc.y;
-                            let src_w = live_gw.round() as i32;
-                            let src_h = live_gh.round() as i32;
-                            let clip_w = (live_gw * cam_scale).round() as i32;
-                            let clip_h = (live_gh * cam_scale).round() as i32;
-                            (
-                                src_x.max(0), src_y.max(0), src_w.max(1), src_h.max(1),
-                                fx, fy, clip_w.max(1).min(fw), clip_h.max(1).min(fh),
-                                fx, fy, clip_w.max(1).min(fw), clip_h.max(1).min(fh),
-                            )
-                        } else {
-                            let src_x = (local_geo.0.round() as i32) - ob.loc.x;
-                            let src_y = (local_geo.1.round() as i32) - ob.loc.y;
-                            let src_w = local_geo.2.round().max(1.0) as i32;
-                            let src_h = local_geo.3.round().max(1.0) as i32;
-                            (src_x, src_y, src_w, src_h, gx, gy, gw.max(1), gh.max(1),
-                             gx, gy, gw.max(1), gh.max(1))
-                        };
+                    let (
+                        src_x,
+                        src_y,
+                        src_w,
+                        src_h,
+                        dst_x,
+                        dst_y,
+                        dst_w,
+                        dst_h,
+                        clip_x,
+                        clip_y,
+                        clip_w,
+                        clip_h,
+                    ) = if let Some(active_resize) = active_resize {
+                        let (fx, fy, fw, fh) = active_resize.frame_rect_px();
+                        // Use live committed geo (updated on every client commit)
+                        // as the single source of truth. Falls back to frozen
+                        // local_geo before the first commit after resize starts.
+                        let (live_lx, live_ly, live_gw, live_gh): (f32, f32, f32, f32) =
+                            if active_resize.live_geo_w > 0.0 {
+                                (
+                                    active_resize.live_geo_lx,
+                                    active_resize.live_geo_ly,
+                                    active_resize.live_geo_w,
+                                    active_resize.live_geo_h,
+                                )
+                            } else {
+                                // Before first commit: use frozen start geo from ResizeCtx.
+                                // local_geo may have stale data; start_geo_lx/ly is reliable.
+                                let rz = resize_preview.unwrap();
+                                (rz.start_geo_lx, rz.start_geo_ly, local_geo.2, local_geo.3)
+                            };
+                        // Crop src to just the geo region — excludes the CSD
+                        // shadow pixels (transparent black) at bbox edges which
+                        // would otherwise blit over the border strips.
+                        // src coords are in logical texture pixels (1:1 with surface).
+                        let src_x = (live_lx.round() as i32) - ob.loc.x;
+                        let src_y = (live_ly.round() as i32) - ob.loc.y;
+                        let src_w = live_gw.round() as i32;
+                        let src_h = live_gh.round() as i32;
+                        let clip_w = (live_gw * cam_scale).round() as i32;
+                        let clip_h = (live_gh * cam_scale).round() as i32;
+                        (
+                            src_x.max(0),
+                            src_y.max(0),
+                            src_w.max(1),
+                            src_h.max(1),
+                            fx,
+                            fy,
+                            clip_w.max(1).min(fw),
+                            clip_h.max(1).min(fh),
+                            fx,
+                            fy,
+                            clip_w.max(1).min(fw),
+                            clip_h.max(1).min(fh),
+                        )
+                    } else {
+                        let src_x = (local_geo.0.round() as i32) - ob.loc.x;
+                        let src_y = (local_geo.1.round() as i32) - ob.loc.y;
+                        let src_w = local_geo.2.round().max(1.0) as i32;
+                        let src_h = local_geo.3.round().max(1.0) as i32;
+                        (
+                            src_x,
+                            src_y,
+                            src_w,
+                            src_h,
+                            gx,
+                            gy,
+                            gw.max(1),
+                            gh.max(1),
+                            gx,
+                            gy,
+                            gw.max(1),
+                            gh.max(1),
+                        )
+                    };
 
                     offscreen_textures.push(OffscreenNodeTexture {
                         texture: offscreen.texture,
-                        src_x, src_y, src_w, src_h,
-                        dst_x, dst_y, dst_w, dst_h,
-                        clip_x, clip_y, clip_w, clip_h,
+                        src_x,
+                        src_y,
+                        src_w,
+                        src_h,
+                        dst_x,
+                        dst_y,
+                        dst_w,
+                        dst_h,
+                        clip_x,
+                        clip_y,
+                        clip_w,
+                        clip_h,
                         focused: st.interaction_focus == Some(node_id),
                     });
                 }

--- a/crates/halley-wl/src/render/node_render.rs
+++ b/crates/halley-wl/src/render/node_render.rs
@@ -55,6 +55,7 @@ pub(crate) struct ActiveBorderRect {
 
 pub(crate) struct OffscreenNodeTexture {
     pub texture: GlesTexture,
+    pub alpha: f32,
     pub src_x: i32,
     pub src_y: i32,
     pub src_w: i32,
@@ -67,7 +68,6 @@ pub(crate) struct OffscreenNodeTexture {
     pub clip_y: i32,
     pub clip_w: i32,
     pub clip_h: i32,
-    pub focused: bool,
 }
 
 fn rect_from_local_geometry(
@@ -277,9 +277,66 @@ pub(crate) fn collect_active_surfaces(
         let use_offscreen_zoom = (cam_scale - 1.0).abs() > 0.001;
 
         if use_offscreen_zoom {
-            match render_surface_tree_to_texture(renderer, &wl, alpha) {
-                Ok(offscreen) => {
-                    let ob = offscreen.bbox;
+            let cache_miss = {
+                let cache =
+                    st.ensure_window_offscreen_cache(node_id, bbox.size.w, bbox.size.h, now);
+                cache.dirty || cache.texture.is_none() || cache.bbox.is_none()
+            };
+
+            if cache_miss {
+                match render_surface_tree_to_texture(renderer, &wl, 1.0) {
+                    Ok(offscreen) => {
+                        let cache = st
+                            .window_offscreen_cache
+                            .get_mut(&node_id)
+                            .expect("offscreen cache should exist after ensure");
+                        cache.texture = Some(offscreen.texture);
+                        cache.bbox = Some(offscreen.bbox);
+                        cache.mark_clean(now);
+                    }
+                    Err(_) => {
+                        let elems = render_elements_from_surface_tree(
+                            renderer,
+                            &wl,
+                            (sx, sy),
+                            element_scale as f64,
+                            alpha,
+                            Kind::Unspecified,
+                        );
+
+                        let (tx, ty, tw, th) = texture_rect;
+                        let display_clip = Rectangle::<i32, Physical>::new(
+                            (tx, ty).into(),
+                            (tw.max(1), th.max(1)).into(),
+                        );
+
+                        let cropped: Vec<_> = elems
+                            .into_iter()
+                            .filter_map(|e| CropRenderElement::from_element(e, 1.0, display_clip))
+                            .collect();
+
+                        if draw_top_this_node {
+                            resized_active_elements.extend(cropped);
+                        } else {
+                            active_elements.extend(cropped);
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            if let Some(cache) = st.window_offscreen_cache.get_mut(&node_id) {
+                cache.touch(now);
+            }
+
+            match st.window_offscreen_cache.get(&node_id) {
+                Some(cache) => {
+                    let Some(texture) = cache.texture.as_ref() else {
+                        continue;
+                    };
+                    let Some(ob) = cache.bbox else {
+                        continue;
+                    };
 
                     // src = full bbox, dst = bbox scaled to screen positioned so geo
                     // lands on frame, clip = frame rect to discard CSD shadow bleed.
@@ -361,7 +418,8 @@ pub(crate) fn collect_active_surfaces(
                     };
 
                     offscreen_textures.push(OffscreenNodeTexture {
-                        texture: offscreen.texture,
+                        texture: texture.clone(),
+                        alpha,
                         src_x,
                         src_y,
                         src_w,
@@ -374,36 +432,9 @@ pub(crate) fn collect_active_surfaces(
                         clip_y,
                         clip_w,
                         clip_h,
-                        focused: st.interaction_focus == Some(node_id),
                     });
                 }
-                Err(_) => {
-                    let elems = render_elements_from_surface_tree(
-                        renderer,
-                        &wl,
-                        (sx, sy),
-                        element_scale as f64,
-                        alpha,
-                        Kind::Unspecified,
-                    );
-
-                    let (tx, ty, tw, th) = texture_rect;
-                    let display_clip = Rectangle::<i32, Physical>::new(
-                        (tx, ty).into(),
-                        (tw.max(1), th.max(1)).into(),
-                    );
-
-                    let cropped: Vec<_> = elems
-                        .into_iter()
-                        .filter_map(|e| CropRenderElement::from_element(e, 1.0, display_clip))
-                        .collect();
-
-                    if draw_top_this_node {
-                        resized_active_elements.extend(cropped);
-                    } else {
-                        active_elements.extend(cropped);
-                    }
-                }
+                None => continue,
             }
         } else {
             let elems = render_elements_from_surface_tree(

--- a/crates/halley-wl/src/render/offscreen.rs
+++ b/crates/halley-wl/src/render/offscreen.rs
@@ -47,13 +47,6 @@ pub(crate) struct OffscreenSurfaceTexture {
     pub bbox: Rectangle<i32, Logical>,
 }
 
-impl OffscreenSurfaceTexture {
-    #[inline]
-    pub fn physical_size(&self) -> Size<i32, Physical> {
-        (self.bbox.size.w.max(1), self.bbox.size.h.max(1)).into()
-    }
-}
-
 pub(crate) fn render_surface_tree_to_texture(
     renderer: &mut GlesRenderer,
     wl: &WlSurface,

--- a/crates/halley-wl/src/render/offscreen.rs
+++ b/crates/halley-wl/src/render/offscreen.rs
@@ -65,8 +65,7 @@ pub(crate) fn render_surface_tree_to_texture(
     }
 
     let logical_size = bbox.size;
-    let physical_size: Size<i32, Physical> =
-        (logical_size.w.max(1), logical_size.h.max(1)).into();
+    let physical_size: Size<i32, Physical> = (logical_size.w.max(1), logical_size.h.max(1)).into();
 
     let elements: Vec<SurfaceElement> = render_elements_from_surface_tree(
         renderer,

--- a/crates/halley-wl/src/render/render_utils.rs
+++ b/crates/halley-wl/src/render/render_utils.rs
@@ -31,7 +31,15 @@ pub(crate) fn draw_ring<F: Frame>(
         let t = (i as f32 / samples as f32) * TAU;
         let x = center_sx + t.cos() * rx;
         let y = center_sy + t.sin() * ry;
-        draw_rect(frame, (x - 1.0) as i32, (y - 1.0) as i32, 3, 3, color, damage)?;
+        draw_rect(
+            frame,
+            (x - 1.0) as i32,
+            (y - 1.0) as i32,
+            3,
+            3,
+            color,
+            damage,
+        )?;
     }
     Ok(())
 }

--- a/crates/halley-wl/src/render/render_utils.rs
+++ b/crates/halley-wl/src/render/render_utils.rs
@@ -9,7 +9,7 @@ use smithay::{
     utils::{Logical, Physical, Rectangle},
 };
 
-use super::anim_utils::proxy_anim_scale;
+use crate::animation::proxy_anim_scale;
 use crate::state::HalleyWlState;
 
 /// Draw an elliptical ring at a fixed screen-space position and radius.

--- a/crates/halley-wl/src/run/common.rs
+++ b/crates/halley-wl/src/run/common.rs
@@ -23,14 +23,14 @@ use rustix::net::{
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum RuntimeBackend {
+pub(crate) enum RuntimeBackend {
     Auto,
     Winit,
     Tty,
 }
 
 impl RuntimeBackend {
-    pub(super) fn from_env() -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn from_env() -> Result<Self, Box<dyn Error>> {
         let raw = env::var("HALLEY_WL_BACKEND").unwrap_or_else(|_| "auto".to_string());
         match raw.trim().to_ascii_lowercase().as_str() {
             "auto" => Ok(Self::Auto),
@@ -44,7 +44,7 @@ impl RuntimeBackend {
     }
 }
 
-pub(super) fn auto_backend() -> RuntimeBackend {
+pub(crate) fn auto_backend() -> RuntimeBackend {
     if !std::io::stdin().is_terminal() {
         return RuntimeBackend::Winit;
     }
@@ -74,7 +74,7 @@ pub(super) fn auto_backend() -> RuntimeBackend {
     RuntimeBackend::Tty
 }
 
-pub(super) fn ensure_xdg_runtime_dir() -> Result<(), Box<dyn Error>> {
+pub(crate) fn ensure_xdg_runtime_dir() -> Result<(), Box<dyn Error>> {
     if let Some(dir) = env::var_os("XDG_RUNTIME_DIR") {
         let path = Path::new(&dir);
         if runtime_dir_is_usable(path) {
@@ -114,7 +114,7 @@ pub(super) fn ensure_xdg_runtime_dir() -> Result<(), Box<dyn Error>> {
     Err("unable to find a usable XDG_RUNTIME_DIR".into())
 }
 
-pub(super) fn ensure_dbus_session_bus_address() {
+pub(crate) fn ensure_dbus_session_bus_address() {
     if env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
         return;
     }
@@ -133,7 +133,7 @@ pub(super) fn ensure_dbus_session_bus_address() {
     unsafe { env::set_var("DBUS_SESSION_BUS_ADDRESS", addr) };
 }
 
-pub(super) struct HostBackendGuard {
+pub(crate) struct HostBackendGuard {
     child: Option<Child>,
 }
 
@@ -146,7 +146,7 @@ impl Drop for HostBackendGuard {
     }
 }
 
-pub(super) fn ensure_host_display() -> Result<HostBackendGuard, Box<dyn Error>> {
+pub(crate) fn ensure_host_display() -> Result<HostBackendGuard, Box<dyn Error>> {
     if env::var("WAYLAND_DISPLAY").is_ok() || env::var("DISPLAY").is_ok() {
         return Ok(HostBackendGuard { child: None });
     }
@@ -202,7 +202,7 @@ impl XwaylandMode {
     }
 }
 
-pub(super) struct XwaylandSatellite {
+pub(crate) struct XwaylandSatellite {
     mode: XwaylandMode,
     satellite_bin: String,
     wayland_display: String,
@@ -303,11 +303,11 @@ impl Drop for X11SocketReservation {
 }
 
 impl XwaylandSatellite {
-    pub(super) fn request_start(&mut self) {
+    pub(crate) fn request_start(&mut self) {
         self.request_pending = true;
     }
 
-    pub(super) fn tick(&mut self) {
+    pub(crate) fn tick(&mut self) {
         let now = Instant::now();
 
         if let Some(child) = self.child.as_mut() {
@@ -418,14 +418,14 @@ impl XwaylandSatellite {
         }
     }
 
-    pub(super) fn filesystem_listener_source(&self) -> io::Result<Option<UnixListener>> {
+    pub(crate) fn filesystem_listener_source(&self) -> io::Result<Option<UnixListener>> {
         self.x11_sockets
             .as_ref()
             .map(X11SocketReservation::filesystem_listener_for_event_loop)
             .transpose()
     }
 
-    pub(super) fn abstract_listener_source(&self) -> io::Result<Option<OwnedFd>> {
+    pub(crate) fn abstract_listener_source(&self) -> io::Result<Option<OwnedFd>> {
         self.x11_sockets
             .as_ref()
             .map(X11SocketReservation::abstract_listener_for_event_loop)
@@ -442,7 +442,7 @@ impl Drop for XwaylandSatellite {
     }
 }
 
-pub(super) fn ensure_xwayland_satellite(
+pub(crate) fn ensure_xwayland_satellite(
     wayland_display: &str,
 ) -> Result<XwaylandSatellite, Box<dyn Error>> {
     let mode = XwaylandMode::from_env()?;

--- a/crates/halley-wl/src/run/mod.rs
+++ b/crates/halley-wl/src/run/mod.rs
@@ -1,74 +1,24 @@
-use std::cell::Cell;
-use std::cell::RefCell;
 use std::env;
 use std::error::Error;
-use std::io;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
-use std::time::{Duration, Instant};
 
 use halley_config::RuntimeTuning;
 
-use calloop::EventLoop;
-use calloop::timer::{TimeoutAction, Timer};
-
-use eventline::{FileSetup, LogLevel, LogPolicy, RunHeader, Setup, debug, info, scope, warn};
-use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use eventline::{FileSetup, LogLevel, LogPolicy, RunHeader, Setup, info, scope, warn};
 use once_cell::sync::OnceCell;
 
-use smithay::reexports::drm::control::{self as drm_control, Device as DrmControlDevice};
-use smithay::{
-    backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice},
-    backend::allocator::{Format, Fourcc},
-    backend::drm::DrmEvent,
-    backend::drm::GbmBufferedSurface,
-    backend::drm::{DrmDevice, DrmDeviceFd},
-    backend::egl::{EGLContext, EGLDisplay},
-    backend::input::{
-        AbsolutePositionEvent, Axis, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
-        PointerButtonEvent,
-    },
-    backend::libinput::LibinputInputBackend,
-    backend::libinput::LibinputSessionInterface,
-    backend::renderer::gles::GlesRenderer,
-    backend::renderer::{Bind, ImportDma},
-    backend::session::libseat::LibSeatSession,
-    backend::session::{Event as SessionEvent, Session},
-    backend::udev::{all_gpus, primary_gpu},
-    backend::winit::{self, WinitEvent},
-    reexports::input::Libinput,
-    reexports::wayland_server::Display,
-    utils::{DeviceFd, Transform},
-    wayland::socket::ListeningSocketSource,
-};
-
-use crate::activity::VisualState;
-use crate::backend_iface::{BackendView, RenderBackend, WinitBackendHandle};
-use crate::interaction::types::{ModState, PointerState};
-use crate::state::{ClientState, HalleyWlState};
-
-use crate::input::{
-    BackendInputEventData, advance_node_move_anim, handle_backend_input_event, spawn_command,
-};
-use crate::render::draw_debug_frame_to_target;
-use crate::surface::current_surface_size_for_node;
+use crate::input::spawn_command;
+use crate::state::HalleyWlState;
 
 mod common;
-mod drm;
-mod input_backend;
 mod ipc;
-mod tty_backend;
-mod winit_backend;
 
-use common::{
+pub(crate) use common::{
     RuntimeBackend, auto_backend, ensure_dbus_session_bus_address, ensure_host_display,
     ensure_xdg_runtime_dir, ensure_xwayland_satellite,
 };
-use drm::probe_tty_drm_device_via_session;
-use input_backend::build_tty_libinput_backend;
 pub(crate) use ipc::{RuntimeIpcCommand, drain_ipc_commands, init_ipc, publish_outputs};
 
 static XWAYLAND_REQUEST_TX: OnceCell<mpsc::Sender<()>> = OnceCell::new();
@@ -128,31 +78,6 @@ pub(crate) fn apply_reloaded_tuning(
     info!("{reason}: reloaded config from {}", config_path);
 }
 
-#[derive(Clone)]
-struct TtyBackendHandle {
-    size: Rc<Cell<(i32, i32)>>,
-}
-
-impl TtyBackendHandle {
-    fn new(width: i32, height: i32) -> Self {
-        Self {
-            size: Rc::new(Cell::new((width, height))),
-        }
-    }
-
-    fn set_size(&self, width: i32, height: i32) {
-        self.size.set((width, height));
-    }
-}
-
-impl BackendView for TtyBackendHandle {
-    fn window_size_i32(&self) -> (i32, i32) {
-        self.size.get()
-    }
-
-    fn request_redraw(&self) {}
-}
-
 pub fn run() -> Result<(), Box<dyn Error>> {
     // Register signal handlers before anything else so that SIGTERM (the
     // default signal sent by `pkill`/`kill`) triggers a clean shutdown.
@@ -177,14 +102,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn run_winit() -> Result<(), Box<dyn Error>> {
-    winit_backend::run_winit_backend()
+    crate::backend::winit::run_winit_backend()
 }
 
 pub fn run_tty() -> Result<(), Box<dyn Error>> {
-    tty_backend::run_tty_backend()
+    crate::backend::tty::run_tty_backend()
 }
 
-fn init_logging() -> Result<(), Box<dyn Error>> {
+pub(crate) fn init_logging() -> Result<(), Box<dyn Error>> {
     scope!("logging-init", success = "ready", {
         let level = env::var("HALLEY_WL_LOG")
             .ok()

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -17,7 +17,7 @@ use smithay::{
     input::{Seat, SeatState, pointer::CursorImageStatus},
     output::{Mode as OutputMode, Output, PhysicalProperties, Scale, Subpixel},
     reexports::wayland_server::{DisplayHandle, backend::ObjectId},
-    utils::{Size, Transform},
+    utils::{Logical, Rectangle, Transform},
     wayland::{
         compositor::CompositorState,
         dmabuf::{DmabufFeedbackBuilder, DmabufGlobal, DmabufState},
@@ -32,6 +32,7 @@ use smithay::{
         viewporter::ViewporterState,
     },
 };
+use smithay::backend::renderer::gles::GlesTexture;
 
 use crate::activity::CommitActivity;
 use crate::anim::{AnimSpec, Animator};
@@ -87,7 +88,7 @@ pub(crate) struct WindowOffscreenKey {
     pub height: i32,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Default)]
 pub(crate) struct WindowOffscreenCache {
     /// Native 1.0x surface-tree bbox size used to build the offscreen image.
     pub key: WindowOffscreenKey,
@@ -97,6 +98,12 @@ pub(crate) struct WindowOffscreenCache {
 
     /// Last frame this cache entry was touched.
     pub last_used_at: Option<Instant>,
+
+    /// Cached 1.0x surface-tree render target for zoomed compositing.
+    pub texture: Option<GlesTexture>,
+
+    /// Logical bbox paired with the cached texture.
+    pub bbox: Option<Rectangle<i32, Logical>>,
 }
 
 impl WindowOffscreenCache {
@@ -108,6 +115,8 @@ impl WindowOffscreenCache {
     #[inline]
     pub fn set_size(&mut self, width: i32, height: i32) {
         self.key = WindowOffscreenKey { width, height };
+        self.texture = None;
+        self.bbox = None;
     }
 
     #[inline]
@@ -126,10 +135,6 @@ impl WindowOffscreenCache {
         self.last_used_at = Some(now);
     }
 
-    #[inline]
-    pub fn size(&self) -> Size<i32, smithay::utils::Physical> {
-        (self.key.width.max(1), self.key.height.max(1)).into()
-    }
 }
 
 pub struct HalleyWlState {

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -3,6 +3,7 @@ use std::os::unix::io::AsFd;
 use std::rc::Rc;
 use std::time::Instant;
 
+use calloop::ping::Ping;
 use halley_config::RuntimeTuning;
 use halley_core::cluster::ClusterId;
 use halley_core::cluster_policy::{ClusterFormationState, ClusterPolicy, tick_cluster_formation};
@@ -223,6 +224,8 @@ pub struct HalleyWlState {
     pub(crate) active_spawn_pan: Option<ActiveSpawnPan>,
     pub(crate) started_at: Instant,
     pub(crate) last_debug_dump_at: Instant,
+    pub(crate) maintenance_dirty: bool,
+    pub(crate) maintenance_ping: Option<Ping>,
 
     pub(crate) spawned_children: Vec<std::process::Child>,
 }
@@ -334,6 +337,8 @@ impl HalleyWlState {
             active_spawn_pan: None,
             started_at: now,
             last_debug_dump_at: now,
+            maintenance_dirty: true,
+            maintenance_ping: None,
 
             spawned_children: Vec::new(),
         };
@@ -472,7 +477,80 @@ impl HalleyWlState {
     }
 
     #[inline]
-    pub fn tick_maintenance(&mut self, now: Instant) {
+    pub fn set_maintenance_ping(&mut self, ping: Ping) {
+        self.maintenance_ping = Some(ping);
+        self.request_maintenance();
+    }
+
+    #[inline]
+    pub fn request_maintenance(&mut self) {
+        self.maintenance_dirty = true;
+        if let Some(ping) = &self.maintenance_ping {
+            ping.ping();
+        }
+    }
+
+    pub fn next_maintenance_deadline(&self, now: Instant) -> Option<Instant> {
+        if !self.app_focused {
+            return None;
+        }
+
+        let now_ms = self.now_ms(now);
+        let mut next_ms: Option<u64> = None;
+        let mut consider = |at_ms: u64| {
+            next_ms = Some(next_ms.map_or(at_ms, |cur| cur.min(at_ms)));
+        };
+
+        if self.interaction_focus.is_some() && self.interaction_focus_until_ms > now_ms {
+            consider(self.interaction_focus_until_ms);
+        }
+        if self.resize_static_node.is_some() && self.resize_static_until_ms > now_ms {
+            consider(self.resize_static_until_ms);
+        }
+        if let Some(at_ms) = self.pending_spawn_activate_at_ms.values().copied().min()
+            && at_ms > now_ms
+        {
+            consider(at_ms);
+        }
+        if let Some(at_ms) = self.active_transition_until_ms.values().copied().min()
+            && at_ms > now_ms
+        {
+            consider(at_ms);
+        }
+        if let Some(at_ms) = self.primary_promote_cooldown_until_ms.values().copied().min()
+            && at_ms > now_ms
+        {
+            consider(at_ms);
+        }
+        if self.tuning.debug_tick_dump {
+            consider(
+                now_ms.saturating_add(
+                    self.tuning.debug_dump_every_ms.saturating_sub(
+                        now.duration_since(self.last_debug_dump_at).as_millis() as u64,
+                    ),
+                ),
+            );
+        }
+
+        next_ms.map(|at_ms| {
+            now.checked_add(std::time::Duration::from_millis(at_ms.saturating_sub(now_ms)))
+                .unwrap_or(now)
+        })
+    }
+
+    #[inline]
+    pub fn run_maintenance_if_needed(&mut self, now: Instant) {
+        let due = self
+            .next_maintenance_deadline(now)
+            .is_some_and(|deadline| deadline <= now);
+        if self.maintenance_dirty || due {
+            self.run_maintenance(now);
+        }
+    }
+
+    #[inline]
+    pub fn run_maintenance(&mut self, now: Instant) {
+        self.maintenance_dirty = false;
         if !self.app_focused {
             return;
         }

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -35,7 +35,7 @@ use smithay::{
 use smithay::backend::renderer::gles::GlesTexture;
 
 use crate::activity::CommitActivity;
-use crate::anim::{AnimSpec, Animator};
+use crate::animation::{AnimSpec, Animator};
 use crate::backend::interface::DmabufImportBackend;
 use crate::wm::ViewportPanAnim;
 

--- a/crates/halley-wl/src/state/mod.rs
+++ b/crates/halley-wl/src/state/mod.rs
@@ -34,7 +34,7 @@ use smithay::{
 
 use crate::activity::CommitActivity;
 use crate::anim::{AnimSpec, Animator};
-use crate::backend_iface::DmabufImportBackend;
+use crate::backend::interface::DmabufImportBackend;
 use crate::wm::ViewportPanAnim;
 
 mod client;

--- a/crates/halley-wl/src/state/render_state.rs
+++ b/crates/halley-wl/src/state/render_state.rs
@@ -160,7 +160,6 @@ impl HalleyWlState {
     }
 }
 
-
 fn send_frames_surface_tree(
     surface: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
     time_ms: u32,

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -52,6 +52,7 @@ impl HalleyWlState {
         }
         self.active_transition_until_ms
             .insert(id, self.now_ms(now).saturating_add(duration_ms.max(1)));
+        self.request_maintenance();
     }
 
     pub fn active_transition_alpha(&self, id: NodeId, now: Instant) -> f32 {
@@ -165,6 +166,7 @@ impl HalleyWlState {
         }
 
         self.tuning = tuning;
+        self.request_maintenance();
 
         if let Some(id) = prev_focus {
             self.set_interaction_focus(Some(id), 30_000, Instant::now());

--- a/crates/halley-wl/src/state/runtime_state.rs
+++ b/crates/halley-wl/src/state/runtime_state.rs
@@ -4,7 +4,7 @@ use halley_config::RuntimeTuning;
 
 use eventline::debug;
 
-use crate::anim::{AnimSpec, AnimStyle};
+use crate::animation::{AnimSpec, AnimStyle};
 use crate::render::{DebugScene, build_debug_scene};
 
 impl HalleyWlState {

--- a/crates/halley-wl/src/surface/mod.rs
+++ b/crates/halley-wl/src/surface/mod.rs
@@ -1,5 +1,6 @@
 mod surface_ops;
 
 pub(crate) use surface_ops::{
-    current_surface_size_for_node, request_toplevel_resize_mode, window_geometry_for_node,
+    current_surface_size_for_node, request_close_focused_toplevel, request_toplevel_resize_mode,
+    window_geometry_for_node,
 };

--- a/crates/halley-wl/src/surface/surface_ops.rs
+++ b/crates/halley-wl/src/surface/surface_ops.rs
@@ -6,6 +6,24 @@ use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use crate::state::HalleyWlState;
 
+pub(crate) fn request_close_focused_toplevel(st: &mut HalleyWlState) -> bool {
+    let Some(node_id) = st.last_focused_surface_node() else {
+        return false;
+    };
+
+    for top in st.xdg_shell_state.toplevel_surfaces() {
+        let wl = top.wl_surface();
+        let key = wl.id();
+        if st.surface_to_node.get(&key).copied() != Some(node_id) {
+            continue;
+        }
+        top.send_close();
+        return true;
+    }
+
+    false
+}
+
 pub(crate) fn request_toplevel_resize_mode(
     st: &mut HalleyWlState,
     node_id: halley_core::field::NodeId,

--- a/crates/halley-wl/src/wayland/handlers.rs
+++ b/crates/halley-wl/src/wayland/handlers.rs
@@ -227,6 +227,7 @@ impl XdgShellHandler for HalleyWlState {
         self.reveal_new_toplevel_node(id, is_transient, now);
 
         self.resolve_surface_overlap();
+        self.request_maintenance();
     }
 
     fn new_popup(&mut self, popup: PopupSurface, _positioner: PositionerState) {

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -35,6 +35,14 @@ impl HalleyWlState {
         surface.id()
     }
 
+    fn surface_tree_root(surface: &WlSurface) -> WlSurface {
+        let mut root = surface.clone();
+        while let Some(parent) = smithay::wayland::compositor::get_parent(&root) {
+            root = parent;
+        }
+        root
+    }
+
     fn viewport_contains_point(&self, pos: Vec2) -> bool {
         let half_w = self.viewport.size.x * 0.5;
         let half_h = self.viewport.size.y * 0.5;
@@ -310,6 +318,8 @@ impl HalleyWlState {
 
     pub fn note_commit(&mut self, surface: &WlSurface, now: Instant) {
         let key = Self::surface_key(surface);
+        let root_surface = Self::surface_tree_root(surface);
+        let root_key = Self::surface_key(&root_surface);
         self.surface_activity
             .entry(key.clone())
             .or_insert_with(|| CommitActivity::new(now))
@@ -326,17 +336,18 @@ impl HalleyWlState {
         // path has a live source of truth. Outside resize this is handled by
         // sync_node_size_from_surface on every render frame, but that path is
         // bypassed for the resizing node.
-        if let Some(node_id) = self.surface_to_node.get(&key).copied() {
+        if let Some(node_id) = self.surface_to_node.get(&root_key).copied() {
+            self.mark_window_offscreen_dirty(node_id);
             if self.resize_active == Some(node_id) {
                 use smithay::desktop::utils::bbox_from_surface_tree;
                 use smithay::wayland::compositor::with_states;
                 use smithay::wayland::shell::xdg::SurfaceCachedState;
 
-                let bbox = bbox_from_surface_tree(surface, (0, 0));
+                let bbox = bbox_from_surface_tree(&root_surface, (0, 0));
                 self.bbox_loc
                     .insert(node_id, (bbox.loc.x as f32, bbox.loc.y as f32));
 
-                let geo = with_states(surface, |states| {
+                let geo = with_states(&root_surface, |states| {
                     states
                         .cached_state
                         .get::<SurfaceCachedState>()
@@ -557,6 +568,7 @@ impl HalleyWlState {
                 self.interaction_focus_until_ms = 0;
             }
             self.smoothed_render_pos.remove(&id);
+            self.clear_window_offscreen_cache_for(id);
             let _ = self.field.remove(id);
         }
         self.request_maintenance();

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -559,6 +559,7 @@ impl HalleyWlState {
             self.smoothed_render_pos.remove(&id);
             let _ = self.field.remove(id);
         }
+        self.request_maintenance();
     }
 }
 

--- a/crates/halley-wl/src/wayland/surface_lifecycle.rs
+++ b/crates/halley-wl/src/wayland/surface_lifecycle.rs
@@ -167,9 +167,18 @@ impl HalleyWlState {
 
         let dirs = [
             base_dir,
-            Vec2 { x: -base_dir.y, y: base_dir.x },
-            Vec2 { x: base_dir.y, y: -base_dir.x },
-            Vec2 { x: -base_dir.x, y: -base_dir.y },
+            Vec2 {
+                x: -base_dir.y,
+                y: base_dir.x,
+            },
+            Vec2 {
+                x: base_dir.y,
+                y: -base_dir.x,
+            },
+            Vec2 {
+                x: -base_dir.x,
+                y: -base_dir.y,
+            },
         ];
 
         for mul in [1.0_f32, 1.35, 1.75, 2.25, 2.9] {
@@ -217,9 +226,8 @@ impl HalleyWlState {
 
         let star_center = if let Some(patch) = &self.spawn_patch {
             let same_focus = patch.focus_node == focus_id;
-            let same_focus_pos =
-                (patch.focus_pos.x - focus_pos.x).abs() < 0.01 &&
-                (patch.focus_pos.y - focus_pos.y).abs() < 0.01;
+            let same_focus_pos = (patch.focus_pos.x - focus_pos.x).abs() < 0.01
+                && (patch.focus_pos.y - focus_pos.y).abs() < 0.01;
 
             if same_focus || same_focus_pos {
                 patch.anchor
@@ -325,26 +333,40 @@ impl HalleyWlState {
                 use smithay::wayland::shell::xdg::SurfaceCachedState;
 
                 let bbox = bbox_from_surface_tree(surface, (0, 0));
-                self.bbox_loc.insert(node_id, (bbox.loc.x as f32, bbox.loc.y as f32));
+                self.bbox_loc
+                    .insert(node_id, (bbox.loc.x as f32, bbox.loc.y as f32));
 
                 let geo = with_states(surface, |states| {
-                    states.cached_state.get::<SurfaceCachedState>().current().geometry
+                    states
+                        .cached_state
+                        .get::<SurfaceCachedState>()
+                        .current()
+                        .geometry
                 });
                 if let Some(g) = geo {
-                    self.window_geometry.insert(node_id, (
-                        g.loc.x as f32, g.loc.y as f32,
-                        g.size.w.max(1) as f32, g.size.h.max(1) as f32,
-                    ));
+                    self.window_geometry.insert(
+                        node_id,
+                        (
+                            g.loc.x as f32,
+                            g.loc.y as f32,
+                            g.size.w.max(1) as f32,
+                            g.size.h.max(1) as f32,
+                        ),
+                    );
                 } else {
-                    self.window_geometry.insert(node_id, (
-                        bbox.loc.x as f32, bbox.loc.y as f32,
-                        bbox.size.w.max(1) as f32, bbox.size.h.max(1) as f32,
-                    ));
+                    self.window_geometry.insert(
+                        node_id,
+                        (
+                            bbox.loc.x as f32,
+                            bbox.loc.y as f32,
+                            bbox.size.w.max(1) as f32,
+                            bbox.size.h.max(1) as f32,
+                        ),
+                    );
                 }
             }
         }
     }
-
 
     pub fn ensure_node_for_surface(
         &mut self,
@@ -472,7 +494,9 @@ impl HalleyWlState {
             return;
         }
 
-        if self.active_spawn_pan.is_some_and(|active| active.node_id == id)
+        if self
+            .active_spawn_pan
+            .is_some_and(|active| active.node_id == id)
             || self
                 .pending_spawn_pan_queue
                 .iter()
@@ -568,7 +592,10 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let (pos, needs_pan) = state.pick_spawn_position(Vec2 { x: 100.0, y: 80.0 });
         assert_eq!(pos, Vec2 { x: 0.0, y: 0.0 });
@@ -583,11 +610,18 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 0.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
         let size = Vec2 { x: 100.0, y: 80.0 };
-        let first = state.field.spawn_surface("first", Vec2 { x: 0.0, y: 0.0 }, size);
-        let _ = state.field.set_state(first, halley_core::field::NodeState::Active);
+        let first = state
+            .field
+            .spawn_surface("first", Vec2 { x: 0.0, y: 0.0 }, size);
+        let _ = state
+            .field
+            .set_state(first, halley_core::field::NodeState::Active);
         state.last_surface_focus_ms.insert(first, 1);
         state.interaction_focus = Some(first);
         state.update_spawn_patch(
@@ -621,7 +655,10 @@ mod tests {
         state.last_surface_focus_ms.insert(focused, 1);
         state.interaction_focus = Some(focused);
 
-        assert_eq!(state.current_spawn_focus(), (Some(focused), Vec2 { x: 0.0, y: 0.0 }));
+        assert_eq!(
+            state.current_spawn_focus(),
+            (Some(focused), Vec2 { x: 0.0, y: 0.0 })
+        );
     }
 
     #[test]
@@ -639,7 +676,9 @@ mod tests {
             Vec2 { x: 0.0, y: 0.0 },
             Vec2 { x: 100.0, y: 80.0 },
         );
-        let _ = state.field.set_state(focused, halley_core::field::NodeState::Active);
+        let _ = state
+            .field
+            .set_state(focused, halley_core::field::NodeState::Active);
         state.last_surface_focus_ms.insert(focused, 1);
         state.interaction_focus = Some(focused);
 
@@ -663,7 +702,9 @@ mod tests {
             Vec2 { x: 0.0, y: 0.0 },
             Vec2 { x: 500.0, y: 300.0 },
         );
-        let _ = state.field.set_state(focused, halley_core::field::NodeState::Active);
+        let _ = state
+            .field
+            .set_state(focused, halley_core::field::NodeState::Active);
         state.last_surface_focus_ms.insert(focused, 1);
         state.interaction_focus = Some(focused);
 
@@ -683,13 +724,15 @@ mod tests {
             .handle();
         let mut state = HalleyWlState::new(&dh, tuning);
         state.viewport.center = Vec2 { x: 700.0, y: 0.0 };
-        state.viewport.size = Vec2 { x: 1600.0, y: 1200.0 };
+        state.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
 
-        let id = state.field.spawn_surface(
-            "new",
-            Vec2 { x: 920.0, y: 0.0 },
-            Vec2 { x: 100.0, y: 80.0 },
-        );
+        let id =
+            state
+                .field
+                .spawn_surface("new", Vec2 { x: 920.0, y: 0.0 }, Vec2 { x: 100.0, y: 80.0 });
 
         state.reveal_new_toplevel_node(id, false, Instant::now());
 

--- a/crates/halley-wl/src/wm/carry.rs
+++ b/crates/halley-wl/src/wm/carry.rs
@@ -132,6 +132,7 @@ impl HalleyWlState {
             self.carry_zone_pending_since_ms.remove(&id);
             self.carry_activation_anim_armed.insert(id);
         }
+        self.request_maintenance();
     }
 
     pub fn end_carry_state_tracking(&mut self, id: NodeId) {
@@ -144,6 +145,7 @@ impl HalleyWlState {
         self.suspend_overlap_resolve = false;
         self.suspend_state_checks = false;
         self.clear_direct_carry_nodes();
+        self.request_maintenance();
     }
 
     pub fn update_carry_state_preview(&mut self, id: NodeId, now: Instant) {
@@ -184,5 +186,6 @@ impl HalleyWlState {
                 self.mark_active_transition(id, now, 360);
             }
         }
+        self.request_maintenance();
     }
 }

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -125,6 +125,7 @@ impl HalleyWlState {
         }
         self.suspend_overlap_resolve = false;
         self.suspend_state_checks = false;
+        self.request_maintenance();
     }
 
     fn spawn_view_handoff_pan_distance(&self) -> f32 {
@@ -139,6 +140,7 @@ impl HalleyWlState {
         if self.spawn_anchor_mode == crate::state::SpawnAnchorMode::View {
             self.spawn_view_anchor = self.viewport.center;
         }
+        self.request_maintenance();
         let Some(start_center) = self.spawn_pan_start_center else {
             return;
         };
@@ -301,6 +303,7 @@ impl HalleyWlState {
         let _ = self.field.touch(id, now_ms);
         let _ = self.field.set_decay_level(id, DecayLevel::Hot);
         self.manual_collapsed_nodes.remove(&id);
+        self.request_maintenance();
     }
 
     pub fn end_resize_interaction(&mut self, now: Instant) {
@@ -317,6 +320,7 @@ impl HalleyWlState {
         self.suspend_state_checks = false;
         self.suspend_overlap_resolve = false;
         self.resolve_surface_overlap();
+        self.request_maintenance();
     }
 
     pub fn resolve_overlap_now(&mut self) {
@@ -347,6 +351,7 @@ impl HalleyWlState {
                 self.interaction_focus_until_ms = 0;
                 self.reassert_wayland_keyboard_focus_if_drifted(None);
             }
+            self.request_maintenance();
             return;
         }
 
@@ -369,6 +374,7 @@ impl HalleyWlState {
             );
         }
         self.apply_wayland_focus_state(id);
+        self.request_maintenance();
     }
 
     pub fn last_focused_surface_node(&self) -> Option<NodeId> {
@@ -439,6 +445,7 @@ impl HalleyWlState {
 
                 self.set_interaction_focus(None, 0, now);
                 self.pan_restore_active_focus = None;
+                self.request_maintenance();
                 Some(id)
             }
             halley_core::field::NodeState::Node => {
@@ -447,6 +454,7 @@ impl HalleyWlState {
                 self.pending_spawn_activate_at_ms.remove(&id);
 
                 self.set_interaction_focus(Some(id), 30_000, now);
+                self.request_maintenance();
                 Some(id)
             }
             _ => None,

--- a/crates/halley-wl/src/wm/focus.rs
+++ b/crates/halley-wl/src/wm/focus.rs
@@ -287,7 +287,7 @@ impl HalleyWlState {
 
         self.set_interaction_focus(Some(id), 12_000, now);
         self.pan_restore_active_focus = None;
-    }   
+    }
 
     pub fn begin_resize_interaction(&mut self, id: NodeId, now: Instant) {
         self.resize_active = Some(id);

--- a/crates/halley-wl/src/wm/mod.rs
+++ b/crates/halley-wl/src/wm/mod.rs
@@ -13,7 +13,7 @@ use smithay::reexports::wayland_server::{
 };
 
 use crate::activity::{CommitActivity, VisualState};
-use crate::anim::{AnimSpec, AnimStyle};
+use crate::animation::{AnimSpec, AnimStyle};
 use crate::render::{DebugScene, build_debug_scene};
 use crate::state::HalleyWlState;
 

--- a/crates/halley-wl/src/wm/zoom.rs
+++ b/crates/halley-wl/src/wm/zoom.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 impl HalleyWlState {
+    const ZOOM_PER_STEP: f32 = 1.10;
+
     #[inline]
     pub(crate) fn camera_view_size(&self) -> Vec2 {
         self.zoom_ref_size
@@ -20,6 +22,23 @@ impl HalleyWlState {
         self.zoom_resize_reject_streak.clear();
         self.zoom_resize_static_streak.clear();
         self.zoom_last_observed_size.clear();
+    }
+
+    pub(crate) fn zoom_by_steps(&mut self, steps: f32) {
+        let steps = steps.clamp(-4.0, 4.0);
+        if steps.abs() < f32::EPSILON {
+            return;
+        }
+
+        let factor = Self::ZOOM_PER_STEP.powf(steps);
+        self.zoom_ref_size = self.clamp_camera_view_size(Vec2 {
+            x: self.camera_view_size().x / factor,
+            y: self.camera_view_size().y / factor,
+        });
+    }
+
+    pub(crate) fn reset_zoom(&mut self) {
+        self.zoom_ref_size = self.viewport.size;
     }
 
     pub fn active_zoom_fallback_scale(&self, id: NodeId) -> Option<f32> {

--- a/examples/halley-finale.rune
+++ b/examples/halley-finale.rune
@@ -301,6 +301,7 @@ keybinds:
 
   # Core compositor controls
   "$var.mod+n" "toggle-state"
+  "$var.mod+q" "close-focused"
   "$var.mod+equal" "zoom-in"
   "$var.mod+minus" "zoom-out"
   "$var.mod+0" "zoom-reset"

--- a/examples/halley-finale.rune
+++ b/examples/halley-finale.rune
@@ -301,6 +301,9 @@ keybinds:
 
   # Core compositor controls
   "$var.mod+n" "toggle-state"
+  "$var.mod+equal" "zoom-in"
+  "$var.mod+minus" "zoom-out"
+  "$var.mod+0" "zoom-reset"
   "$var.mod+h" "home"
 
   # Lock the screen

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -52,9 +52,9 @@ keybinds:
   # Basic compositor controls
   "$var.mod+r" "reload"
   "$var.mod+n" "toggle-state"
-  "$var.mod+equal" "zoom-in"
-  "$var.mod+minus" "zoom-out"
-  "$var.mod+0" "zoom-reset"
+  "$var.mod+mousewheelup" "zoom-in"
+  "$var.mod+mousewheeldown" "zoom-out"
+  "$var.mod+middlemouse" "zoom-reset"
 
   # Quit Halley
   "$var.mod+shift+q" "quit"

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -79,10 +79,6 @@ dev:
   zoom_decay_enabled true
   zoom_decay_min_frac 0.07
 
-  runtime:
-    tick-ms 200
-  end
-
   anim:
     enabled true
     state_change_ms 360

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -47,11 +47,14 @@ env:
 end
 
 keybinds:
-  mod "lsuper"
+  mod "super"
 
   # Basic compositor controls
   "$var.mod+r" "reload"
-  "$var.mod+n" "minimize_focused"
+  "$var.mod+n" "toggle-state"
+  "$var.mod+equal" "zoom-in"
+  "$var.mod+minus" "zoom-out"
+  "$var.mod+0" "zoom-reset"
 
   # Quit Halley
   "$var.mod+shift+q" "quit"

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -52,6 +52,7 @@ keybinds:
   # Basic compositor controls
   "$var.mod+r" "reload"
   "$var.mod+n" "toggle-state"
+  "$var.mod+q" "close-focused"
   "$var.mod+mousewheelup" "zoom-in"
   "$var.mod+mousewheeldown" "zoom-out"
   "$var.mod+middlemouse" "zoom-reset"


### PR DESCRIPTION
This PR delivers a major input, rendering, and backend architecture upgrade, centered around first-class zoom interactions and cleaner compositor defaults.

### Zoom + Input Overhaul
- Add built-in compositor actions: `zoom-in`, `zoom-out`, and `zoom-reset`
- Replace `overview-toggle` with unified `toggle-state` (with compatibility aliases)
- Make background scroll pan by default and zoom when a modifier is held
- Introduce bindable mouse inputs: `mousewheelup`, `mousewheeldown`, `middlemouse`
- Move zoom bindings to default keybinds (`mod+wheel`, `mod+middlemouse`)
- Route mouse and wheel bindings through the standard keybind dispatch path
- Ensure zoom bindings are always interceptable, even over client windows
- Remove legacy mouse zoom toggles in favor of binding-driven control

### Default Keybind System
- Seed compositor keybinds from internal defaults instead of requiring explicit config
- Allow config to override defaults without changing syntax
- Add `keybinds.scroll-zoom` for configurable modifier-based scroll zoom behavior

### Backend Architecture Refactor
- Move backend code into a dedicated `backend/` module tree
- Rename and reorganize backend interfaces and implementations
- Convert backends to event-driven operation (remove fixed tick loop)
- Drive maintenance via state invalidation and deadlines instead of polling
- Sync frame scheduling to output refresh rates (DRM mode / configured viewport)

### Rendering Performance Improvements
- Cache offscreen surface-tree textures for zoomed windows
- Reuse cached textures across frames with proper invalidation
- Preserve per-window alpha in cached rendering paths
- Remove obsolete resize geometry fields and unused helpers

### Rendering + Input Fixes
- Fix clipping of oversized windows in zoomed rendering paths
  - Correct damage space (destination-local vs framebuffer-global)
  - Clamp sampled source regions to texture bounds
- Fix layer-shell pointer hit testing under zoom
  - Use raw compositor-space coordinates for layer surfaces
  - Preserve zoom compensation for XDG windows

### Animation Refactor
- Move animation logic into `animation/` module tree
- Split into focused components:
  - curves
  - node-state animation
  - surface scaling
  - node movement
- Eliminate cross-cutting animation logic from unrelated subsystems

### New Compositor Actions
- Add `close-focused` action for closing the active XDG toplevel
- Remove need for external shell commands for window closing
- Update default config (`mod+q`) and move compositor exit to shifted binding

---

Overall, this PR establishes zoom as a core interaction primitive, introduces a proper default keybind system, removes legacy input paths, and transitions the backend to a modern event-driven model while improving rendering correctness and performance.