### PR TITLE
feat(config,overlay): add secondary border source support for overlays and nodes

### DIFF
--- a/crates/halley-config/src/layout/runtime.rs
+++ b/crates/halley-config/src/layout/runtime.rs
@@ -442,6 +442,9 @@ node:
   # Auto tints the node fill from its border colour.
   background-colour "auto"
 
+  # Border colour source for hovered/inactive nodes.
+  # Allowed values: "use-window-active", "use-window-inactive",
+  # "use-window-secondary-active", "use-window-secondary-inactive".
   border-colour-hover "use-window-active"
   border-colour-inactive "use-window-inactive"
 
@@ -559,6 +562,7 @@ overlays:
   text-colour "auto"
   shape "square"
   borders "true"
+  border-source "primary"
 end
 
 # Main input bindings.

--- a/crates/halley-config/src/layout/types.rs
+++ b/crates/halley-config/src/layout/types.rs
@@ -6,6 +6,8 @@ use regex::Regex;
 pub enum NodeBorderColorMode {
     UseWindowActive,
     UseWindowInactive,
+    UseWindowSecondaryActive,
+    UseWindowSecondaryInactive,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,12 +46,19 @@ pub enum OverlayShape {
     Rounded,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OverlayBorderSource {
+    Primary,
+    Secondary,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OverlayStyleConfig {
     pub background_color: OverlayColorMode,
     pub text_color: OverlayColorMode,
     pub shape: OverlayShape,
     pub borders: bool,
+    pub border_source: OverlayBorderSource,
 }
 
 impl Default for OverlayStyleConfig {
@@ -59,6 +68,7 @@ impl Default for OverlayStyleConfig {
             text_color: OverlayColorMode::Auto,
             shape: OverlayShape::Square,
             borders: true,
+            border_source: OverlayBorderSource::Primary,
         }
     }
 }

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -14,9 +14,9 @@ pub use layout::{
     CloseRestorePanMode, ClusterBloomDirection, ClusterDefaultLayout, CursorConfig,
     DecorationBorderColor, DecorationsConfig, FontConfig, InitialWindowClusterParticipation,
     InitialWindowOverlapPolicy, InitialWindowSpawnPlacement, InputConfig, InputFocusMode,
-    NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy, OverlayColorMode,
-    OverlayShape, OverlayStyleConfig, PanToNewMode, PrimaryBorderConfig, RuntimeTuning,
-    ScreenshotConfig, SecondaryBorderConfig, ShapeStyle, TimedAnimationConfig,
+    NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy, OverlayBorderSource,
+    OverlayColorMode, OverlayShape, OverlayStyleConfig, PanToNewMode, PrimaryBorderConfig,
+    RuntimeTuning, ScreenshotConfig, SecondaryBorderConfig, ShapeStyle, TimedAnimationConfig,
     ViewportOutputConfig, ViewportVrrMode, WindowCloseAnimationConfig, WindowCloseAnimationStyle,
     WindowRule, WindowRulePattern,
 };

--- a/crates/halley-config/src/parse/primitives.rs
+++ b/crates/halley-config/src/parse/primitives.rs
@@ -6,7 +6,8 @@ use crate::layout::{
     ClickCollapsedOutsideFocusMode, ClickCollapsedPanMode, CloseRestorePanMode,
     ClusterBloomDirection, ClusterDefaultLayout, DecorationBorderColor, FocusRingConfig,
     InputFocusMode, NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy,
-    OverlayColorMode, OverlayShape, PanToNewMode, ShapeStyle, WindowCloseAnimationStyle,
+    OverlayBorderSource, OverlayColorMode, OverlayShape, PanToNewMode, ShapeStyle,
+    WindowCloseAnimationStyle,
 };
 
 pub(crate) fn merge_env_map(cfg: &RuneConfig, out: &mut HashMap<String, String>, path: &str) {
@@ -262,6 +263,23 @@ pub(crate) fn pick_node_border_color_mode(
     match raw.trim().trim_matches('"') {
         "use-window-active" => NodeBorderColorMode::UseWindowActive,
         "use-window-inactive" => NodeBorderColorMode::UseWindowInactive,
+        "use-window-secondary-active" => NodeBorderColorMode::UseWindowSecondaryActive,
+        "use-window-secondary-inactive" => NodeBorderColorMode::UseWindowSecondaryInactive,
+        _ => default,
+    }
+}
+
+pub(crate) fn pick_overlay_border_source(
+    cfg: &RuneConfig,
+    paths: &[&str],
+    default: OverlayBorderSource,
+) -> OverlayBorderSource {
+    let Some(raw) = pick_string(cfg, paths) else {
+        return default;
+    };
+    match raw.trim().trim_matches('"') {
+        "primary" => OverlayBorderSource::Primary,
+        "secondary" => OverlayBorderSource::Secondary,
         _ => default,
     }
 }

--- a/crates/halley-config/src/parse/sections/nodes.rs
+++ b/crates/halley-config/src/parse/sections/nodes.rs
@@ -195,3 +195,37 @@ pub(crate) fn load_nodes_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         out.click_collapsed_pan,
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use rune_cfg::RuneConfig;
+
+    use crate::layout::{NodeBorderColorMode, RuntimeTuning};
+
+    use super::load_nodes_section;
+
+    #[test]
+    fn nodes_section_parses_secondary_border_color_modes() {
+        let cfg = RuneConfig::from_str(
+            r##"
+node:
+  border-colour-hover "use-window-secondary-active"
+  border-colour-inactive "use-window-secondary-inactive"
+end
+"##,
+        )
+        .expect("node config should parse");
+
+        let mut out = RuntimeTuning::default();
+        load_nodes_section(&cfg, &mut out);
+
+        assert_eq!(
+            out.node_border_color_hover,
+            NodeBorderColorMode::UseWindowSecondaryActive
+        );
+        assert_eq!(
+            out.node_border_color_inactive,
+            NodeBorderColorMode::UseWindowSecondaryInactive
+        );
+    }
+}

--- a/crates/halley-config/src/parse/sections/overlays.rs
+++ b/crates/halley-config/src/parse/sections/overlays.rs
@@ -2,7 +2,9 @@ use rune_cfg::RuneConfig;
 
 use crate::layout::RuntimeTuning;
 
-use super::super::primitives::{pick_bool, pick_overlay_color_mode, pick_overlay_shape};
+use super::super::primitives::{
+    pick_bool, pick_overlay_border_source, pick_overlay_color_mode, pick_overlay_shape,
+};
 
 pub(crate) fn load_overlays_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.overlay_style.background_color = pick_overlay_color_mode(
@@ -43,13 +45,23 @@ pub(crate) fn load_overlays_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         &["overlay.borders", "overlays.borders"],
         out.overlay_style.borders,
     );
+    out.overlay_style.border_source = pick_overlay_border_source(
+        cfg,
+        &[
+            "overlay.border-source",
+            "overlay.border_source",
+            "overlays.border-source",
+            "overlays.border_source",
+        ],
+        out.overlay_style.border_source,
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use rune_cfg::RuneConfig;
 
-    use crate::layout::{OverlayColorMode, OverlayShape, RuntimeTuning};
+    use crate::layout::{OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning};
 
     use super::load_overlays_section;
 
@@ -62,6 +74,7 @@ overlays:
   text-colour "dark"
   shape "rounded"
   borders false
+  border-source "secondary"
 end
 "##,
         )
@@ -81,6 +94,10 @@ end
         assert_eq!(out.overlay_style.text_color, OverlayColorMode::Dark);
         assert_eq!(out.overlay_style.shape, OverlayShape::Rounded);
         assert!(!out.overlay_style.borders);
+        assert_eq!(
+            out.overlay_style.border_source,
+            OverlayBorderSource::Secondary
+        );
     }
 
     #[test]
@@ -93,5 +110,9 @@ end
         assert_eq!(defaults.overlay_style.text_color, OverlayColorMode::Auto);
         assert_eq!(defaults.overlay_style.shape, OverlayShape::Square);
         assert!(defaults.overlay_style.borders);
+        assert_eq!(
+            defaults.overlay_style.border_source,
+            OverlayBorderSource::Primary
+        );
     }
 }

--- a/crates/halley-wl/src/bootstrap/mod.rs
+++ b/crates/halley-wl/src/bootstrap/mod.rs
@@ -9,8 +9,7 @@ use halley_config::{RuntimeTuning, ViewportOutputConfig};
 
 use eventline::{
     FileSetup, LogLevel, LogPolicy, RunHeader, Setup, debug, enable_console_color,
-    enable_console_duration, info, scope,
-    warn,
+    enable_console_duration, info, scope, warn,
 };
 use once_cell::sync::OnceCell;
 use rustix::process::Signal;

--- a/crates/halley-wl/src/compositor/focus/decay.rs
+++ b/crates/halley-wl/src/compositor/focus/decay.rs
@@ -242,7 +242,10 @@ impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
         }
 
         if self.runtime.tuning.field_active_windows_allowed == 0 {
-            self.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+            self.model
+                .focus_state
+                .outside_focus_ring_since_ms
+                .remove(&id);
             let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
             return;
         }
@@ -424,7 +427,11 @@ mod tests {
     fn zero_active_window_limit_disables_decay() {
         let (mut state, id) = outside_ring_test_state();
         state.runtime.tuning.field_active_windows_allowed = 0;
-        state.model.focus_state.outside_focus_ring_since_ms.insert(id, 5);
+        state
+            .model
+            .focus_state
+            .outside_focus_ring_since_ms
+            .insert(id, 5);
         let _ = state.model.field.set_decay_level(id, DecayLevel::Cold);
 
         state.apply_single_surface_decay_policy(id, 100_000, 120_000, 30_000);
@@ -433,6 +440,12 @@ mod tests {
             state.model.field.node(id).map(|n| n.decay),
             Some(DecayLevel::Hot)
         );
-        assert!(!state.model.focus_state.outside_focus_ring_since_ms.contains_key(&id));
+        assert!(
+            !state
+                .model
+                .focus_state
+                .outside_focus_ring_since_ms
+                .contains_key(&id)
+        );
     }
 }

--- a/crates/halley-wl/src/input/pointer/motion/tests.rs
+++ b/crates/halley-wl/src/input/pointer/motion/tests.rs
@@ -114,11 +114,7 @@ fn hover_focus_mode_works_for_tiled_cluster_members() {
         st.assign_node_to_monitor(id, "monitor_a");
     }
 
-    let cid = st
-        .model
-        .field
-        .create_cluster(vec![a, b])
-        .expect("cluster");
+    let cid = st.model.field.create_cluster(vec![a, b]).expect("cluster");
     let core = st.model.field.collapse_cluster(cid).expect("core");
     st.assign_node_to_monitor(core, "monitor_a");
     assert!(st.toggle_cluster_workspace_by_core(core, Instant::now()));
@@ -174,11 +170,7 @@ fn hover_focus_mode_only_focuses_top_of_stack_in_clusters() {
         st.assign_node_to_monitor(id, "monitor_a");
     }
 
-    let cid = st
-        .model
-        .field
-        .create_cluster(vec![a, b])
-        .expect("cluster");
+    let cid = st.model.field.create_cluster(vec![a, b]).expect("cluster");
     let core = st.model.field.collapse_cluster(cid).expect("core");
     st.assign_node_to_monitor(core, "monitor_a");
     assert!(st.toggle_cluster_workspace_by_core(core, Instant::now()));

--- a/crates/halley-wl/src/overlay/mod.rs
+++ b/crates/halley-wl/src/overlay/mod.rs
@@ -6,7 +6,7 @@ mod view;
 
 use std::error::Error;
 
-use halley_config::{OverlayColorMode, OverlayShape, RuntimeTuning};
+use halley_config::{OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning};
 use smithay::{
     backend::renderer::{
         Color32F, Texture,
@@ -160,11 +160,36 @@ fn resolve_overlay_base_text(mode: OverlayColorMode, background: OverlayRgb) -> 
 }
 
 fn resolve_overlay_border_color(tuning: &RuntimeTuning) -> OverlayRgb {
-    let color = tuning.decorations.border.color_focused;
+    let color = match tuning.overlay_style.border_source {
+        OverlayBorderSource::Primary => tuning.decorations.border.color_focused,
+        OverlayBorderSource::Secondary => {
+            if tuning.window_secondary_border_enabled() {
+                tuning.decorations.secondary_border.color_focused
+            } else {
+                tuning.decorations.border.color_focused
+            }
+        }
+    };
     OverlayRgb {
         r: color.r,
         g: color.g,
         b: color.b,
+    }
+}
+
+fn resolve_overlay_border_width(tuning: &RuntimeTuning) -> f32 {
+    if !tuning.overlay_style.borders {
+        return 0.0;
+    }
+    match tuning.overlay_style.border_source {
+        OverlayBorderSource::Primary => tuning.window_primary_border_size_px() as f32,
+        OverlayBorderSource::Secondary => {
+            if tuning.window_secondary_border_enabled() {
+                tuning.window_secondary_border_size_px() as f32
+            } else {
+                tuning.window_primary_border_size_px() as f32
+            }
+        }
     }
 }
 
@@ -174,11 +199,7 @@ fn resolve_overlay_visuals(tuning: &RuntimeTuning) -> OverlayVisuals {
     let border = resolve_overlay_border_color(tuning);
     OverlayVisuals {
         rounded: matches!(tuning.overlay_style.shape, OverlayShape::Rounded),
-        border_px: if tuning.overlay_style.borders {
-            tuning.window_primary_border_size_px() as f32
-        } else {
-            0.0
-        },
+        border_px: resolve_overlay_border_width(tuning),
         palette: OverlayPalette {
             fill,
             text,
@@ -1311,7 +1332,9 @@ fn draw_overlay_chip(
 
 #[cfg(test)]
 mod tests {
-    use halley_config::{OverlayColorMode, OverlayShape};
+    use halley_config::{
+        DecorationBorderColor, OverlayBorderSource, OverlayColorMode, OverlayShape,
+    };
 
     use super::{overlay_accent_fill, overlay_text_color_for_fill, resolve_overlay_visuals};
 
@@ -1340,6 +1363,55 @@ mod tests {
         tuning.overlay_style.borders = false;
         let visuals = resolve_overlay_visuals(&tuning);
         assert_eq!(visuals.border_px, 0.0);
+    }
+
+    #[test]
+    fn overlay_secondary_border_source_uses_secondary_style_when_enabled() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.decorations.secondary_border.enabled = true;
+        tuning.decorations.secondary_border.size_px = 2;
+        tuning.decorations.secondary_border.color_focused = DecorationBorderColor {
+            r: 0.9,
+            g: 0.8,
+            b: 0.1,
+        };
+        tuning.overlay_style.border_source = OverlayBorderSource::Secondary;
+
+        let visuals = resolve_overlay_visuals(&tuning);
+
+        assert_eq!(visuals.border_px, 2.0);
+        assert_eq!(
+            (
+                visuals.palette.border.r,
+                visuals.palette.border.g,
+                visuals.palette.border.b
+            ),
+            (0.9, 0.8, 0.1)
+        );
+    }
+
+    #[test]
+    fn overlay_secondary_border_source_falls_back_to_primary_when_disabled() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.decorations.border.size_px = 4;
+        tuning.decorations.border.color_focused = DecorationBorderColor {
+            r: 0.1,
+            g: 0.2,
+            b: 0.3,
+        };
+        tuning.overlay_style.border_source = OverlayBorderSource::Secondary;
+
+        let visuals = resolve_overlay_visuals(&tuning);
+
+        assert_eq!(visuals.border_px, 4.0);
+        assert_eq!(
+            (
+                visuals.palette.border.r,
+                visuals.palette.border.g,
+                visuals.palette.border.b
+            ),
+            (0.1, 0.2, 0.3)
+        );
     }
 
     #[test]

--- a/crates/halley-wl/src/presentation.rs
+++ b/crates/halley-wl/src/presentation.rs
@@ -91,7 +91,29 @@ fn window_inactive_border_color_for_tuning(tuning: &RuntimeTuning) -> Color32F {
     Color32F::new(color.r, color.g, color.b, 1.0)
 }
 
-fn node_ring_color_for_tuning(tuning: &RuntimeTuning, hovered: bool, alpha: f32) -> Color32F {
+fn window_secondary_active_border_color_for_tuning(tuning: &RuntimeTuning) -> Color32F {
+    let color = if tuning.window_secondary_border_enabled() {
+        tuning.decorations.secondary_border.color_focused
+    } else {
+        tuning.decorations.border.color_focused
+    };
+    Color32F::new(color.r, color.g, color.b, 1.0)
+}
+
+fn window_secondary_inactive_border_color_for_tuning(tuning: &RuntimeTuning) -> Color32F {
+    let color = if tuning.window_secondary_border_enabled() {
+        tuning.decorations.secondary_border.color_unfocused
+    } else {
+        tuning.decorations.border.color_unfocused
+    };
+    Color32F::new(color.r, color.g, color.b, 1.0)
+}
+
+pub(crate) fn themed_node_ring_color(
+    tuning: &RuntimeTuning,
+    hovered: bool,
+    alpha: f32,
+) -> Color32F {
     let mode = if hovered {
         tuning.node_border_color_hover
     } else {
@@ -100,6 +122,12 @@ fn node_ring_color_for_tuning(tuning: &RuntimeTuning, hovered: bool, alpha: f32)
     let base = match mode {
         NodeBorderColorMode::UseWindowActive => window_active_border_color_for_tuning(tuning),
         NodeBorderColorMode::UseWindowInactive => window_inactive_border_color_for_tuning(tuning),
+        NodeBorderColorMode::UseWindowSecondaryActive => {
+            window_secondary_active_border_color_for_tuning(tuning)
+        }
+        NodeBorderColorMode::UseWindowSecondaryInactive => {
+            window_secondary_inactive_border_color_for_tuning(tuning)
+        }
     };
     Color32F::new(base.r(), base.g(), base.b(), alpha)
 }
@@ -107,7 +135,7 @@ fn node_ring_color_for_tuning(tuning: &RuntimeTuning, hovered: bool, alpha: f32)
 pub(crate) fn themed_node_fill_color(tuning: &RuntimeTuning, hovered: bool) -> Color32F {
     match tuning.node_background_color {
         NodeBackgroundColorMode::Auto | NodeBackgroundColorMode::Theme => {
-            let ring = node_ring_color_for_tuning(tuning, hovered, 1.0);
+            let ring = themed_node_ring_color(tuning, hovered, 1.0);
             let base = (0.94, 0.96, 0.985);
             Color32F::new(
                 base.0 * 0.86 + ring.r() * 0.14,
@@ -149,4 +177,48 @@ pub(crate) fn themed_node_label_colors(
     let fill = themed_node_label_fill_color(tuning, hovered, fill_alpha);
     let text = themed_node_label_text_color(fill, text_alpha);
     (fill, text)
+}
+
+#[cfg(test)]
+mod tests {
+    use halley_config::{DecorationBorderColor, NodeBorderColorMode, RuntimeTuning};
+
+    use super::themed_node_ring_color;
+
+    #[test]
+    fn themed_node_ring_color_uses_secondary_border_when_enabled() {
+        let mut tuning = RuntimeTuning::default();
+        tuning.decorations.secondary_border.enabled = true;
+        tuning.decorations.secondary_border.color_focused = DecorationBorderColor {
+            r: 0.9,
+            g: 0.8,
+            b: 0.1,
+        };
+        tuning.node_border_color_hover = NodeBorderColorMode::UseWindowSecondaryActive;
+
+        let color = themed_node_ring_color(&tuning, true, 0.75);
+
+        assert_eq!(
+            (color.r(), color.g(), color.b(), color.a()),
+            (0.9, 0.8, 0.1, 0.75)
+        );
+    }
+
+    #[test]
+    fn themed_node_ring_color_falls_back_to_primary_when_secondary_disabled() {
+        let mut tuning = RuntimeTuning::default();
+        tuning.decorations.border.color_unfocused = DecorationBorderColor {
+            r: 0.2,
+            g: 0.3,
+            b: 0.4,
+        };
+        tuning.node_border_color_inactive = NodeBorderColorMode::UseWindowSecondaryInactive;
+
+        let color = themed_node_ring_color(&tuning, false, 0.6);
+
+        assert_eq!(
+            (color.r(), color.g(), color.b(), color.a()),
+            (0.2, 0.3, 0.4, 0.6)
+        );
+    }
 }

--- a/crates/halley-wl/src/render/node.rs
+++ b/crates/halley-wl/src/render/node.rs
@@ -16,14 +16,15 @@ use smithay::{
 };
 
 use crate::compositor::root::Halley;
-use halley_config::{NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy, ShapeStyle};
+use halley_config::{NodeBackgroundColorMode, NodeDisplayPolicy, ShapeStyle};
 
 use super::log_rounded_shader_failure;
 use crate::animation::ease_in_out_cubic;
 use crate::frame_loop::anim_style_for;
 use crate::presentation::{
     node_marker_bounds, node_marker_metrics, node_render_diameter_px, themed_node_fill_color,
-    themed_node_label_fill_color, themed_node_label_text_color, world_to_screen,
+    themed_node_label_fill_color, themed_node_label_text_color, themed_node_ring_color,
+    world_to_screen,
 };
 use crate::render::state::{ClosingWindowAnimationKind, ClosingWindowAnimationSnapshot};
 use crate::text::{draw_ui_text, ui_text_size};
@@ -325,27 +326,8 @@ fn draw_shader_label(
     Ok(())
 }
 
-fn window_active_border_color(st: &Halley) -> Color32F {
-    let color = st.runtime.tuning.decorations.border.color_focused;
-    Color32F::new(color.r, color.g, color.b, 1.0)
-}
-
-fn window_inactive_border_color(st: &Halley) -> Color32F {
-    let color = st.runtime.tuning.decorations.border.color_unfocused;
-    Color32F::new(color.r, color.g, color.b, 1.0)
-}
-
 fn node_ring_color(st: &Halley, hovered: bool, alpha: f32) -> Color32F {
-    let mode = if hovered {
-        st.runtime.tuning.node_border_color_hover
-    } else {
-        st.runtime.tuning.node_border_color_inactive
-    };
-    let base = match mode {
-        NodeBorderColorMode::UseWindowActive => window_active_border_color(st),
-        NodeBorderColorMode::UseWindowInactive => window_inactive_border_color(st),
-    };
-    Color32F::new(base.r(), base.g(), base.b(), alpha)
+    themed_node_ring_color(&st.runtime.tuning, hovered, alpha)
 }
 
 fn node_fill_color(st: &Halley, hovered: bool) -> Color32F {

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -147,6 +147,8 @@ node:
   # Auto tints the node fill from its border colour.
   background-colour "auto"
 
+  # Allowed values: "use-window-active", "use-window-inactive",
+  # "use-window-secondary-active", "use-window-secondary-inactive".
   border-colour-hover "use-window-active"
   border-colour-inactive "use-window-inactive"
 
@@ -264,6 +266,7 @@ overlays:
   text-colour "auto"
   shape "square"
   borders "true"
+  border-source "primary"
 end
 
 # Main input bindings.


### PR DESCRIPTION
- add `overlays.border-source` with `primary` (default) and `secondary`
- make overlay border source control both border colour and border width
- fall back to primary automatically when secondary is selected but dual borders are disabled
- extend node border colour settings to accept:
  - `use-window-secondary-active`
  - `use-window-secondary-inactive`
- preserve existing node hover/inactive border settings while adding secondary-aware values
- update example config and fresh-config runtime template

Verification:
- cargo fmt --all
- cargo test -p halley-config
- cargo test -p halley-wl --lib