### PR TITLE
refactor(halley-wl): narrow state access and fix vblank pacing

### DIFF
--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -25,7 +25,7 @@ use crate::backend::vblank_throttle::VBlankThrottle;
 use crate::compositor::exit_confirm::exit_confirm_controller;
 use crate::compositor::interaction::ResizeCtx;
 use calloop::{Interest, Mode, PostAction, generic::Generic, ping::make_ping};
-use smithay::backend::drm::DrmNode;
+use smithay::backend::drm::{DrmEventMetadata, DrmEventTime, DrmNode};
 use smithay::backend::renderer::gles::GlesTexture;
 
 use smithay::backend::input::{
@@ -87,6 +87,22 @@ fn tty_env_flag(name: &str) -> bool {
             "1" | "true" | "yes" | "on"
         )
     })
+}
+
+fn monotonic_now_duration() -> Duration {
+    smithay::utils::Clock::<smithay::utils::Monotonic>::new()
+        .now()
+        .into()
+}
+
+fn drm_vblank_timestamp(metadata: Option<&DrmEventMetadata>) -> Duration {
+    if let Some(metadata) = metadata {
+        if let DrmEventTime::Monotonic(timestamp) = metadata.time {
+            return timestamp;
+        }
+    }
+
+    monotonic_now_duration()
 }
 
 fn record_tty_frame_queue(
@@ -1445,10 +1461,11 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 let vblank_mismatch_state_for_notifier = vblank_mismatch_state_for_notifier.clone();
                 let frame_stats_for_notifier = frame_stats.clone();
                 ev.handle().insert_source(
-                notifier,
-                move |event, _metadata, _st| match event {
-                    DrmEvent::VBlank(crtc) => {
-                        let timestamp = Instant::now();
+                    notifier,
+                    move |event, metadata, _st| match event {
+                        DrmEvent::VBlank(crtc) => {
+                        let now = Instant::now();
+                        let timestamp = drm_vblank_timestamp(metadata.as_ref());
                         let mut matched_outputs = Vec::new();
                         for output in outputs_for_vblank.borrow().iter() {
                             let initial_crtc = output.crtc;
@@ -1460,7 +1477,9 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             let refresh_interval = active_modes_for_notifier
                                 .borrow()
                                 .get(output_name.as_str())
-                                .map(|mode| frame_interval_for_refresh_hz(Some(mode.vrefresh() as f64)));
+                                .map(|mode| {
+                                    frame_interval_for_refresh_hz(Some(mode.vrefresh() as f64))
+                                });
                             let throttled_output_name = output_name.clone();
                             let redraw_ping_for_throttle = redraw_ping_for_vblank.clone();
                             let should_throttle = vblank_throttles_for_notifier
@@ -1555,7 +1574,7 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                                 vblank_mismatch_state_for_notifier.borrow_mut();
                             let active_for = mismatch_state
                                 .first_seen_at
-                                .get_or_insert(timestamp)
+                                .get_or_insert(now)
                                 .elapsed();
                             if active_for
                                 >= Duration::from_millis(VBLANK_MISMATCH_LOG_AFTER_MS)
@@ -1597,10 +1616,10 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             mismatch_state.first_seen_at = None;
                             mismatch_state.reported_active = false;
                         }
-                    }
-                    DrmEvent::Error(err) => warn!("drm event error: {}", err),
-                },
-            )?;
+                        }
+                        DrmEvent::Error(err) => warn!("drm event error: {}", err),
+                    },
+                )?;
             }
 
             let dpms_enabled_for_redraw = dpms_enabled.clone();

--- a/crates/halley-wl/src/backend/vblank_throttle.rs
+++ b/crates/halley-wl/src/backend/vblank_throttle.rs
@@ -9,7 +9,7 @@ use crate::compositor::root::Halley;
 #[derive(Debug)]
 pub(crate) struct VBlankThrottle {
     event_loop: LoopHandle<'static, Halley>,
-    last_vblank_at: Option<Instant>,
+    last_vblank_timestamp: Option<Duration>,
     throttle_timer_token: Option<RegistrationToken>,
     printed_warning: bool,
     output_name: String,
@@ -32,7 +32,7 @@ impl VBlankThrottle {
     pub(crate) fn new(event_loop: LoopHandle<'static, Halley>, output_name: String) -> Self {
         Self {
             event_loop,
-            last_vblank_at: None,
+            last_vblank_timestamp: None,
             throttle_timer_token: None,
             printed_warning: false,
             output_name,
@@ -146,20 +146,20 @@ impl VBlankThrottle {
     pub(crate) fn throttle(
         &mut self,
         refresh_interval: Option<Duration>,
-        timestamp: Instant,
+        timestamp: Duration,
         mut call_vblank: impl FnMut(&mut Halley) + 'static,
     ) -> bool {
+        let now = Instant::now();
         if let Some(token) = self.throttle_timer_token.take() {
             self.event_loop.remove(token);
         }
 
-        if let Some(last) = self.last_vblank_at {
-            let passed = timestamp.saturating_duration_since(last);
-            self.update_metrics(refresh_interval, passed, timestamp);
+        if let Some(last) = self.last_vblank_timestamp {
+            let passed = timestamp.saturating_sub(last);
+            self.update_metrics(refresh_interval, passed, now);
 
             if let Some(refresh) = refresh_interval {
-                let min_interval_ns = (refresh.as_nanos() * 3) / 4;
-                if passed.as_nanos() < min_interval_ns {
+                if passed < refresh / 2 {
                     if !self.printed_warning {
                         self.printed_warning = true;
                         debug!(
@@ -179,13 +179,12 @@ impl VBlankThrottle {
                         })
                         .expect("vblank throttle timer should insert");
                     self.throttle_timer_token = Some(token);
-                    self.last_vblank_at = Some(timestamp);
                     return true;
                 }
             }
         }
 
-        self.last_vblank_at = Some(timestamp);
+        self.last_vblank_timestamp = Some(timestamp);
         false
     }
 }

--- a/crates/halley-wl/src/compositor/carry/mod.rs
+++ b/crates/halley-wl/src/compositor/carry/mod.rs
@@ -7,7 +7,6 @@ use halley_core::decay::DecayLevel;
 use halley_core::field::{NodeId, Vec2};
 use halley_core::viewport::{FocusRing, FocusZone};
 
-use crate::compositor::ctx::CarryCtx;
 use crate::compositor::root::Halley;
 
 pub mod state;

--- a/crates/halley-wl/src/compositor/clusters/mod.rs
+++ b/crates/halley-wl/src/compositor/clusters/mod.rs
@@ -14,7 +14,6 @@ use smithay::reexports::wayland_server::{
 
 use crate::animation::{AnimSpec, AnimStyle};
 use crate::compositor::activity::{CommitActivity, VisualState};
-use crate::compositor::ctx::ClusterCtx;
 use crate::compositor::debug_scene::{DebugScene, build_debug_scene};
 use crate::compositor::root::Halley;
 

--- a/crates/halley-wl/src/compositor/ctx.rs
+++ b/crates/halley-wl/src/compositor/ctx.rs
@@ -1,9 +1,8 @@
-#![allow(dead_code)]
-
 use crate::compositor::root::Halley;
+use smithay::reexports::wayland_server::DisplayHandle;
 
 pub(crate) struct FocusCtx<'a> {
-    pub(crate) st: &'a mut Halley,
+    pub(crate) display_handle: &'a DisplayHandle,
 }
 
 pub(crate) struct SpawnCtx<'a> {
@@ -26,28 +25,10 @@ pub(crate) struct FullscreenCtx<'a> {
     pub(crate) st: &'a mut Halley,
 }
 
-pub(crate) struct MonitorCtx<'a> {
-    pub(crate) st: &'a mut Halley,
-}
-
-pub(crate) struct ClusterCtx<'a> {
-    pub(crate) st: &'a mut Halley,
-}
-
-pub(crate) struct CarryCtx<'a> {
-    pub(crate) st: &'a mut Halley,
-}
-
-pub(crate) struct InteractionCtx<'a> {
-    pub(crate) st: &'a mut Halley,
-}
-
-pub(crate) struct WorkspaceCtx<'a> {
-    pub(crate) st: &'a mut Halley,
-}
-
-pub(crate) fn focus_ctx(st: &mut Halley) -> FocusCtx<'_> {
-    FocusCtx { st }
+pub(crate) fn focus_ctx(st: &Halley) -> FocusCtx<'_> {
+    FocusCtx {
+        display_handle: &st.platform.display_handle,
+    }
 }
 
 pub(crate) fn spawn_ctx(st: &mut Halley) -> SpawnCtx<'_> {
@@ -68,24 +49,4 @@ pub(crate) fn pointer_ctx(st: &mut Halley) -> PointerCtx<'_> {
 
 pub(crate) fn fullscreen_ctx(st: &mut Halley) -> FullscreenCtx<'_> {
     FullscreenCtx { st }
-}
-
-pub(crate) fn monitor_ctx(st: &mut Halley) -> MonitorCtx<'_> {
-    MonitorCtx { st }
-}
-
-pub(crate) fn cluster_ctx(st: &mut Halley) -> ClusterCtx<'_> {
-    ClusterCtx { st }
-}
-
-pub(crate) fn carry_ctx(st: &mut Halley) -> CarryCtx<'_> {
-    CarryCtx { st }
-}
-
-pub(crate) fn interaction_ctx(st: &mut Halley) -> InteractionCtx<'_> {
-    InteractionCtx { st }
-}
-
-pub(crate) fn workspace_ctx(st: &mut Halley) -> WorkspaceCtx<'_> {
-    WorkspaceCtx { st }
 }

--- a/crates/halley-wl/src/compositor/focus/system.rs
+++ b/crates/halley-wl/src/compositor/focus/system.rs
@@ -15,19 +15,18 @@ use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
 pub(crate) fn on_seat_focus_changed(
-    ctx: &mut FocusCtx<'_>,
+    ctx: &FocusCtx<'_>,
     seat: &Seat<Halley>,
     focused: Option<&WlSurface>,
 ) {
-    let st = &mut ctx.st;
     debug!(
         "seat focus_changed -> {:?}",
         focused.map(|wl| format!("{:?}", wl.id()))
     );
 
     let client = focused.and_then(|wl| wl.client());
-    set_data_device_focus(&st.platform.display_handle, seat, client.clone());
-    set_primary_focus(&st.platform.display_handle, seat, client);
+    set_data_device_focus(ctx.display_handle, seat, client.clone());
+    set_primary_focus(ctx.display_handle, seat, client);
 }
 
 pub(crate) struct FocusSystemController<T> {

--- a/crates/halley-wl/src/compositor/monitor/mod.rs
+++ b/crates/halley-wl/src/compositor/monitor/mod.rs
@@ -11,7 +11,7 @@ use smithay::{
     utils::Transform,
 };
 
-use crate::compositor::ctx::{LayerShellCtx, MonitorCtx};
+use crate::compositor::ctx::LayerShellCtx;
 use crate::compositor::root::Halley;
 
 pub mod camera;

--- a/crates/halley-wl/src/compositor/overlap/mod.rs
+++ b/crates/halley-wl/src/compositor/overlap/mod.rs
@@ -13,7 +13,6 @@ use smithay::reexports::wayland_server::{
 
 use crate::animation::{AnimSpec, AnimStyle};
 use crate::compositor::activity::{CommitActivity, VisualState};
-use crate::compositor::ctx::InteractionCtx;
 use crate::compositor::debug_scene::{DebugScene, build_debug_scene};
 use crate::compositor::root::Halley;
 

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -456,7 +456,7 @@ impl Halley {
             .snapshot_for_mode(mode, output_rect, work_area_rect, scale, measure_text)
     }
 
-    pub(crate) fn focus_ctx(&mut self) -> super::ctx::FocusCtx<'_> {
+    pub(crate) fn focus_ctx(&self) -> super::ctx::FocusCtx<'_> {
         super::ctx::focus_ctx(self)
     }
 
@@ -478,31 +478,6 @@ impl Halley {
 
     pub(crate) fn fullscreen_ctx(&mut self) -> super::ctx::FullscreenCtx<'_> {
         super::ctx::fullscreen_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn monitor_ctx(&mut self) -> super::ctx::MonitorCtx<'_> {
-        super::ctx::monitor_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn cluster_ctx(&mut self) -> super::ctx::ClusterCtx<'_> {
-        super::ctx::cluster_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn carry_ctx(&mut self) -> super::ctx::CarryCtx<'_> {
-        super::ctx::carry_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn interaction_ctx(&mut self) -> super::ctx::InteractionCtx<'_> {
-        super::ctx::interaction_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn workspace_ctx(&mut self) -> super::ctx::WorkspaceCtx<'_> {
-        super::ctx::workspace_ctx(self)
     }
 
     #[allow(dead_code)]

--- a/crates/halley-wl/src/compositor/workspace/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/mod.rs
@@ -12,7 +12,7 @@ use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::XdgToplevelSurfaceData;
 
 use crate::compositor::activity::CommitActivity;
-use crate::compositor::ctx::{SurfaceLifecycleCtx, WorkspaceCtx};
+use crate::compositor::ctx::SurfaceLifecycleCtx;
 use crate::compositor::root::Halley;
 
 pub mod lifecycle;

--- a/crates/halley-wl/src/ipc/mod.rs
+++ b/crates/halley-wl/src/ipc/mod.rs
@@ -2,6 +2,7 @@ mod cluster;
 mod monitor;
 mod node;
 mod trail;
+mod view;
 
 use std::time::Instant;
 
@@ -17,6 +18,7 @@ use self::cluster::handle_cluster_request;
 use self::monitor::handle_monitor_request;
 use self::node::handle_node_request;
 use self::trail::handle_trail_request;
+use self::view::IpcView;
 
 #[cfg(test)]
 use self::cluster::{inspect_cluster, list_clusters};
@@ -186,19 +188,12 @@ fn handle_tile_request(st: &mut Halley, request: TileRequest) -> Response {
 }
 
 fn resolve_output_context(st: &Halley, output: Option<&str>) -> Result<String, IpcError> {
-    match output {
-        Some(name) => Ok(validate_output(st, name)?.to_string()),
-        None => Ok(st.focused_monitor().to_string()),
-    }
+    IpcView::from_halley(st).resolve_output_context(output)
 }
 
-fn validate_output<'a>(st: &'a Halley, output: &'a str) -> Result<&'a str, IpcError> {
-    st.model
-        .monitor_state
-        .monitors
-        .contains_key(output)
-        .then_some(output)
-        .ok_or_else(|| IpcError::NotFound(format!("output {output} not found")))
+fn validate_output<'a>(st: &Halley, output: &'a str) -> Result<&'a str, IpcError> {
+    IpcView::from_halley(st).validate_output(output)?;
+    Ok(output)
 }
 
 fn focus_output_if_needed(st: &mut Halley, output: &str, now: Instant) {
@@ -208,16 +203,7 @@ fn focus_output_if_needed(st: &mut Halley, output: &str, now: Instant) {
 }
 
 fn sorted_outputs(st: &Halley) -> Vec<String> {
-    let mut outputs: Vec<_> = st.model.monitor_state.monitors.keys().cloned().collect();
-    outputs.sort_by(|a, b| {
-        let am = st.model.monitor_state.monitors.get(a).expect("monitor");
-        let bm = st.model.monitor_state.monitors.get(b).expect("monitor");
-        am.offset_x
-            .cmp(&bm.offset_x)
-            .then(am.offset_y.cmp(&bm.offset_y))
-            .then(a.cmp(b))
-    });
-    outputs
+    IpcView::from_halley(st).sorted_outputs()
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/ipc/monitor.rs
+++ b/crates/halley-wl/src/ipc/monitor.rs
@@ -1,11 +1,10 @@
-use std::cmp::Ordering;
 use std::time::Instant;
 
 use halley_ipc::{IpcError, MonitorFocusDirection, MonitorFocusTarget, MonitorRequest, Response};
 
 use crate::compositor::root::Halley;
 
-use super::validate_output;
+use super::view::IpcView;
 
 pub(super) fn handle_monitor_request(st: &mut Halley, request: MonitorRequest) -> Response {
     match request {
@@ -23,59 +22,27 @@ fn resolve_monitor_focus_target(
     st: &Halley,
     target: &MonitorFocusTarget,
 ) -> Result<String, IpcError> {
+    let view = IpcView::from_halley(st);
     match target {
-        MonitorFocusTarget::Output(output) => Ok(validate_output(st, output)?.to_string()),
+        MonitorFocusTarget::Output(output) => {
+            view.validate_output(output)?;
+            Ok(output.to_string())
+        }
         MonitorFocusTarget::Direction(direction) => {
-            adjacent_monitor(st, *direction).ok_or_else(|| {
+            view.adjacent_monitor(*direction).ok_or_else(|| {
                 IpcError::NotFound(format!(
                     "no {} output adjacent to {}",
                     monitor_direction_label(*direction),
-                    st.focused_monitor()
+                    view.focused_monitor()
                 ))
             })
         }
     }
 }
 
+#[cfg(test)]
 pub(super) fn adjacent_monitor(st: &Halley, direction: MonitorFocusDirection) -> Option<String> {
-    let current_name = st.focused_monitor();
-    let current = st.model.monitor_state.monitors.get(current_name)?;
-    let current_center = (
-        current.offset_x as f32 + current.width as f32 * 0.5,
-        current.offset_y as f32 + current.height as f32 * 0.5,
-    );
-
-    let mut candidates: Vec<(String, f32, f32)> = st
-        .model
-        .monitor_state
-        .monitors
-        .iter()
-        .filter_map(|(name, monitor)| {
-            if name == current_name {
-                return None;
-            }
-            let center = (
-                monitor.offset_x as f32 + monitor.width as f32 * 0.5,
-                monitor.offset_y as f32 + monitor.height as f32 * 0.5,
-            );
-            let dx = center.0 - current_center.0;
-            let dy = center.1 - current_center.1;
-            let (primary, secondary, keep) = match direction {
-                MonitorFocusDirection::Left => (-dx, dy.abs(), dx < 0.0),
-                MonitorFocusDirection::Right => (dx, dy.abs(), dx > 0.0),
-                MonitorFocusDirection::Up => (-dy, dx.abs(), dy < 0.0),
-                MonitorFocusDirection::Down => (dy, dx.abs(), dy > 0.0),
-            };
-            keep.then_some((name.clone(), primary, secondary))
-        })
-        .collect();
-    candidates.sort_by(|a, b| {
-        a.1.partial_cmp(&b.1)
-            .unwrap_or(Ordering::Equal)
-            .then(a.2.partial_cmp(&b.2).unwrap_or(Ordering::Equal))
-            .then(a.0.cmp(&b.0))
-    });
-    candidates.into_iter().next().map(|(name, _, _)| name)
+    IpcView::from_halley(st).adjacent_monitor(direction)
 }
 
 fn monitor_direction_label(direction: MonitorFocusDirection) -> &'static str {

--- a/crates/halley-wl/src/ipc/view.rs
+++ b/crates/halley-wl/src/ipc/view.rs
@@ -1,0 +1,121 @@
+use std::cmp::Ordering;
+
+use halley_ipc::{IpcError, MonitorFocusDirection};
+
+use crate::compositor::root::Halley;
+
+#[derive(Clone, Debug)]
+struct IpcMonitorView {
+    name: String,
+    offset_x: i32,
+    offset_y: i32,
+    width: i32,
+    height: i32,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct IpcView {
+    focused_monitor: String,
+    monitors: Vec<IpcMonitorView>,
+}
+
+impl IpcView {
+    pub(super) fn from_halley(st: &Halley) -> Self {
+        let mut monitors: Vec<_> = st
+            .model
+            .monitor_state
+            .monitors
+            .iter()
+            .map(|(name, monitor)| IpcMonitorView {
+                name: name.clone(),
+                offset_x: monitor.offset_x,
+                offset_y: monitor.offset_y,
+                width: monitor.width,
+                height: monitor.height,
+            })
+            .collect();
+        monitors.sort_by(|a, b| monitor_order(a, b));
+        Self {
+            focused_monitor: st.focused_monitor().to_string(),
+            monitors,
+        }
+    }
+
+    pub(super) fn focused_monitor(&self) -> &str {
+        self.focused_monitor.as_str()
+    }
+
+    pub(super) fn validate_output(&self, output: &str) -> Result<(), IpcError> {
+        self.monitors
+            .iter()
+            .any(|monitor| monitor.name == output)
+            .then_some(())
+            .ok_or_else(|| IpcError::NotFound(format!("output {output} not found")))
+    }
+
+    pub(super) fn resolve_output_context(&self, output: Option<&str>) -> Result<String, IpcError> {
+        match output {
+            Some(name) => {
+                self.validate_output(name)?;
+                Ok(name.to_string())
+            }
+            None => Ok(self.focused_monitor.clone()),
+        }
+    }
+
+    pub(super) fn sorted_outputs(&self) -> Vec<String> {
+        self.monitors
+            .iter()
+            .map(|monitor| monitor.name.clone())
+            .collect()
+    }
+
+    pub(super) fn adjacent_monitor(&self, direction: MonitorFocusDirection) -> Option<String> {
+        let current = self
+            .monitors
+            .iter()
+            .find(|monitor| monitor.name == self.focused_monitor)?;
+        let current_center = monitor_center(current);
+
+        let mut candidates: Vec<(String, f32, f32)> = self
+            .monitors
+            .iter()
+            .filter_map(|monitor| {
+                if monitor.name == current.name {
+                    return None;
+                }
+                let center = monitor_center(monitor);
+                let dx = center.0 - current_center.0;
+                let dy = center.1 - current_center.1;
+                let (primary, secondary, keep) = match direction {
+                    MonitorFocusDirection::Left => (-dx, dy.abs(), dx < 0.0),
+                    MonitorFocusDirection::Right => (dx, dy.abs(), dx > 0.0),
+                    MonitorFocusDirection::Up => (-dy, dx.abs(), dy < 0.0),
+                    MonitorFocusDirection::Down => (dy, dx.abs(), dy > 0.0),
+                };
+                keep.then_some((monitor.name.clone(), primary, secondary))
+            })
+            .collect();
+        candidates.sort_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(Ordering::Equal)
+                .then(a.2.partial_cmp(&b.2).unwrap_or(Ordering::Equal))
+                .then(a.0.cmp(&b.0))
+        });
+        candidates.into_iter().next().map(|(name, _, _)| name)
+    }
+}
+
+fn monitor_order(a: &IpcMonitorView, b: &IpcMonitorView) -> Ordering {
+    a.offset_x
+        .cmp(&b.offset_x)
+        .then(a.offset_y.cmp(&b.offset_y))
+        .then(a.name.cmp(&b.name))
+}
+
+fn monitor_center(monitor: &IpcMonitorView) -> (f32, f32) {
+    (
+        monitor.offset_x as f32 + monitor.width as f32 * 0.5,
+        monitor.offset_y as f32 + monitor.height as f32 * 0.5,
+    )
+}

--- a/crates/halley-wl/src/protocol/wayland/handlers.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers.rs
@@ -53,7 +53,7 @@ impl SeatHandler for Halley {
     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) {
         let now = Instant::now();
         fullscreen::system::on_seat_focus_changed(&mut self.fullscreen_ctx(), focused, now);
-        focus::system::on_seat_focus_changed(&mut self.focus_ctx(), seat, focused);
+        focus::system::on_seat_focus_changed(&self.focus_ctx(), seat, focused);
     }
 
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {

--- a/crates/halley-wl/src/spatial/hit_test.rs
+++ b/crates/halley-wl/src/spatial/hit_test.rs
@@ -1,3 +1,5 @@
+use std::cmp::{Ordering, Reverse};
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use crate::compositor::interaction::{HitNode, ResizeCtx};
@@ -7,7 +9,129 @@ use crate::compositor::surface::active_stacking_visible_members_for_monitor;
 use crate::frame_loop::anim_style_for;
 use crate::input::active_node_screen_rect;
 use crate::presentation::{node_marker_metrics, world_to_screen};
-use halley_core::viewport::FocusZone;
+use halley_core::field::{Field, NodeId, Vec2};
+use halley_core::viewport::{FocusRing, FocusZone};
+
+struct ActiveAreaView<'a> {
+    field: &'a Field,
+    node_monitor: &'a HashMap<NodeId, String>,
+    monitor: &'a str,
+    focus_ring: FocusRing,
+    focus_center: Vec2,
+}
+
+struct ActiveHitOrderingView {
+    stack_ranks: HashMap<NodeId, usize>,
+    draws_above_fullscreen: HashSet<NodeId>,
+    fullscreen_on_current_monitor: HashSet<NodeId>,
+    persistent_top: HashSet<NodeId>,
+    recent_top_node: Option<NodeId>,
+}
+
+impl ActiveHitOrderingView {
+    fn from_halley(
+        st: &Halley,
+        now: Instant,
+        stack_visible_front_to_back: &[NodeId],
+        hits: &[HitNode],
+    ) -> Self {
+        let current_monitor = st.model.monitor_state.current_monitor.as_str();
+        let stack_ranks = stack_visible_front_to_back
+            .iter()
+            .enumerate()
+            .map(|(index, &node_id)| (node_id, index))
+            .collect();
+        let mut draws_above_fullscreen = HashSet::new();
+        let mut fullscreen_on_current_monitor = HashSet::new();
+        let mut persistent_top = HashSet::new();
+        for hit in hits {
+            let node_id = hit.node_id;
+            if st.node_draws_above_fullscreen_on_current_monitor(node_id) {
+                draws_above_fullscreen.insert(node_id);
+            }
+            if st
+                .fullscreen_monitor_for_node(node_id)
+                .is_some_and(|monitor| monitor == current_monitor)
+            {
+                fullscreen_on_current_monitor.insert(node_id);
+            }
+            if is_persistent_rule_top(st, node_id) {
+                persistent_top.insert(node_id);
+            }
+        }
+        let recent_top_node = st
+            .model
+            .focus_state
+            .recent_top_until
+            .filter(|&until| now < until)
+            .and(st.model.focus_state.recent_top_node);
+
+        Self {
+            stack_ranks,
+            draws_above_fullscreen,
+            fullscreen_on_current_monitor,
+            persistent_top,
+            recent_top_node,
+        }
+    }
+
+    fn compare(&self, a: &HitNode, b: &HitNode) -> Ordering {
+        let compare_bool = |lhs: bool, rhs: bool| rhs.cmp(&lhs);
+        compare_bool(
+            self.draws_above_fullscreen.contains(&a.node_id),
+            self.draws_above_fullscreen.contains(&b.node_id),
+        )
+        .then_with(|| {
+            compare_bool(
+                self.fullscreen_on_current_monitor.contains(&a.node_id),
+                self.fullscreen_on_current_monitor.contains(&b.node_id),
+            )
+        })
+        .then_with(|| {
+            compare_bool(
+                self.persistent_top.contains(&a.node_id),
+                self.persistent_top.contains(&b.node_id),
+            )
+        })
+        .then_with(|| {
+            compare_bool(
+                Some(a.node_id) == self.recent_top_node,
+                Some(b.node_id) == self.recent_top_node,
+            )
+        })
+        .then_with(|| {
+            match (
+                self.stack_ranks.get(&a.node_id),
+                self.stack_ranks.get(&b.node_id),
+            ) {
+                (Some(a_rank), Some(b_rank)) => a_rank.cmp(b_rank),
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => Ordering::Equal,
+            }
+        })
+        .then_with(|| Reverse(a.node_id.as_u64()).cmp(&Reverse(b.node_id.as_u64())))
+    }
+}
+
+impl ActiveAreaView<'_> {
+    fn contains(&self, node_id: NodeId) -> bool {
+        let Some(node) = self.field.node(node_id) else {
+            return false;
+        };
+        if self
+            .node_monitor
+            .get(&node_id)
+            .is_some_and(|owner| owner != self.monitor)
+        {
+            return false;
+        }
+        matches!(
+            self.focus_ring.zone(self.focus_center, node.pos),
+            FocusZone::Inside
+        )
+    }
+}
 
 pub(crate) fn pick_hit_node_at(
     st: &Halley,
@@ -24,17 +148,6 @@ pub(crate) fn pick_hit_node_at(
         st,
         st.model.monitor_state.current_monitor.as_str(),
     );
-    let recent_top_node = st
-        .model
-        .focus_state
-        .recent_top_until
-        .filter(|&until| now < until)
-        .and(st.model.focus_state.recent_top_node);
-    let stack_ranks = stack_visible_front_to_back
-        .iter()
-        .enumerate()
-        .map(|(index, &node_id)| (node_id, index))
-        .collect::<std::collections::HashMap<_, _>>();
     for id in st.model.field.node_ids_all() {
         let Some(n) = st.model.field.node(id) else {
             continue;
@@ -109,51 +222,10 @@ pub(crate) fn pick_hit_node_at(
         };
     }
 
-    active.sort_by(
-        |a, b| match (stack_ranks.get(&a.node_id), stack_ranks.get(&b.node_id)) {
-            _ => {
-                let current_monitor = st.model.monitor_state.current_monitor.as_str();
-                let compare_bool = |lhs: bool, rhs: bool| rhs.cmp(&lhs);
-                compare_bool(
-                    st.node_draws_above_fullscreen_on_current_monitor(a.node_id),
-                    st.node_draws_above_fullscreen_on_current_monitor(b.node_id),
-                )
-                .then_with(|| {
-                    compare_bool(
-                        st.fullscreen_monitor_for_node(a.node_id)
-                            .is_some_and(|monitor| monitor == current_monitor),
-                        st.fullscreen_monitor_for_node(b.node_id)
-                            .is_some_and(|monitor| monitor == current_monitor),
-                    )
-                })
-                .then_with(|| {
-                    compare_bool(
-                        is_persistent_rule_top(st, a.node_id),
-                        is_persistent_rule_top(st, b.node_id),
-                    )
-                })
-                .then_with(|| {
-                    compare_bool(
-                        Some(a.node_id) == recent_top_node,
-                        Some(b.node_id) == recent_top_node,
-                    )
-                })
-                .then_with(
-                    || match (stack_ranks.get(&a.node_id), stack_ranks.get(&b.node_id)) {
-                        (Some(a_rank), Some(b_rank)) => a_rank.cmp(b_rank),
-                        (Some(_), None) => std::cmp::Ordering::Less,
-                        (None, Some(_)) => std::cmp::Ordering::Greater,
-                        (None, None) => std::cmp::Ordering::Equal,
-                    },
-                )
-                .then_with(|| {
-                    std::cmp::Reverse(a.node_id.as_u64())
-                        .cmp(&std::cmp::Reverse(b.node_id.as_u64()))
-                })
-            }
-        },
-    );
-    node_dot.sort_by_key(|h| std::cmp::Reverse(h.node_id.as_u64()));
+    let active_ordering =
+        ActiveHitOrderingView::from_halley(st, now, &stack_visible_front_to_back, &active);
+    active.sort_by(|a, b| active_ordering.compare(a, b));
+    node_dot.sort_by_key(|h| Reverse(h.node_id.as_u64()));
 
     active
         .into_iter()
@@ -161,30 +233,19 @@ pub(crate) fn pick_hit_node_at(
         .or_else(|| node_dot.into_iter().next())
 }
 
-pub(crate) fn node_in_active_area(st: &Halley, node_id: halley_core::field::NodeId) -> bool {
+pub(crate) fn node_in_active_area(st: &Halley, node_id: NodeId) -> bool {
     node_in_active_area_for_monitor(st, node_id, st.model.monitor_state.current_monitor.as_str())
 }
 
-pub(crate) fn node_in_active_area_for_monitor(
-    st: &Halley,
-    node_id: halley_core::field::NodeId,
-    monitor: &str,
-) -> bool {
-    let Some(n) = st.model.field.node(node_id) else {
-        return false;
-    };
-    if st
-        .model
-        .monitor_state
-        .node_monitor
-        .get(&node_id)
-        .is_some_and(|owner| owner != monitor)
-    {
-        return false;
+pub(crate) fn node_in_active_area_for_monitor(st: &Halley, node_id: NodeId, monitor: &str) -> bool {
+    ActiveAreaView {
+        field: &st.model.field,
+        node_monitor: &st.model.monitor_state.node_monitor,
+        monitor,
+        focus_ring: st.focus_ring_for_monitor(monitor),
+        focus_center: st.view_center_for_monitor(monitor),
     }
-    let focus_ring = st.focus_ring_for_monitor(monitor);
-    let focus_center = st.view_center_for_monitor(monitor);
-    matches!(focus_ring.zone(focus_center, n.pos), FocusZone::Inside)
+    .contains(node_id)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR does two things:

1. Incrementally reduces direct access to the Halley root state from focus, IPC, and hit-test paths.
2. Fixes vblank throttling so pacing is based on DRM event metadata timestamps instead of `Instant::now()` sampling.

## Changes

### Compositor state access cleanup

- Narrowed `FocusCtx` so it only carries `DisplayHandle` instead of `&mut Halley`
- Updated focus-change handling to use `&FocusCtx` without reaching through `ctx.st`
- Added `IpcView` as a snapshot for focused monitor and monitor geometry
- Moved IPC output validation, sorted output listing, and adjacent monitor resolution onto the IPC snapshot
- Removed unused placeholder context types and matching root methods
- Added `ActiveAreaView` in spatial hit testing to isolate active-area checks
- Added `ActiveHitOrderingView` to precompute active hit ordering inputs before sorting hits

This keeps behavior unchanged while moving toward smaller scene/view boundaries and reducing god-object coupling.

### Vblank pacing fix

- Use DRM event metadata timestamps for vblank pacing instead of sampling `Instant::now()`
- Fall back to monotonic time when DRM metadata is realtime or missing
- Only suppress events arriving faster than half-refresh
- Avoid advancing the saved vblank timestamp for suppressed early events

This mirrors niri’s safer behavior and prevents benign-looking NVIDIA event timing/batching from turning into visible frame stalls.

## Verification

- `cargo fmt`
- `cargo check -p halley-wl`
- `cargo test -p halley-wl --lib`

Result: 244 passed.