### PR TITLE
fix(tty): send callbacks after successful no-pageflip renders

### DIFF
--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -178,7 +178,7 @@ fn queue_ready_tty_outputs(
     now: Instant,
     resize_preview: Option<ResizeCtx>,
     eligible_outputs: Option<&HashSet<String>>,
-    _source: &str,
+    source: &str,
 ) {
     if !any_tty_output_dpms_enabled(&dpms_enabled.borrow()) {
         return;
@@ -256,6 +256,9 @@ fn queue_ready_tty_outputs(
                     output_frame_pending_since
                         .borrow_mut()
                         .remove(output.connector_name.as_str());
+                    if source == "timer" {
+                        crate::frame_loop::send_frame_callbacks_for_output(st, output_name, now);
+                    }
                     continue;
                 }
                 if first_frame_queued


### PR DESCRIPTION
Restore video playback progress on AMD by sending timer frame callbacks after successful render passes where Smithay reports an empty render result and no DRM frame is queued.

This keeps the NVIDIA triage behavior intact: callbacks are still withheld before render/queue attempts, and clients still receive no callbacks when queue_frame() errors or an output is skipped.

Without this, quiet outputs could starve clients like YouTube/video playback when no DRM pageflip was needed, causing the AMD video freeze regression.

Verification:
- cargo fmt
- cargo check
- git diff --check