### PR TITLE
feat(halley-wl): add first shadow rendering pass

### DIFF
--- a/crates/halley-config/src/layout/guards.rs
+++ b/crates/halley-config/src/layout/guards.rs
@@ -25,6 +25,20 @@ impl RuntimeTuning {
             self.decorations.secondary_border.size_px.clamp(0, 64);
         self.decorations.secondary_border.gap_px =
             self.decorations.secondary_border.gap_px.clamp(0, 8);
+        for shadow in [
+            &mut self.decorations.shadows.window,
+            &mut self.decorations.shadows.node,
+            &mut self.decorations.shadows.overlay,
+        ] {
+            shadow.blur_radius = shadow.blur_radius.clamp(0.0, 256.0);
+            shadow.spread = shadow.spread.clamp(0.0, 256.0);
+            shadow.offset_x = shadow.offset_x.clamp(-256.0, 256.0);
+            shadow.offset_y = shadow.offset_y.clamp(-256.0, 256.0);
+            shadow.color.r = shadow.color.r.clamp(0.0, 1.0);
+            shadow.color.g = shadow.color.g.clamp(0.0, 1.0);
+            shadow.color.b = shadow.color.b.clamp(0.0, 1.0);
+            shadow.color.a = shadow.color.a.clamp(0.0, 1.0);
+        }
         self.bearings.fade_distance = self.bearings.fade_distance.clamp(120.0, 100_000.0);
 
         self.cluster_distance_px = self.cluster_distance_px.clamp(24.0, 4_000.0);

--- a/crates/halley-config/src/layout/runtime.rs
+++ b/crates/halley-config/src/layout/runtime.rs
@@ -571,6 +571,35 @@ decorations:
     colour-unfocused "#1f1f1f"
   end
 
+  shadows:
+    window:
+      enabled true
+      blur-radius 10
+      spread 10
+      offset-x 0
+      offset-y 12
+      colour "#00000005"
+    end
+
+    node:
+      enabled true
+      blur-radius 10
+      spread 5
+      offset-x 0
+      offset-y 6
+      colour "#0000002e"
+    end
+
+    overlay:
+      enabled true
+      blur-radius 16
+      spread 4
+      offset-x 0
+      offset-y 8
+      colour "#00000038"
+    end
+  end
+
   resize-using-border true
 end
 

--- a/crates/halley-config/src/layout/types.rs
+++ b/crates/halley-config/src/layout/types.rs
@@ -193,9 +193,35 @@ pub struct SecondaryBorderConfig {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ShadowColor {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ShadowLayerConfig {
+    pub enabled: bool,
+    pub blur_radius: f32,
+    pub spread: f32,
+    pub offset_x: f32,
+    pub offset_y: f32,
+    pub color: ShadowColor,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ShadowsConfig {
+    pub window: ShadowLayerConfig,
+    pub node: ShadowLayerConfig,
+    pub overlay: ShadowLayerConfig,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DecorationsConfig {
     pub border: PrimaryBorderConfig,
     pub secondary_border: SecondaryBorderConfig,
+    pub shadows: ShadowsConfig,
     pub resize_using_border: bool,
 }
 
@@ -238,11 +264,58 @@ impl Default for SecondaryBorderConfig {
     }
 }
 
+impl Default for ShadowsConfig {
+    fn default() -> Self {
+        Self {
+            window: ShadowLayerConfig {
+                enabled: true,
+                blur_radius: 10.0,
+                spread: 10.0,
+                offset_x: 0.0,
+                offset_y: 12.0,
+                color: ShadowColor {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 0.018,
+                },
+            },
+            node: ShadowLayerConfig {
+                enabled: true,
+                blur_radius: 10.0,
+                spread: 5.0,
+                offset_x: 0.0,
+                offset_y: 6.0,
+                color: ShadowColor {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 0.18,
+                },
+            },
+            overlay: ShadowLayerConfig {
+                enabled: true,
+                blur_radius: 16.0,
+                spread: 4.0,
+                offset_x: 0.0,
+                offset_y: 8.0,
+                color: ShadowColor {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 0.22,
+                },
+            },
+        }
+    }
+}
+
 impl Default for DecorationsConfig {
     fn default() -> Self {
         Self {
             border: PrimaryBorderConfig::default(),
             secondary_border: SecondaryBorderConfig::default(),
+            shadows: ShadowsConfig::default(),
             resize_using_border: false,
         }
     }

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -16,7 +16,8 @@ pub use layout::{
     InitialWindowOverlapPolicy, InitialWindowSpawnPlacement, InputConfig, InputFocusMode,
     KeyboardConfig, NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy,
     OverlayBorderSource, OverlayColorMode, OverlayShape, OverlayStyleConfig, PanToNewMode,
-    PrimaryBorderConfig, RuntimeTuning, ScreenshotConfig, SecondaryBorderConfig, ShapeStyle,
-    TimedAnimationConfig, ViewportOutputConfig, ViewportVrrMode, WindowCloseAnimationConfig,
-    WindowCloseAnimationStyle, WindowRule, WindowRulePattern,
+    PrimaryBorderConfig, RuntimeTuning, ScreenshotConfig, SecondaryBorderConfig, ShadowColor,
+    ShadowLayerConfig, ShadowsConfig, ShapeStyle, TimedAnimationConfig, ViewportOutputConfig,
+    ViewportVrrMode, WindowCloseAnimationConfig, WindowCloseAnimationStyle, WindowRule,
+    WindowRulePattern,
 };

--- a/crates/halley-config/src/parse/primitives.rs
+++ b/crates/halley-config/src/parse/primitives.rs
@@ -6,7 +6,7 @@ use crate::layout::{
     ClickCollapsedOutsideFocusMode, ClickCollapsedPanMode, CloseRestorePanMode,
     ClusterBloomDirection, ClusterDefaultLayout, DecorationBorderColor, FocusRingConfig,
     InputFocusMode, NodeBackgroundColorMode, NodeBorderColorMode, NodeDisplayPolicy,
-    OverlayBorderSource, OverlayColorMode, OverlayShape, PanToNewMode, ShapeStyle,
+    OverlayBorderSource, OverlayColorMode, OverlayShape, PanToNewMode, ShadowColor, ShapeStyle,
     WindowCloseAnimationStyle,
 };
 
@@ -414,6 +414,19 @@ pub(crate) fn pick_decoration_border_color(
         .unwrap_or(default)
 }
 
+pub(crate) fn pick_shadow_color(
+    cfg: &RuneConfig,
+    paths: &[&str],
+    default: ShadowColor,
+) -> ShadowColor {
+    let Some(raw) = pick_string(cfg, paths) else {
+        return default;
+    };
+    parse_hex_rgba(raw.trim().trim_matches('"'))
+        .map(|(r, g, b, a)| ShadowColor { r, g, b, a })
+        .unwrap_or(default)
+}
+
 pub(crate) fn parse_hex_rgb(value: &str) -> Option<(f32, f32, f32)> {
     let hex = value.strip_prefix('#').unwrap_or(value);
     let expanded = match hex.len() {
@@ -433,4 +446,36 @@ pub(crate) fn parse_hex_rgb(value: &str) -> Option<(f32, f32, f32)> {
     let g = u8::from_str_radix(&expanded[2..4], 16).ok()? as f32 / 255.0;
     let b = u8::from_str_radix(&expanded[4..6], 16).ok()? as f32 / 255.0;
     Some((r, g, b))
+}
+
+fn parse_hex_rgba(value: &str) -> Option<(f32, f32, f32, f32)> {
+    let hex = value.strip_prefix('#').unwrap_or(value);
+    let expanded = match hex.len() {
+        3 => {
+            let mut out = String::with_capacity(8);
+            for ch in hex.chars() {
+                out.push(ch);
+                out.push(ch);
+            }
+            out.push_str("ff");
+            out
+        }
+        4 => {
+            let mut out = String::with_capacity(8);
+            for ch in hex.chars() {
+                out.push(ch);
+                out.push(ch);
+            }
+            out
+        }
+        6 => format!("{hex}ff"),
+        8 => hex.to_string(),
+        _ => return None,
+    };
+
+    let r = u8::from_str_radix(&expanded[0..2], 16).ok()? as f32 / 255.0;
+    let g = u8::from_str_radix(&expanded[2..4], 16).ok()? as f32 / 255.0;
+    let b = u8::from_str_radix(&expanded[4..6], 16).ok()? as f32 / 255.0;
+    let a = u8::from_str_radix(&expanded[6..8], 16).ok()? as f32 / 255.0;
+    Some((r, g, b, a))
 }

--- a/crates/halley-config/src/parse/sections/decorations.rs
+++ b/crates/halley-config/src/parse/sections/decorations.rs
@@ -1,8 +1,10 @@
 use rune_cfg::RuneConfig;
 
-use crate::layout::RuntimeTuning;
+use crate::layout::{RuntimeTuning, ShadowLayerConfig};
 
-use super::super::primitives::{pick_bool, pick_decoration_border_color, pick_i32};
+use super::super::primitives::{
+    pick_bool, pick_decoration_border_color, pick_f32, pick_i32, pick_shadow_color,
+};
 
 pub(crate) fn load_decorations_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
     out.decorations.border.size_px = pick_i32(
@@ -72,10 +74,63 @@ pub(crate) fn load_decorations_section(cfg: &RuneConfig, out: &mut RuntimeTuning
         out.decorations.secondary_border.color_unfocused,
     );
 
+    load_shadow_layer(
+        cfg,
+        "decorations.shadows.window",
+        &mut out.decorations.shadows.window,
+    );
+    load_shadow_layer(
+        cfg,
+        "decorations.shadows.node",
+        &mut out.decorations.shadows.node,
+    );
+    load_shadow_layer(
+        cfg,
+        "decorations.shadows.overlay",
+        &mut out.decorations.shadows.overlay,
+    );
+
     out.decorations.resize_using_border = pick_bool(
         cfg,
         &["decorations.resize-using-border"],
         out.decorations.resize_using_border,
+    );
+}
+
+fn load_shadow_layer(cfg: &RuneConfig, root: &str, out: &mut ShadowLayerConfig) {
+    out.enabled = pick_bool(cfg, &[format!("{root}.enabled").as_str()], out.enabled);
+    out.blur_radius = pick_f32(
+        cfg,
+        &[
+            format!("{root}.blur-radius").as_str(),
+            format!("{root}.blur_radius").as_str(),
+        ],
+        out.blur_radius,
+    );
+    out.spread = pick_f32(cfg, &[format!("{root}.spread").as_str()], out.spread);
+    out.offset_x = pick_f32(
+        cfg,
+        &[
+            format!("{root}.offset-x").as_str(),
+            format!("{root}.offset_x").as_str(),
+        ],
+        out.offset_x,
+    );
+    out.offset_y = pick_f32(
+        cfg,
+        &[
+            format!("{root}.offset-y").as_str(),
+            format!("{root}.offset_y").as_str(),
+        ],
+        out.offset_y,
+    );
+    out.color = pick_shadow_color(
+        cfg,
+        &[
+            format!("{root}.colour").as_str(),
+            format!("{root}.color").as_str(),
+        ],
+        out.color,
     );
 }
 
@@ -107,6 +162,35 @@ decorations:
     color-unfocused "#1f1f1f"
   end
 
+  shadows:
+    window:
+      enabled true
+      blur-radius 40.0
+      spread 1.0
+      offset-x 2.0
+      offset-y 10.0
+      colour "#22446688"
+    end
+
+    node:
+      enabled false
+      blur-radius 11.0
+      spread 5.0
+      offset-x 0.0
+      offset-y 6.0
+      colour "#0000002e"
+    end
+
+    overlay:
+      enabled true
+      blur-radius 16.0
+      spread 4.0
+      offset-x 0.0
+      offset-y 8.0
+      color "#00000038"
+    end
+  end
+
   resize-using-border true
 end
 "##,
@@ -121,6 +205,20 @@ end
         assert_eq!(out.decorations.secondary_border.enabled, true);
         assert_eq!(out.decorations.secondary_border.size_px, 2);
         assert_eq!(out.decorations.secondary_border.gap_px, 3);
+        assert!(out.decorations.shadows.window.enabled);
+        assert_eq!(out.decorations.shadows.window.blur_radius, 40.0);
+        assert_eq!(out.decorations.shadows.window.spread, 1.0);
+        assert_eq!(out.decorations.shadows.window.offset_x, 2.0);
+        assert_eq!(out.decorations.shadows.window.offset_y, 10.0);
+        assert_eq!(out.decorations.shadows.window.color.r, 0x22 as f32 / 255.0);
+        assert_eq!(out.decorations.shadows.window.color.g, 0x44 as f32 / 255.0);
+        assert_eq!(out.decorations.shadows.window.color.b, 0x66 as f32 / 255.0);
+        assert_eq!(out.decorations.shadows.window.color.a, 0x88 as f32 / 255.0);
+        assert!(!out.decorations.shadows.node.enabled);
+        assert_eq!(out.decorations.shadows.node.blur_radius, 11.0);
+        assert_eq!(out.decorations.shadows.node.color.a, 0x2e as f32 / 255.0);
+        assert!(out.decorations.shadows.overlay.enabled);
+        assert_eq!(out.decorations.shadows.overlay.color.a, 0x38 as f32 / 255.0);
         assert!(out.decorations.resize_using_border);
     }
 

--- a/crates/halley-wl/src/overlay/cluster_naming.rs
+++ b/crates/halley-wl/src/overlay/cluster_naming.rs
@@ -14,8 +14,8 @@ use crate::text::{draw_ui_text_in, ui_text_size_in};
 use super::{
     ACTION_ROW_GAP_Y, BANNER_GAP, BANNER_META_SCALE, BANNER_TITLE_SCALE,
     EXIT_CONFIRM_MAX_WIDTH_PAD, OverlayView, draw_overlay_action_row, draw_overlay_chip,
-    overlay_accent_fill, overlay_action_row_size, overlay_text_color_for_fill,
-    resolve_overlay_visuals,
+    draw_overlay_chip_without_shadow, overlay_accent_fill, overlay_action_row_size,
+    overlay_text_color_for_fill, resolve_overlay_visuals,
 };
 
 const CLUSTER_DIALOG_TITLE: &str = "Create cluster";
@@ -401,7 +401,7 @@ pub(crate) fn draw_cluster_naming_dialog(
             visuals.palette.subtext.alpha(0.98),
             damage,
         )?;
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             overlay.render_state,
             &visuals,
@@ -477,7 +477,7 @@ pub(crate) fn draw_cluster_naming_dialog(
             prompt.confirm_hover_mix,
         );
         let confirm_text_color = overlay_text_color_for_fill(confirm_fill, 1.0);
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             overlay.render_state,
             &visuals,

--- a/crates/halley-wl/src/overlay/mod.rs
+++ b/crates/halley-wl/src/overlay/mod.rs
@@ -351,7 +351,7 @@ fn draw_overflow_member_chip(
     alpha: f32,
     damage: Rectangle<i32, Physical>,
 ) -> Result<(), Box<dyn Error>> {
-    draw_overlay_chip(
+    draw_overlay_chip_without_shadow(
         frame,
         overlay.render_state,
         visuals,
@@ -539,7 +539,7 @@ fn draw_overlay_action_row(
             (cursor_x, y + (row_h - keycap_h) / 2).into(),
             (keycap_w, keycap_h).into(),
         );
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             render_state,
             visuals,
@@ -729,7 +729,7 @@ pub(crate) fn draw_cluster_overflow_strip(
     }
 
     if let (Some(track), Some(thumb)) = (scrollbar_track, scrollbar_thumb) {
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             overlay.render_state,
             &visuals,
@@ -740,7 +740,7 @@ pub(crate) fn draw_cluster_overflow_strip(
             damage,
             reveal_alpha,
         )?;
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             overlay.render_state,
             &visuals,
@@ -1150,7 +1150,7 @@ fn draw_focus_cycle_card(
         (rect.loc.x + rect.size.w - badge_w - 12, rect.loc.y + 10).into(),
         (badge_w, monitor_h + 8).into(),
     );
-    draw_overlay_chip(
+    draw_overlay_chip_without_shadow(
         frame,
         overlay.render_state,
         visuals,
@@ -1209,7 +1209,7 @@ fn draw_focus_cycle_card(
 
     if let Some(select_rect) = selection_rect {
         let select_fill = visuals.palette.border.alpha(0.94);
-        draw_overlay_chip(
+        draw_overlay_chip_without_shadow(
             frame,
             overlay.render_state,
             visuals,
@@ -1678,21 +1678,74 @@ fn draw_overlay_chip(
     damage: Rectangle<i32, Physical>,
     alpha: f32,
 ) -> Result<(), Box<dyn Error>> {
+    draw_overlay_chip_impl(
+        frame,
+        render_state,
+        visuals,
+        rect,
+        corner_radius,
+        fill_color,
+        draw_border,
+        true,
+        damage,
+        alpha,
+    )
+}
+
+fn draw_overlay_chip_without_shadow(
+    frame: &mut GlesFrame<'_, '_>,
+    render_state: &RenderState,
+    visuals: &OverlayVisuals,
+    rect: Rectangle<i32, Physical>,
+    corner_radius: f32,
+    fill_color: Color32F,
+    draw_border: bool,
+    damage: Rectangle<i32, Physical>,
+    alpha: f32,
+) -> Result<(), Box<dyn Error>> {
+    draw_overlay_chip_impl(
+        frame,
+        render_state,
+        visuals,
+        rect,
+        corner_radius,
+        fill_color,
+        draw_border,
+        false,
+        damage,
+        alpha,
+    )
+}
+
+fn draw_overlay_chip_impl(
+    frame: &mut GlesFrame<'_, '_>,
+    render_state: &RenderState,
+    visuals: &OverlayVisuals,
+    rect: Rectangle<i32, Physical>,
+    corner_radius: f32,
+    fill_color: Color32F,
+    draw_border: bool,
+    draw_shadow: bool,
+    damage: Rectangle<i32, Physical>,
+    alpha: f32,
+) -> Result<(), Box<dyn Error>> {
     let Some(texture) = render_state.gpu.node_circle_texture.as_ref() else {
         return Ok(());
     };
     let Some(program) = render_state.ui_rect_program(visuals.rounded) else {
         return Ok(());
     };
-    draw_shadow_rect(
-        frame,
-        render_state,
-        visuals.shadow,
-        rect,
-        if visuals.rounded { corner_radius } else { 0.0 },
-        alpha,
-        damage,
-    )?;
+    if draw_shadow {
+        draw_shadow_rect(
+            frame,
+            render_state,
+            visuals.shadow,
+            rect,
+            if visuals.rounded { corner_radius } else { 0.0 },
+            alpha,
+            damage,
+        )?;
+    }
     let tex_size: smithay::utils::Size<i32, Buffer> = texture.size();
     let src = Rectangle::<f64, Buffer>::new(
         (0.0, 0.0).into(),

--- a/crates/halley-wl/src/overlay/mod.rs
+++ b/crates/halley-wl/src/overlay/mod.rs
@@ -6,7 +6,9 @@ mod view;
 
 use std::error::Error;
 
-use halley_config::{OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning};
+use halley_config::{
+    OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning, ShadowLayerConfig,
+};
 use smithay::{
     backend::renderer::{
         Color32F, Texture,
@@ -18,6 +20,7 @@ use smithay::{
 use crate::compositor::root::Halley;
 use crate::presentation::themed_node_label_colors;
 use crate::render::draw_primitives::draw_rect;
+use crate::render::shadow::draw_shadow_rect;
 use crate::render::state::RenderState;
 use crate::render::{node_app_icon_fallback_glyph, node_app_icon_texture_allowed};
 use crate::text::{draw_ui_text, draw_ui_text_in, ui_text_size, ui_text_size_in};
@@ -120,6 +123,7 @@ struct OverlayPalette {
 struct OverlayVisuals {
     rounded: bool,
     border_px: f32,
+    shadow: ShadowLayerConfig,
     palette: OverlayPalette,
 }
 
@@ -208,6 +212,7 @@ fn resolve_overlay_visuals(tuning: &RuntimeTuning) -> OverlayVisuals {
     OverlayVisuals {
         rounded: matches!(tuning.overlay_style.shape, OverlayShape::Rounded),
         border_px: resolve_overlay_border_width(tuning),
+        shadow: tuning.decorations.shadows.overlay,
         palette: OverlayPalette {
             fill,
             text,
@@ -1679,6 +1684,15 @@ fn draw_overlay_chip(
     let Some(program) = render_state.ui_rect_program(visuals.rounded) else {
         return Ok(());
     };
+    draw_shadow_rect(
+        frame,
+        render_state,
+        visuals.shadow,
+        rect,
+        if visuals.rounded { corner_radius } else { 0.0 },
+        alpha,
+        damage,
+    )?;
     let tex_size: smithay::utils::Size<i32, Buffer> = texture.size();
     let src = Rectangle::<f64, Buffer>::new(
         (0.0, 0.0).into(),

--- a/crates/halley-wl/src/overlay/screenshot.rs
+++ b/crates/halley-wl/src/overlay/screenshot.rs
@@ -289,13 +289,17 @@ fn draw_screenshot_menu(
     let item_fill = screenshot_menu_item_fill_color(overlay.tuning);
     let style = resolve_screenshot_menu_style(overlay.tuning);
     let bar_rect = screenshot_menu_bar_rect(screen_w, screen_h);
-    
+
     draw_shadow_rect(
         frame,
         overlay.render_state,
         overlay.tuning.decorations.shadows.overlay,
         bar_rect,
-        if style.rounded { style.bar_corner_radius } else { 0.0 },
+        if style.rounded {
+            style.bar_corner_radius
+        } else {
+            0.0
+        },
         1.0,
         damage,
     )?;

--- a/crates/halley-wl/src/overlay/screenshot.rs
+++ b/crates/halley-wl/src/overlay/screenshot.rs
@@ -13,6 +13,7 @@ use smithay::{
 
 use crate::compositor::root::Halley;
 use crate::render::draw_primitives::{draw_outline_rect, draw_rect, draw_ring};
+use crate::render::shadow::draw_shadow_rect;
 use crate::render::state::RenderState;
 use crate::render::{
     screenshot_menu_background_color, screenshot_menu_highlight_color,
@@ -288,6 +289,17 @@ fn draw_screenshot_menu(
     let item_fill = screenshot_menu_item_fill_color(overlay.tuning);
     let style = resolve_screenshot_menu_style(overlay.tuning);
     let bar_rect = screenshot_menu_bar_rect(screen_w, screen_h);
+    
+    draw_shadow_rect(
+        frame,
+        overlay.render_state,
+        overlay.tuning.decorations.shadows.overlay,
+        bar_rect,
+        if style.rounded { style.bar_corner_radius } else { 0.0 },
+        1.0,
+        damage,
+    )?;
+
     draw_screenshot_menu_chip(
         frame,
         overlay.render_state,

--- a/crates/halley-wl/src/render/frame/draw.rs
+++ b/crates/halley-wl/src/render/frame/draw.rs
@@ -25,7 +25,10 @@ use crate::overlay::{
     draw_cluster_selection_markers, draw_monitor_hud, draw_overlay_hover_label,
 };
 use crate::presentation::world_to_screen;
-use crate::window::{ActiveBorderRect, OffscreenNodeTexture, StackWindowDrawUnit};
+use crate::render::shadow::draw_shadow_rect;
+use crate::window::{
+    ActiveBorderRect, OffscreenNodeTexture, StackWindowDrawUnit, WindowShadowRect,
+};
 
 fn focus_ring_screen_radii(
     view_size: Vec2,
@@ -117,6 +120,7 @@ pub(super) fn draw_debug_frame_scene(
         prepared.now,
     )?;
 
+    draw_window_shadows(frame, size, prepared.damage, &scene.shadow_rects, st)?;
     if !scene.active_elements.is_empty() {
         let _ = draw_render_elements(frame, 1.0, &scene.active_elements, &[prepared.damage]);
     }
@@ -130,6 +134,13 @@ pub(super) fn draw_debug_frame_scene(
     draw_window_borders(frame, size, prepared.damage, &scene.border_rects, st)?;
     draw_stack_window_units(frame, size, prepared.damage, &scene.stack_window_units, st)?;
     draw_overlap_overlays(frame, prepared.damage, &scene.overlap_overlay_rects)?;
+    draw_window_shadows(
+        frame,
+        size,
+        prepared.damage,
+        &scene.resized_shadow_rects,
+        st,
+    )?;
     if !scene.resized_active_elements.is_empty() {
         let _ = draw_render_elements(
             frame,
@@ -251,6 +262,13 @@ pub(super) fn draw_debug_frame_scene(
             &[prepared.damage],
         );
     }
+    draw_window_shadows(
+        frame,
+        size,
+        prepared.damage,
+        &scene.above_fullscreen_shadow_rects,
+        st,
+    )?;
     if !scene.above_fullscreen_active_elements.is_empty() {
         let _ = draw_render_elements(
             frame,
@@ -506,6 +524,7 @@ fn draw_stack_window_units(
     st: &mut Halley,
 ) -> Result<(), Box<dyn Error>> {
     for unit in stack_window_units {
+        draw_window_shadows(frame, size, damage, &unit.shadow_rects, st)?;
         if !unit.active_elements.is_empty() {
             let _ = draw_render_elements(frame, 1.0, &unit.active_elements, &[damage]);
         }
@@ -519,6 +538,43 @@ fn draw_stack_window_units(
             draw_window_borders(frame, size, damage, &unit.border_rects, st)?;
         }
     }
+    Ok(())
+}
+
+pub(crate) fn draw_window_shadows(
+    frame: &mut GlesFrame<'_, '_>,
+    size: smithay::utils::Size<i32, Physical>,
+    damage: Rectangle<i32, Physical>,
+    shadow_rects: &[WindowShadowRect],
+    st: &Halley,
+) -> Result<(), Box<dyn Error>> {
+    if shadow_rects.is_empty() {
+        return Ok(());
+    }
+
+    let config = st.runtime.tuning.decorations.shadows.window;
+    if !config.enabled || config.color.a <= 0.0 || config.blur_radius <= 0.0 {
+        return Ok(());
+    }
+    let clipped_damage = damage
+        .intersection(Rectangle::<i32, Physical>::from_size(size))
+        .unwrap_or(damage);
+
+    for rect in shadow_rects {
+        if rect.alpha <= 0.0 || rect.w <= 0 || rect.h <= 0 {
+            continue;
+        }
+        draw_shadow_rect(
+            frame,
+            &st.ui.render_state,
+            config,
+            Rectangle::<i32, Physical>::new((rect.x, rect.y).into(), (rect.w, rect.h).into()),
+            rect.corner_radius,
+            rect.alpha,
+            clipped_damage,
+        )?;
+    }
+
     Ok(())
 }
 

--- a/crates/halley-wl/src/render/frame/mod.rs
+++ b/crates/halley-wl/src/render/frame/mod.rs
@@ -34,6 +34,7 @@ use scene::{collect_cursor_scene, collect_debug_frame_scene, prepare_debug_frame
 pub(crate) use draw::{draw_offscreen_textures, draw_window_borders};
 
 const WINDOW_TEXTURE_SHADER: &str = include_str!("../shaders/window_rounded_texture.frag");
+const WINDOW_SHADOW_SHADER: &str = include_str!("../shaders/window_shadow.frag");
 const SURFACE_CLIP_SHADER: &str = include_str!("../shaders/surface_clipped_texture.frag");
 
 pub(crate) fn ensure_window_texture_program(renderer: &mut GlesRenderer, st: &mut Halley) {
@@ -64,6 +65,33 @@ pub(crate) fn ensure_window_texture_program(renderer: &mut GlesRenderer, st: &mu
                 "window-content-clip",
                 &err,
             );
+        }
+    }
+}
+
+fn ensure_window_shadow_program(renderer: &mut GlesRenderer, st: &mut Halley) {
+    if st.ui.render_state.gpu.window_shadow_program.is_some()
+        || st.ui.render_state.gpu.window_shadow_program_failed
+    {
+        return;
+    }
+
+    match renderer.compile_custom_texture_shader(
+        WINDOW_SHADOW_SHADER,
+        &[
+            UniformName::new("rect_size", UniformType::_2f),
+            UniformName::new("caster_size", UniformType::_2f),
+            UniformName::new("caster_center", UniformType::_2f),
+            UniformName::new("corner_radius", UniformType::_1f),
+            UniformName::new("spread", UniformType::_1f),
+            UniformName::new("shadow_radius", UniformType::_1f),
+            UniformName::new("shadow_color", UniformType::_4f),
+        ],
+    ) {
+        Ok(program) => st.ui.render_state.gpu.window_shadow_program = Some(program),
+        Err(err) => {
+            st.ui.render_state.gpu.window_shadow_program_failed = true;
+            log_rounded_shader_failure("render/shaders/window_shadow.frag", "window-shadow", &err);
         }
     }
 }
@@ -141,6 +169,7 @@ pub(crate) fn draw_debug_frame_to_target(
 ) -> Result<(), Box<dyn Error>> {
     ensure_node_circle_resources(renderer, st)?;
     ensure_window_texture_program(renderer, st);
+    ensure_window_shadow_program(renderer, st);
     ensure_surface_clip_program(renderer, st);
 
     let prepared = prepare_debug_frame_state(st, size);

--- a/crates/halley-wl/src/render/frame/scene.rs
+++ b/crates/halley-wl/src/render/frame/scene.rs
@@ -17,7 +17,7 @@ use crate::compositor::interaction::ResizeCtx;
 use crate::compositor::root::Halley;
 use crate::window::{
     ActiveBorderRect, CroppedClippedSurfaceElement, OffscreenNodeTexture, StackWindowDrawUnit,
-    collect_active_surfaces,
+    WindowShadowRect, collect_active_surfaces,
 };
 
 pub(super) type SurfaceElement =
@@ -52,6 +52,9 @@ pub(super) struct SceneCollections {
     pub(super) above_fullscreen_popup_elements:
         Vec<smithay::backend::renderer::element::utils::CropRenderElement<SurfaceElement>>,
     pub(super) stack_window_units: Vec<StackWindowDrawUnit>,
+    pub(super) shadow_rects: Vec<WindowShadowRect>,
+    pub(super) resized_shadow_rects: Vec<WindowShadowRect>,
+    pub(super) above_fullscreen_shadow_rects: Vec<WindowShadowRect>,
     pub(super) border_rects: Vec<ActiveBorderRect>,
     pub(super) resized_border_rects: Vec<ActiveBorderRect>,
     pub(super) above_fullscreen_border_rects: Vec<ActiveBorderRect>,
@@ -134,6 +137,9 @@ pub(super) fn collect_debug_frame_scene(
             above_fullscreen_popup_offscreen_textures: Vec::new(),
             above_fullscreen_popup_elements: Vec::new(),
             stack_window_units: Vec::new(),
+            shadow_rects: Vec::new(),
+            resized_shadow_rects: Vec::new(),
+            above_fullscreen_shadow_rects: Vec::new(),
             border_rects: Vec::new(),
             resized_border_rects: Vec::new(),
             above_fullscreen_border_rects: Vec::new(),
@@ -175,6 +181,9 @@ pub(super) fn collect_debug_frame_scene(
         above_fullscreen_popup_elements,
         node_surface_map,
         stack_window_units,
+        shadow_rects,
+        resized_shadow_rects,
+        above_fullscreen_shadow_rects,
         border_rects,
         resized_border_rects,
         above_fullscreen_border_rects,
@@ -272,6 +281,9 @@ pub(super) fn collect_debug_frame_scene(
         above_fullscreen_popup_offscreen_textures,
         above_fullscreen_popup_elements,
         stack_window_units,
+        shadow_rects,
+        resized_shadow_rects,
+        above_fullscreen_shadow_rects,
         border_rects,
         resized_border_rects,
         above_fullscreen_border_rects,

--- a/crates/halley-wl/src/render/mod.rs
+++ b/crates/halley-wl/src/render/mod.rs
@@ -10,6 +10,7 @@ mod icon_tint;
 pub mod layer_shell;
 mod node;
 mod screenshot_icon;
+pub(crate) mod shadow;
 pub(crate) mod state;
 pub(crate) mod surface_capture;
 

--- a/crates/halley-wl/src/render/node.rs
+++ b/crates/halley-wl/src/render/node.rs
@@ -26,6 +26,7 @@ use crate::presentation::{
     themed_node_label_fill_color, themed_node_label_text_color, themed_node_ring_color,
     world_to_screen,
 };
+use crate::render::shadow::draw_shadow_rect;
 use crate::render::state::{ClosingWindowAnimationKind, ClosingWindowAnimationSnapshot};
 use crate::text::{draw_ui_text, ui_text_size};
 
@@ -243,6 +244,16 @@ enum NodeRoundShape {
     Circle,
     Square,
     Squircle,
+}
+
+impl NodeRoundShape {
+    fn shadow_corner_radius(self, radius: i32) -> f32 {
+        match self {
+            NodeRoundShape::Circle => radius.max(1) as f32,
+            NodeRoundShape::Square => 0.0,
+            NodeRoundShape::Squircle => radius.max(1) as f32 * 0.42,
+        }
+    }
 }
 
 fn draw_shader_label(
@@ -660,6 +671,18 @@ pub(crate) fn draw_node_markers(
             let node_color = Color32F::new(nc.r(), nc.g(), nc.b(), border_frac);
             let fill_color = node_fill_color(st, highlighted);
             let fill_flat = node_fill_uses_flat_mode(st);
+            draw_shadow_rect(
+                frame,
+                &st.ui.render_state,
+                st.runtime.tuning.decorations.shadows.node,
+                Rectangle::<i32, Physical>::new(
+                    (sx - render_radius, sy - render_radius).into(),
+                    (render_radius * 2, render_radius * 2).into(),
+                ),
+                round_shape.shadow_corner_radius(render_radius),
+                ring_mix,
+                damage,
+            )?;
             draw_shader_circle(
                 frame,
                 st,

--- a/crates/halley-wl/src/render/shaders/window_shadow.frag
+++ b/crates/halley-wl/src/render/shaders/window_shadow.frag
@@ -23,14 +23,14 @@ void main() {
     vec2 caster = max(caster_size, vec2(1.0));
     float radius = min(max(corner_radius, 0.0), min(caster.x, caster.y) * 0.5);
 
-    // The shadow quad is padded and may be offset from the real window/caster.
-    // Measure the rounded-rect SDF from the actual caster center inside the quad,
-    // not from rect_size * 0.5, otherwise offset shadows expose their padded bounds.
+    // The shadow quad is padded and placed according to the shadow offset.
+    // The caster center is now correctly centered in the quad.
     vec2 p = v_coords * size - caster_center;
     float dist = rounded_rect_sdf(p, caster, radius);
 
     float blur = max(shadow_radius, 1.0);
     float outset = max(spread, 0.0);
+    // Expanding the fade slightly makes the shadow tail look more natural
     float fade_end = outset + blur * 3.0;
 
     // Only the outside falloff matters for the visible shadow. The window itself
@@ -40,8 +40,12 @@ void main() {
         discard;
     }
 
-    float falloff = 1.0 - smoothstep(outset, fade_end, outside_dist);
-    falloff = pow(clamp(falloff, 0.0, 1.0), 1.6);
+    // A Gaussian-like or exponential falloff looks much better than smoothstep (which is an S-curve).
+    // Shadows should drop off quickly near the caster and have a long, soft tail.
+    float t = clamp((outside_dist - outset) / (fade_end - outset), 0.0, 1.0);
+    
+    // A simple approximation for a soft, natural tail:
+    float falloff = pow(1.0 - t, 2.5);
 
     float a = shadow_color.a * alpha * falloff;
 

--- a/crates/halley-wl/src/render/shaders/window_shadow.frag
+++ b/crates/halley-wl/src/render/shaders/window_shadow.frag
@@ -1,0 +1,57 @@
+precision highp float;
+//_DEFINES
+
+varying vec2 v_coords;
+uniform sampler2D tex;
+uniform float alpha;
+uniform vec2 rect_size;
+uniform vec2 caster_size;
+uniform vec2 caster_center;
+uniform float corner_radius;
+uniform float spread;
+uniform float shadow_radius;
+uniform vec4 shadow_color;
+
+float rounded_rect_sdf(vec2 p, vec2 size, float radius) {
+    vec2 half_size = size * 0.5;
+    vec2 q = abs(p) - (half_size - vec2(radius));
+    return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
+}
+
+void main() {
+    vec2 size = max(rect_size, vec2(1.0));
+    vec2 caster = max(caster_size, vec2(1.0));
+    float radius = min(max(corner_radius, 0.0), min(caster.x, caster.y) * 0.5);
+
+    // The shadow quad is padded and may be offset from the real window/caster.
+    // Measure the rounded-rect SDF from the actual caster center inside the quad,
+    // not from rect_size * 0.5, otherwise offset shadows expose their padded bounds.
+    vec2 p = v_coords * size - caster_center;
+    float dist = rounded_rect_sdf(p, caster, radius);
+
+    float blur = max(shadow_radius, 1.0);
+    float outset = max(spread, 0.0);
+    float fade_end = outset + blur * 3.0;
+
+    // Only the outside falloff matters for the visible shadow. The window itself
+    // covers the inner region, but keeping this stable avoids odd edge behavior.
+    float outside_dist = max(dist, 0.0);
+    if (outside_dist >= fade_end) {
+        discard;
+    }
+
+    float falloff = 1.0 - smoothstep(outset, fade_end, outside_dist);
+    falloff = pow(clamp(falloff, 0.0, 1.0), 1.6);
+
+    float a = shadow_color.a * alpha * falloff;
+
+    // Kill tiny fringe values. On bright wallpapers, very low-alpha tinted pixels
+    // can read as a visible halo/bounds rectangle even when the math reaches 0.
+    if (a <= 0.003) {
+        discard;
+    }
+
+    // Output premultiplied RGB so colored/tinted shadows do not leak color in the
+    // transparent tail of the blur. This is the important anti-halo bit.
+    gl_FragColor = vec4(shadow_color.rgb * a, a);
+}

--- a/crates/halley-wl/src/render/shadow.rs
+++ b/crates/halley-wl/src/render/shadow.rs
@@ -58,12 +58,12 @@ pub(crate) fn draw_shadow_rect(
         (0.0, 0.0).into(),
         (tex_size.w as f64, tex_size.h as f64).into(),
     );
-    // Position of the actual caster/window inside the padded shadow quad.
-    // This keeps the shader's rounded-rect SDF aligned even when the shadow
-    // has a non-zero offset.
+    // Position of the shadow inside the padded shadow quad.
+    // The quad `dst` is already offset on the screen, so placing the shadow
+    // in the center of `dst` will naturally result in an offset shadow.
     let caster_center = (
-        (rect.loc.x - dst.loc.x) as f32 + rect.size.w as f32 * 0.5,
-        (rect.loc.y - dst.loc.y) as f32 + rect.size.h as f32 * 0.5,
+        pad as f32 + rect.size.w as f32 * 0.5,
+        pad as f32 + rect.size.h as f32 * 0.5,
     );
 
     let uniforms = [

--- a/crates/halley-wl/src/render/shadow.rs
+++ b/crates/halley-wl/src/render/shadow.rs
@@ -1,0 +1,98 @@
+use halley_config::ShadowLayerConfig;
+use smithay::{
+    backend::renderer::{
+        Texture,
+        gles::{GlesError, GlesFrame, Uniform},
+    },
+    utils::{Buffer, Physical, Rectangle, Transform},
+};
+
+use crate::render::state::RenderState;
+
+pub(crate) fn draw_shadow_rect(
+    frame: &mut GlesFrame<'_, '_>,
+    render_state: &RenderState,
+    config: ShadowLayerConfig,
+    rect: Rectangle<i32, Physical>,
+    corner_radius: f32,
+    alpha: f32,
+    damage: Rectangle<i32, Physical>,
+) -> Result<(), GlesError> {
+    if !config.enabled
+        || config.color.a <= 0.0
+        || config.blur_radius <= 0.0
+        || alpha <= 0.0
+        || rect.size.w <= 0
+        || rect.size.h <= 0
+    {
+        return Ok(());
+    }
+
+    let Some(texture) = render_state.gpu.node_circle_texture.as_ref() else {
+        return Ok(());
+    };
+    let Some(program) = render_state.gpu.window_shadow_program.as_ref() else {
+        return Ok(());
+    };
+
+    let blur_radius = config.blur_radius.max(0.0);
+    let spread = config.spread.max(0.0);
+    let falloff_extent = (blur_radius * 3.0).ceil().max(1.0) as i32;
+    let pad = falloff_extent + spread.ceil() as i32 + 2;
+    let offset_x = config.offset_x.round() as i32;
+    let offset_y = config.offset_y.round() as i32;
+    let dst = Rectangle::<i32, Physical>::new(
+        (rect.loc.x + offset_x - pad, rect.loc.y + offset_y - pad).into(),
+        (rect.size.w + pad * 2, rect.size.h + pad * 2).into(),
+    );
+    let Some(visible) = dst.intersection(damage) else {
+        return Ok(());
+    };
+    let local_damage = Rectangle::<i32, Physical>::new(
+        (visible.loc.x - dst.loc.x, visible.loc.y - dst.loc.y).into(),
+        visible.size,
+    );
+
+    let tex_size: smithay::utils::Size<i32, Buffer> = texture.size();
+    let src = Rectangle::<f64, Buffer>::new(
+        (0.0, 0.0).into(),
+        (tex_size.w as f64, tex_size.h as f64).into(),
+    );
+    // Position of the actual caster/window inside the padded shadow quad.
+    // This keeps the shader's rounded-rect SDF aligned even when the shadow
+    // has a non-zero offset.
+    let caster_center = (
+        (rect.loc.x - dst.loc.x) as f32 + rect.size.w as f32 * 0.5,
+        (rect.loc.y - dst.loc.y) as f32 + rect.size.h as f32 * 0.5,
+    );
+
+    let uniforms = [
+        Uniform::new("rect_size", (dst.size.w as f32, dst.size.h as f32)),
+        Uniform::new("caster_size", (rect.size.w as f32, rect.size.h as f32)),
+        Uniform::new("caster_center", caster_center),
+        Uniform::new("corner_radius", corner_radius.max(0.0)),
+        Uniform::new("spread", spread),
+        Uniform::new("shadow_radius", blur_radius),
+        Uniform::new(
+            "shadow_color",
+            (
+                config.color.r.clamp(0.0, 1.0),
+                config.color.g.clamp(0.0, 1.0),
+                config.color.b.clamp(0.0, 1.0),
+                config.color.a.clamp(0.0, 1.0),
+            ),
+        ),
+    ];
+
+    frame.render_texture_from_to(
+        texture,
+        src,
+        dst,
+        &[local_damage],
+        &[],
+        Transform::Normal,
+        alpha.clamp(0.0, 1.0),
+        Some(program),
+        &uniforms,
+    )
+}

--- a/crates/halley-wl/src/render/state/gpu.rs
+++ b/crates/halley-wl/src/render/state/gpu.rs
@@ -14,6 +14,8 @@ pub(crate) struct RenderGpuState {
     pub(crate) ui_rect_square_program_failed: bool,
     pub(crate) window_texture_program: Option<GlesTexProgram>,
     pub(crate) window_texture_program_failed: bool,
+    pub(crate) window_shadow_program: Option<GlesTexProgram>,
+    pub(crate) window_shadow_program_failed: bool,
     pub(crate) surface_clip_program: Option<GlesTexProgram>,
     pub(crate) surface_clip_program_failed: bool,
 }

--- a/crates/halley-wl/src/window/decoration.rs
+++ b/crates/halley-wl/src/window/decoration.rs
@@ -202,3 +202,43 @@ pub(super) fn build_window_border_rects(
 
     rects
 }
+
+pub(super) fn build_window_shadow_rect(
+    st: &Halley,
+    node_id: NodeId,
+    gx: i32,
+    gy: i32,
+    gw: i32,
+    gh: i32,
+    alpha: f32,
+    metrics: WindowDecorationMetrics,
+    fullscreen_on_current_monitor: bool,
+) -> Option<WindowShadowRect> {
+    let shadows = st.runtime.tuning.decorations.shadows.window;
+    if !shadows.enabled
+        || fullscreen_on_current_monitor
+        || shadows.color.a <= 0.0
+        || shadows.blur_radius <= 0.0
+        || alpha <= 0.0
+    {
+        return None;
+    }
+
+    let current_monitor = st.model.monitor_state.current_monitor.as_str();
+    if crate::compositor::workspace::state::maximize_session_target_for_monitor(st, current_monitor)
+        == Some(node_id)
+    {
+        return None;
+    }
+
+    let outer_inset =
+        metrics.primary_border_px + metrics.secondary_gap_px + metrics.secondary_border_px;
+    Some(WindowShadowRect {
+        x: gx - outer_inset,
+        y: gy - outer_inset,
+        w: (gw + outer_inset * 2).max(1),
+        h: (gh + outer_inset * 2).max(1),
+        corner_radius: metrics.secondary_outer_corner_radius_px as f32,
+        alpha,
+    })
+}

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -45,7 +45,10 @@ pub(crate) use capture::{
     prewarm_visible_active_window_offscreen_caches,
 };
 pub(crate) use decoration::active_window_frame_pad_px;
-use decoration::{build_window_border_rects, scaled_window_border_px, window_decoration_metrics};
+use decoration::{
+    build_window_border_rects, build_window_shadow_rect, scaled_window_border_px,
+    window_decoration_metrics,
+};
 use geometry::{
     log_window_render_path, offscreen_visual_crop_and_dst, rect_from_local_geometry, rect4_str,
     rect4f_str, should_draw_resize_overlap_overlay, sync_node_size_from_surface,
@@ -109,9 +112,20 @@ pub(crate) struct OffscreenNodeTexture {
     pub geo_h: f32,
 }
 
+#[derive(Clone)]
+pub(crate) struct WindowShadowRect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+    pub corner_radius: f32,
+    pub alpha: f32,
+}
+
 pub(crate) struct StackWindowDrawUnit {
     pub node_id: NodeId,
     pub draw_order: i32,
+    pub shadow_rects: Vec<WindowShadowRect>,
     pub border_rects: Vec<ActiveBorderRect>,
     pub active_elements: Vec<CroppedClippedSurfaceElement>,
     pub offscreen_textures: Vec<OffscreenNodeTexture>,
@@ -122,6 +136,7 @@ impl StackWindowDrawUnit {
         Self {
             node_id,
             draw_order,
+            shadow_rects: Vec::new(),
             border_rects: Vec::new(),
             active_elements: Vec::new(),
             offscreen_textures: Vec::new(),
@@ -156,6 +171,9 @@ pub(crate) fn collect_active_surfaces(
         smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
     >,
     Vec<StackWindowDrawUnit>,
+    Vec<WindowShadowRect>,
+    Vec<WindowShadowRect>,
+    Vec<WindowShadowRect>,
     Vec<ActiveBorderRect>,
     Vec<ActiveBorderRect>,
     Vec<ActiveBorderRect>,
@@ -229,6 +247,9 @@ pub(crate) fn collect_active_surfaces(
         stack_draw_order_map(&stack_visible_front_to_back)
     };
     let mut stack_window_units: HashMap<NodeId, StackWindowDrawUnit> = HashMap::new();
+    let mut shadow_rects: Vec<WindowShadowRect> = Vec::new();
+    let mut resized_shadow_rects: Vec<WindowShadowRect> = Vec::new();
+    let mut above_fullscreen_shadow_rects: Vec<WindowShadowRect> = Vec::new();
     let mut border_rects: Vec<ActiveBorderRect> = Vec::new();
     let mut resized_border_rects: Vec<ActiveBorderRect> = Vec::new();
     let mut above_fullscreen_border_rects: Vec<ActiveBorderRect> = Vec::new();
@@ -519,6 +540,37 @@ pub(crate) fn collect_active_surfaces(
                 )
             });
         let preserve_visual_margin = false;
+        let window_shadow_rect = build_window_shadow_rect(
+            st,
+            node_id,
+            gx,
+            gy,
+            gw.max(1),
+            gh.max(1),
+            alpha,
+            decoration_metrics,
+            fullscreen_on_current_monitor,
+        );
+        if let Some(shadow_rect) = window_shadow_rect {
+            if stack_render_set.contains(&node_id) {
+                stack_window_units
+                    .entry(node_id)
+                    .or_insert_with(|| {
+                        StackWindowDrawUnit::new(
+                            node_id,
+                            stack_draw_orders.get(&node_id).copied().unwrap_or_default(),
+                        )
+                    })
+                    .shadow_rects
+                    .push(shadow_rect);
+            } else if draw_above_fullscreen_this_node {
+                above_fullscreen_shadow_rects.push(shadow_rect);
+            } else if draw_top_this_node {
+                resized_shadow_rects.push(shadow_rect);
+            } else {
+                shadow_rects.push(shadow_rect);
+            }
+        }
         let window_border_rects = build_window_border_rects(
             st,
             node_id,
@@ -1234,6 +1286,9 @@ pub(crate) fn collect_active_surfaces(
         above_fullscreen_popup_elements,
         node_surface_map,
         stack_window_units,
+        shadow_rects,
+        resized_shadow_rects,
+        above_fullscreen_shadow_rects,
         border_rects,
         resized_border_rects,
         above_fullscreen_border_rects,

--- a/crates/halley-wl/src/window/stack.rs
+++ b/crates/halley-wl/src/window/stack.rs
@@ -234,6 +234,31 @@ pub(super) fn clone_stack_window_unit_for_pose(
     let scale_x = (to_pose.size.x / from_pose.size.x.max(1.0)).max(0.01);
     let scale_y = (to_pose.size.y / from_pose.size.y.max(1.0)).max(0.01);
 
+    let shadow_rects = unit
+        .shadow_rects
+        .iter()
+        .cloned()
+        .map(|mut rect| {
+            let (x, y, w, h) = transform_rect_about_center(
+                rect.x,
+                rect.y,
+                rect.w,
+                rect.h,
+                (from_cx as f32, from_cy as f32),
+                (to_cx as f32, to_cy as f32),
+                scale_x,
+                scale_y,
+            );
+            rect.x = x;
+            rect.y = y;
+            rect.w = w;
+            rect.h = h;
+            rect.corner_radius *= scale_x.min(scale_y);
+            rect.alpha *= to_pose.alpha.clamp(0.0, 1.0);
+            rect
+        })
+        .collect::<Vec<_>>();
+
     let border_rects = unit
         .border_rects
         .iter()
@@ -302,13 +327,14 @@ pub(super) fn clone_stack_window_unit_for_pose(
         })
         .collect::<Vec<_>>();
 
-    if border_rects.is_empty() && offscreen_textures.is_empty() {
+    if shadow_rects.is_empty() && border_rects.is_empty() && offscreen_textures.is_empty() {
         return None;
     }
 
     Some(StackWindowDrawUnit {
         node_id: unit.node_id,
         draw_order: to_pose.draw_order,
+        shadow_rects,
         border_rects,
         active_elements: Vec::new(),
         offscreen_textures,


### PR DESCRIPTION
## Summary

Adds the first pass of shadow support for Halley’s Wayland renderer, with fixes and polish for window and overlay shadow behavior.

## Changes

* Fix `draw_shadow_rect` logic that was canceling out configured shadow offsets.
* Replace `smoothstep` with a softer cubic falloff in `window_shadow.frag` for more natural, diffuse shadows.
* Add the missing shadow to the screenshot menu bar / screenshot overlay.
* Make overlay shadow rendering explicit so only outer overlay shapes cast shadows.
* Prevent internal overlay chips from casting shadows, including:

  * Enter/Esc keycaps
  * input and confirm controls
  * overflow items
  * scrollbars
  * focus-card badges

## Verification

* `cargo fmt`
* `cargo check -p halley-wl`
