### PR TITLE
fix(wl): prevent fullscreen timer frames from advancing camera smoothing and website link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Prevent fullscreen timer frames from advancing camera smoothing on monitors that are still pending presentation by queuing animation-active outputs before non-animation outputs and skipping shared camera-smoothing ticks from fullscreen/direct-scanout timer frames in that case.
+- Fix zoom/pan progress being consumed by invisible fullscreen or game frames, which could cause the next visible frame to jump.
+- Preserve the existing NVIDIA and direct-scanout behavior with no changes to direct scanout, `HALLEY_FORCE_COMPOSED`, `HALLEY_DISABLE_DIRECT_SCANOUT`, sync waits, or frame stats.
+
 ## [v0.2.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <p align="center"><em>Named after Halley's comet — periodic, precise, returning.</em></p>
 
+<p align="center">
+  <a href="https://saltnpepper97.github.io/halley-site/"><strong>Website</strong></a>
+</p>
+
 ![License](https://img.shields.io/badge/license-GPL--3.0--only-blueviolet?style=for-the-badge)
 ![Status](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge)
 ![Wayland](https://img.shields.io/badge/display-Wayland-blue?style=for-the-badge)
@@ -137,111 +141,3 @@ or
 git clone https://github.com/saltnpepper97/halley
 cd halley
 cargo build --release
-```
-
-The compositor binary will be available at `target/release/halley`.
-
-### Display Manager Session
-
-Halley's native session needs to start the tty backend rather than the nested `winit` backend. This repo now ships the assets needed for display managers such as SDDM and LightDM:
-
-- `packaging/wayland-sessions/halley-session`
-- `packaging/wayland-sessions/halley.desktop`
-
-Install them to the standard system locations alongside the compositor binary:
-
-```bash
-sudo install -Dm755 target/release/halley /usr/bin/halley
-sudo install -Dm755 packaging/wayland-sessions/halley-session /usr/bin/halley-session
-sudo install -Dm644 packaging/wayland-sessions/halley.desktop /usr/share/wayland-sessions/halley.desktop
-sudo install -Dm644 packaging/systemd-user/halley.service /usr/lib/systemd/user/halley.service
-sudo install -Dm644 packaging/systemd-user/halley-shutdown.target /usr/lib/systemd/user/halley-shutdown.target
-```
-
-`halley-session` will start `halley.service` when a user systemd instance is available, which makes `graphical-session.target`, `xdg-desktop-autostart.target`, and related user-session units behave correctly under display managers like SDDM. If those units are not installed, the launcher falls back to executing `halley` directly.
-
-After that, `Halley` should appear in Wayland-capable display managers.
-
----
-
-## Default Keybinds
-
-Defaults follow Halley's shipped fresh-config template.
-
-| Category | Keybind | Action |
-|---|---|---|
-| Basic | `Super+Shift+r` | Reload config |
-| Basic | `Super+n` | Toggle state |
-| Basic | `Super+q` | Close focused window |
-| Quit | `Super+Shift+e` | Quit Halley |
-| Zoom | `Super+MouseWheelUp` | Zoom in |
-| Zoom | `Super+MouseWheelDown` | Zoom out |
-| Zoom | `Super+MiddleMouse` | Reset zoom |
-| Move | `Super+Left` | Move node left |
-| Move | `Super+Right` | Move node right |
-| Move | `Super+Up` | Move node up |
-| Move | `Super+Down` | Move node down |
-| Monitor | `Super+Shift+Left` | Focus monitor left |
-| Monitor | `Super+Shift+Right` | Focus monitor right |
-| Monitor | `Super+Shift+Up` | Focus monitor up |
-| Monitor | `Super+Shift+Down` | Focus monitor down |
-| Clusters | `Super+Shift+c` | Enter cluster mode |
-| Clusters | `Super+l` | Cycle cluster layout |
-| Bearings | `Super+z` | Show bearings |
-| Bearings | `Super+Shift+z` | Toggle bearings |
-| Trail | `Super+,` | Trail previous |
-| Trail | `Super+.` | Trail next |
-| Launch | `Super+Return` | Open terminal |
-| Launch | `Super+d` | Launch `fuzzel` |
-| Pointer | `Super+LeftMouse` | Move window |
-| Pointer | `Super+RightMouse` | Resize window |
-| Pointer | `Super+Shift+LeftMouse` | Field jump |
-| Screenshot | `Super+Shift+s` | Open capture menu |
-| Tile | `Super+Left/Right/Up/Down` | Focus tile in that direction |
-| Tile | `Super+Ctrl+Left/Right/Up/Down` | Swap tile in that direction |
-| Stacking | `Super+Left` | Cycle stack forward |
-| Stacking | `Super+Right` | Cycle stack backward |
-| Media | `XF86AudioRaiseVolume` | Raise volume |
-| Media | `XF86AudioLowerVolume` | Lower volume |
-| Media | `XF86AudioMute` | Toggle mute |
-
----
-
-## Configuration
-
-On first launch Halley bootstraps `~/.config/halley/halley.rune` for you from an internal fully documented template, inserting detected tty monitors into the `viewport` section. Normal config precedence is `~/.config/halley/halley.rune`, then `/etc/halley/halley.rune`, then bundled internal defaults.
-
-Handled by `crates/halley-config`. Covers input settings like repeat/focus mode, keybinds, focus ring shape and size, decay threshold, max windows per Field, viewports, autostart programs and much **more**.
-
-## Contributing
-
-View the [contributing](CONTRIBUTING.md) guidelines before making any pull requests
-
----
-
-## Portals To Use
-
-- `xdg-desktop-portal-wlr`
-- `xdg-desktop-portal-gtk`
-
----
-
-## Website
-
-Coming soon. This section will hold the project website link once it is live.
-
----
-
-## Inspirations
-
-- [niri](https://github.com/niri-wm/niri) — for how to do Wayland compositor things in Rust
-- [vxwm](https://codeberg.org/wh1tepearl/vxwm) — for studying some of its eyecandy
-- [hevel](https://sr.ht/~dlm/hevel/) — for zoooooooom
-- [Hyprland](https://github.com/hyprwm/hyprland) — for some config organization and eyecandy
-- [newm](https://github.com/jbuchermn/newm) - Godfather of spatial compositing
-
----
-
-## License
-
-Released under the [**GPL-3.0**](LICENSE) license.

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -204,7 +204,15 @@ fn queue_ready_tty_outputs(
 
     let outputs_ref = outputs.borrow();
     let mut render_order: Vec<_> = outputs_ref.iter().collect();
-    render_order.sort_by_key(|output| output.mode.vrefresh());
+    render_order.sort_by_key(|output| {
+        let animation_active = tty_output_animation_redraw_active(
+            st,
+            pointer_state,
+            output.connector_name.as_str(),
+            now,
+        );
+        (!animation_active, output.mode.vrefresh())
+    });
 
     for output in render_order {
         let output_name = output.connector_name.as_str();
@@ -416,6 +424,17 @@ fn tty_animation_output_ready_for_redraw(
                 output.connector_name.as_str(),
                 now,
             )
+    })
+}
+
+fn tty_due_outputs_include_animation_redraw(
+    st: &Halley,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    due_outputs: &HashSet<String>,
+    now: Instant,
+) -> bool {
+    due_outputs.iter().any(|output_name| {
+        tty_output_animation_redraw_active(st, pointer_state, output_name.as_str(), now)
     })
 }
 
@@ -2230,7 +2249,24 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                         // let the timer continue servicing every due output. Otherwise local
                         // zoom/pan on one monitor can starve unrelated outputs that still need
                         // regular scanout, such as fullscreen video playback.
-                        advance_tty_redraw_frame(st, &pointer_state_for_timer, now, false);
+                        // Do not advance camera smoothing on fullscreen-only timer frames; those
+                        // presents are invisible to the monitor currently animating pan/zoom.
+                        let animation_redraw_active = tty_animation_redraw_active(
+                            st,
+                            &outputs_for_timer,
+                            &pointer_state_for_timer,
+                            now,
+                        );
+                        if !animation_redraw_active
+                            || tty_due_outputs_include_animation_redraw(
+                                st,
+                                &pointer_state_for_timer,
+                                &due_outputs,
+                                now,
+                            )
+                        {
+                            advance_tty_redraw_frame(st, &pointer_state_for_timer, now, false);
+                        }
                         queue_ready_tty_outputs(
                             &outputs_for_timer,
                             &dpms_enabled_for_timer,


### PR DESCRIPTION
- Queue animation-active outputs before non-animation outputs, and keep fullscreen/direct-scanout timer frames from ticking shared camera smoothing for monitors that are still pending presentation.

- This fixes zoom/pan progress being consumed by invisible fullscreen/game frames, which could cause the next visible frame to jump.

- Preserve the existing NVIDIA/direct-scanout behavior: direct scanout, HALLEY_FORCE_COMPOSED, HALLEY_DISABLE_DIRECT_SCANOUT, sync waits, and frame stats are unchanged.

- Add Website link to README.md

Verified:
- cargo fmt --check
- cargo check -p halley-wl
- cargo test -p halley-wl compositor::monitor::camera --lib