### PR TITLE
fix(halley-wl): smooth focus, activation, fullscreen, tty redraw, and dialog behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Keep fullscreen video timer frames from delaying ready pan/zoom redraws on other monitors by including animation-active outputs in tty timer redraw eligibility before servicing video scanout.
 - Stop valid `xdg-activation` requests from revealing or panning existing windows, preventing Steam cover clicks from recentring the Steam window.
 - Prevent close-focus restore from panning toward a fullscreen-displaced window while a fullscreen app is closing, so exiting games restores the previous window without flinging the viewport past it.
 - Make `input.focus-mode "hover"` focus collapsed surface nodes when the pointer hovers them, so close-window actions target the hovered node instead of the previously focused window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Make `input.focus-mode "hover"` focus collapsed surface nodes when the pointer hovers them, so close-window actions target the hovered node instead of the previously focused window.
 - Prevent fullscreen timer frames from advancing camera smoothing on monitors that are still pending presentation by queuing animation-active outputs before non-animation outputs and skipping shared camera-smoothing ticks from fullscreen/direct-scanout timer frames in that case.
 - Fix zoom/pan progress being consumed by invisible fullscreen or game frames, which could cause the next visible frame to jump.
 - Preserve the existing NVIDIA and direct-scanout behavior with no changes to direct scanout, `HALLEY_FORCE_COMPOSED`, `HALLEY_DISABLE_DIRECT_SCANOUT`, sync waits, or frame stats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Treat XDG modal/transient dialogs as floating overlap windows by default, centering them over their parent window when available or the viewport otherwise.
 - Keep fullscreen video timer frames from delaying ready pan/zoom redraws on other monitors by including animation-active outputs in tty timer redraw eligibility before servicing video scanout.
 - Stop valid `xdg-activation` requests from revealing or panning existing windows, preventing Steam cover clicks from recentring the Steam window.
 - Prevent close-focus restore from panning toward a fullscreen-displaced window while a fullscreen app is closing, so exiting games restores the previous window without flinging the viewport past it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Prevent close-focus restore from panning toward a fullscreen-displaced window while a fullscreen app is closing, so exiting games restores the previous window without flinging the viewport past it.
 - Make `input.focus-mode "hover"` focus collapsed surface nodes when the pointer hovers them, so close-window actions target the hovered node instead of the previously focused window.
 - Prevent fullscreen timer frames from advancing camera smoothing on monitors that are still pending presentation by queuing animation-active outputs before non-animation outputs and skipping shared camera-smoothing ticks from fullscreen/direct-scanout timer frames in that case.
 - Fix zoom/pan progress being consumed by invisible fullscreen or game frames, which could cause the next visible frame to jump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Stop valid `xdg-activation` requests from revealing or panning existing windows, preventing Steam cover clicks from recentring the Steam window.
 - Prevent close-focus restore from panning toward a fullscreen-displaced window while a fullscreen app is closing, so exiting games restores the previous window without flinging the viewport past it.
 - Make `input.focus-mode "hover"` focus collapsed surface nodes when the pointer hovers them, so close-window actions target the hovered node instead of the previously focused window.
 - Prevent fullscreen timer frames from advancing camera smoothing on monitors that are still pending presentation by queuing animation-active outputs before non-animation outputs and skipping shared camera-smoothing ticks from fullscreen/direct-scanout timer frames in that case.

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -427,13 +427,37 @@ fn tty_animation_output_ready_for_redraw(
     })
 }
 
-fn tty_due_outputs_include_animation_redraw(
+fn tty_ready_animation_redraw_outputs(
+    st: &Halley,
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
+    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    now: Instant,
+) -> HashSet<String> {
+    let outputs_ref = outputs.borrow();
+    let dpms_ref = dpms_enabled.borrow();
+    let pending_ref = output_frame_pending.borrow();
+
+    outputs_ref
+        .iter()
+        .filter_map(|output| {
+            let output_name = output.connector_name.as_str();
+            (dpms_ref.get(output_name).copied().unwrap_or(true)
+                && !pending_ref.get(output_name).copied().unwrap_or(false)
+                && tty_output_animation_redraw_active(st, pointer_state, output_name, now))
+            .then(|| output.connector_name.clone())
+        })
+        .collect()
+}
+
+fn tty_outputs_include_animation_redraw(
     st: &Halley,
     pointer_state: &Rc<RefCell<PointerState>>,
-    due_outputs: &HashSet<String>,
+    output_names: &HashSet<String>,
     now: Instant,
 ) -> bool {
-    due_outputs.iter().any(|output_name| {
+    output_names.iter().any(|output_name| {
         tty_output_animation_redraw_active(st, pointer_state, output_name.as_str(), now)
     })
 }
@@ -2257,11 +2281,22 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             &pointer_state_for_timer,
                             now,
                         );
+                        let mut eligible_outputs = due_outputs.clone();
+                        if animation_redraw_active {
+                            eligible_outputs.extend(tty_ready_animation_redraw_outputs(
+                                st,
+                                &outputs_for_timer,
+                                &dpms_enabled_for_timer,
+                                &output_frame_pending_for_dpms_timer,
+                                &pointer_state_for_timer,
+                                now,
+                            ));
+                        }
                         if !animation_redraw_active
-                            || tty_due_outputs_include_animation_redraw(
+                            || tty_outputs_include_animation_redraw(
                                 st,
                                 &pointer_state_for_timer,
-                                &due_outputs,
+                                &eligible_outputs,
                                 now,
                             )
                         {
@@ -2282,7 +2317,7 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                             st,
                             now,
                             resize_preview,
-                            Some(&due_outputs),
+                            Some(&eligible_outputs),
                             "timer",
                         );
                     }

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -1,5 +1,7 @@
 mod dpms;
 mod drm;
+mod scheduler;
+mod stats;
 
 use super::*;
 
@@ -16,9 +18,17 @@ use crate::backend::tty::dpms::{
     sync_tty_dpms_state, tty_output_dpms_enabled, wake_tty_dpms_on_input,
 };
 use crate::backend::tty::drm::{
-    TtyDrmDevice, TtyDrmOutput, TtyFrameQueueReport, TtyGpuManager, TtyOutputCaptureBackend,
+    TtyDrmDevice, TtyDrmOutput, TtyGpuManager, TtyOutputCaptureBackend,
     build_tty_dmabuf_output_feedbacks, current_tty_output_signature,
     probe_tty_drm_device_via_session, queue_tty_drm_frame, rebuild_tty_outputs,
+};
+use crate::backend::tty::scheduler::{
+    tty_animation_output_ready_for_redraw, tty_animation_redraw_active,
+    tty_animation_redraw_outputs, tty_due_outputs_for_timer, tty_output_animation_redraw_active,
+    tty_outputs_include_animation_redraw, tty_ready_animation_redraw_outputs,
+};
+use crate::backend::tty::stats::{
+    TtyFrameStats, maybe_log_tty_frame_stats, record_tty_frame_queue,
 };
 use crate::backend::vblank_throttle::VBlankThrottle;
 use crate::compositor::exit_confirm::exit_confirm_controller;
@@ -36,7 +46,6 @@ use smithay::backend::input::{
 const CONFIG_RELOAD_SETTLE_MS: u64 = 100;
 const VBLANK_MISMATCH_LOG_AFTER_MS: u64 = 1_000;
 const PENDING_FRAME_TIMEOUT_MS: u64 = 1_500;
-const FRAME_STATS_LOG_INTERVAL_SECS: u64 = 10;
 
 const HALLEY_X11_DISPLAY_NUM: u32 = 0;
 
@@ -44,39 +53,6 @@ const HALLEY_X11_DISPLAY_NUM: u32 = 0;
 struct VBlankMismatchState {
     first_seen_at: Option<Instant>,
     reported_active: bool,
-}
-
-#[derive(Debug)]
-struct TtyFrameStats {
-    last_report_at: Instant,
-    queued_frames: u64,
-    completed_vblanks: u64,
-    page_flip_timeouts: u64,
-    page_flip_recoveries: u64,
-    vblank_mismatches: u64,
-    direct_scanout_frames: u64,
-    composed_frames: u64,
-    sync_wait_count: u64,
-    sync_wait_total_ns: u128,
-    max_sync_wait: Duration,
-}
-
-impl TtyFrameStats {
-    fn new(now: Instant) -> Self {
-        Self {
-            last_report_at: now,
-            queued_frames: 0,
-            completed_vblanks: 0,
-            page_flip_timeouts: 0,
-            page_flip_recoveries: 0,
-            vblank_mismatches: 0,
-            direct_scanout_frames: 0,
-            composed_frames: 0,
-            sync_wait_count: 0,
-            sync_wait_total_ns: 0,
-            max_sync_wait: Duration::ZERO,
-        }
-    }
 }
 
 fn tty_env_flag(name: &str) -> bool {
@@ -102,79 +78,6 @@ fn drm_vblank_timestamp(metadata: Option<&DrmEventMetadata>) -> Duration {
     }
 
     monotonic_now_duration()
-}
-
-fn record_tty_frame_queue(
-    frame_stats: Option<&Rc<RefCell<TtyFrameStats>>>,
-    report: &TtyFrameQueueReport,
-) {
-    let Some(frame_stats) = frame_stats else {
-        return;
-    };
-    if !report.queued {
-        return;
-    }
-
-    let mut stats = frame_stats.borrow_mut();
-    stats.queued_frames += 1;
-    if report.direct_scanout_active {
-        stats.direct_scanout_frames += 1;
-    }
-    if report.composed {
-        stats.composed_frames += 1;
-    }
-    if let Some(wait) = report.sync_wait {
-        stats.sync_wait_count += 1;
-        stats.sync_wait_total_ns += wait.as_nanos();
-        stats.max_sync_wait = stats.max_sync_wait.max(wait);
-    }
-}
-
-fn maybe_log_tty_frame_stats(
-    frame_stats: Option<&Rc<RefCell<TtyFrameStats>>>,
-    output_frame_pending_since: &Rc<RefCell<HashMap<String, Instant>>>,
-    now: Instant,
-) {
-    let Some(frame_stats) = frame_stats else {
-        return;
-    };
-
-    let mut stats = frame_stats.borrow_mut();
-    if now.saturating_duration_since(stats.last_report_at)
-        < Duration::from_secs(FRAME_STATS_LOG_INTERVAL_SECS)
-    {
-        return;
-    }
-
-    let pending_since = output_frame_pending_since.borrow();
-    let pending_frames = pending_since.len();
-    let max_pending_age = pending_since
-        .values()
-        .map(|queued_at| now.saturating_duration_since(*queued_at))
-        .max()
-        .unwrap_or(Duration::ZERO);
-    let avg_sync_wait = if stats.sync_wait_count == 0 {
-        Duration::ZERO
-    } else {
-        Duration::from_nanos((stats.sync_wait_total_ns / stats.sync_wait_count as u128) as u64)
-    };
-
-    debug!(
-        "tty frame stats: queued={} completed_vblanks={} page_flip_timeouts={} page_flip_recoveries={} vblank_mismatches={} direct_scanout={} composed={} sync_waits={} avg_sync_wait={:?} max_sync_wait={:?} pending_frames={} max_pending_age={:?}",
-        stats.queued_frames,
-        stats.completed_vblanks,
-        stats.page_flip_timeouts,
-        stats.page_flip_recoveries,
-        stats.vblank_mismatches,
-        stats.direct_scanout_frames,
-        stats.composed_frames,
-        stats.sync_wait_count,
-        avg_sync_wait,
-        stats.max_sync_wait,
-        pending_frames,
-        max_pending_age
-    );
-    stats.last_report_at = now;
 }
 
 fn queue_ready_tty_outputs(
@@ -350,164 +253,6 @@ fn release_pending_tty_outputs(
     }
 
     released.len()
-}
-
-fn tty_animation_redraw_active(
-    st: &Halley,
-    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    now: Instant,
-) -> bool {
-    outputs.borrow().iter().any(|output| {
-        tty_output_animation_redraw_active(st, pointer_state, output.connector_name.as_str(), now)
-    })
-}
-
-fn tty_animation_redraw_outputs(
-    st: &Halley,
-    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    now: Instant,
-) -> HashSet<String> {
-    outputs
-        .borrow()
-        .iter()
-        .filter_map(|output| {
-            tty_output_animation_redraw_active(
-                st,
-                pointer_state,
-                output.connector_name.as_str(),
-                now,
-            )
-            .then_some(output.connector_name.clone())
-        })
-        .collect()
-}
-
-fn tty_output_animation_redraw_active(
-    st: &Halley,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    output_name: &str,
-    now: Instant,
-) -> bool {
-    if !pointer_state.borrow().move_anim.is_empty() {
-        return true;
-    }
-
-    crate::frame_loop::tty_output_animation_redraw_state(st, output_name, now).active
-}
-
-fn tty_animation_output_ready_for_redraw(
-    st: &Halley,
-    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
-    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
-    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    now: Instant,
-) -> bool {
-    let outputs_ref = outputs.borrow();
-    let dpms_ref = dpms_enabled.borrow();
-    let pending_ref = output_frame_pending.borrow();
-
-    outputs_ref.iter().any(|output| {
-        dpms_ref
-            .get(output.connector_name.as_str())
-            .copied()
-            .unwrap_or(true)
-            && !pending_ref
-                .get(output.connector_name.as_str())
-                .copied()
-                .unwrap_or(false)
-            && tty_output_animation_redraw_active(
-                st,
-                pointer_state,
-                output.connector_name.as_str(),
-                now,
-            )
-    })
-}
-
-fn tty_ready_animation_redraw_outputs(
-    st: &Halley,
-    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
-    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
-    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    now: Instant,
-) -> HashSet<String> {
-    let outputs_ref = outputs.borrow();
-    let dpms_ref = dpms_enabled.borrow();
-    let pending_ref = output_frame_pending.borrow();
-
-    outputs_ref
-        .iter()
-        .filter_map(|output| {
-            let output_name = output.connector_name.as_str();
-            (dpms_ref.get(output_name).copied().unwrap_or(true)
-                && !pending_ref.get(output_name).copied().unwrap_or(false)
-                && tty_output_animation_redraw_active(st, pointer_state, output_name, now))
-            .then(|| output.connector_name.clone())
-        })
-        .collect()
-}
-
-fn tty_outputs_include_animation_redraw(
-    st: &Halley,
-    pointer_state: &Rc<RefCell<PointerState>>,
-    output_names: &HashSet<String>,
-    now: Instant,
-) -> bool {
-    output_names.iter().any(|output_name| {
-        tty_output_animation_redraw_active(st, pointer_state, output_name.as_str(), now)
-    })
-}
-
-fn tty_due_outputs_for_timer(
-    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
-    active_modes: &Rc<RefCell<HashMap<String, drm_control::Mode>>>,
-    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
-    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
-    output_timer_tick_at: &Rc<RefCell<HashMap<String, Instant>>>,
-    now: Instant,
-) -> HashSet<String> {
-    let outputs_ref = outputs.borrow();
-    let modes_ref = active_modes.borrow();
-    let dpms_ref = dpms_enabled.borrow();
-    let pending_ref = output_frame_pending.borrow();
-    let mut last_tick_ref = output_timer_tick_at.borrow_mut();
-
-    last_tick_ref.retain(|name, _| {
-        outputs_ref
-            .iter()
-            .any(|output| output.connector_name == *name)
-    });
-
-    outputs_ref
-        .iter()
-        .filter_map(|output| {
-            let output_name = output.connector_name.as_str();
-            if !dpms_ref.get(output_name).copied().unwrap_or(true)
-                || pending_ref.get(output_name).copied().unwrap_or(false)
-            {
-                return None;
-            }
-
-            let refresh_hz = modes_ref
-                .get(output_name)
-                .map(|mode| mode.vrefresh() as f64)
-                .or(Some(output.mode.vrefresh() as f64));
-            let interval = frame_interval_for_refresh_hz(refresh_hz);
-            let due = last_tick_ref
-                .get(output_name)
-                .is_none_or(|last| now.saturating_duration_since(*last) >= interval);
-            if !due {
-                return None;
-            }
-
-            last_tick_ref.insert(output.connector_name.clone(), now);
-            Some(output.connector_name.clone())
-        })
-        .collect()
 }
 
 fn advance_tty_redraw_frame(

--- a/crates/halley-wl/src/backend/tty/scheduler.rs
+++ b/crates/halley-wl/src/backend/tty/scheduler.rs
@@ -1,0 +1,169 @@
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use std::time::Instant;
+
+use smithay::reexports::drm::control as drm_control;
+
+use super::drm::TtyDrmOutput;
+use crate::backend::frame_interval_for_refresh_hz;
+use crate::compositor::interaction::PointerState;
+use crate::compositor::root::Halley;
+
+pub(super) fn tty_animation_redraw_active(
+    st: &Halley,
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    now: Instant,
+) -> bool {
+    outputs.borrow().iter().any(|output| {
+        tty_output_animation_redraw_active(st, pointer_state, output.connector_name.as_str(), now)
+    })
+}
+
+pub(super) fn tty_animation_redraw_outputs(
+    st: &Halley,
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    now: Instant,
+) -> HashSet<String> {
+    outputs
+        .borrow()
+        .iter()
+        .filter_map(|output| {
+            tty_output_animation_redraw_active(
+                st,
+                pointer_state,
+                output.connector_name.as_str(),
+                now,
+            )
+            .then_some(output.connector_name.clone())
+        })
+        .collect()
+}
+
+pub(super) fn tty_output_animation_redraw_active(
+    st: &Halley,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    output_name: &str,
+    now: Instant,
+) -> bool {
+    if !pointer_state.borrow().move_anim.is_empty() {
+        return true;
+    }
+
+    crate::frame_loop::tty_output_animation_redraw_state(st, output_name, now).active
+}
+
+pub(super) fn tty_animation_output_ready_for_redraw(
+    st: &Halley,
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
+    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    now: Instant,
+) -> bool {
+    let outputs_ref = outputs.borrow();
+    let dpms_ref = dpms_enabled.borrow();
+    let pending_ref = output_frame_pending.borrow();
+
+    outputs_ref.iter().any(|output| {
+        dpms_ref
+            .get(output.connector_name.as_str())
+            .copied()
+            .unwrap_or(true)
+            && !pending_ref
+                .get(output.connector_name.as_str())
+                .copied()
+                .unwrap_or(false)
+            && tty_output_animation_redraw_active(
+                st,
+                pointer_state,
+                output.connector_name.as_str(),
+                now,
+            )
+    })
+}
+
+pub(super) fn tty_ready_animation_redraw_outputs(
+    st: &Halley,
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
+    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    now: Instant,
+) -> HashSet<String> {
+    let outputs_ref = outputs.borrow();
+    let dpms_ref = dpms_enabled.borrow();
+    let pending_ref = output_frame_pending.borrow();
+
+    outputs_ref
+        .iter()
+        .filter_map(|output| {
+            let output_name = output.connector_name.as_str();
+            (dpms_ref.get(output_name).copied().unwrap_or(true)
+                && !pending_ref.get(output_name).copied().unwrap_or(false)
+                && tty_output_animation_redraw_active(st, pointer_state, output_name, now))
+            .then(|| output.connector_name.clone())
+        })
+        .collect()
+}
+
+pub(super) fn tty_outputs_include_animation_redraw(
+    st: &Halley,
+    pointer_state: &Rc<RefCell<PointerState>>,
+    output_names: &HashSet<String>,
+    now: Instant,
+) -> bool {
+    output_names.iter().any(|output_name| {
+        tty_output_animation_redraw_active(st, pointer_state, output_name.as_str(), now)
+    })
+}
+
+pub(super) fn tty_due_outputs_for_timer(
+    outputs: &Rc<RefCell<Vec<TtyDrmOutput>>>,
+    active_modes: &Rc<RefCell<HashMap<String, drm_control::Mode>>>,
+    dpms_enabled: &Rc<RefCell<HashMap<String, bool>>>,
+    output_frame_pending: &Rc<RefCell<HashMap<String, bool>>>,
+    output_timer_tick_at: &Rc<RefCell<HashMap<String, Instant>>>,
+    now: Instant,
+) -> HashSet<String> {
+    let outputs_ref = outputs.borrow();
+    let modes_ref = active_modes.borrow();
+    let dpms_ref = dpms_enabled.borrow();
+    let pending_ref = output_frame_pending.borrow();
+    let mut last_tick_ref = output_timer_tick_at.borrow_mut();
+
+    last_tick_ref.retain(|name, _| {
+        outputs_ref
+            .iter()
+            .any(|output| output.connector_name == *name)
+    });
+
+    outputs_ref
+        .iter()
+        .filter_map(|output| {
+            let output_name = output.connector_name.as_str();
+            if !dpms_ref.get(output_name).copied().unwrap_or(true)
+                || pending_ref.get(output_name).copied().unwrap_or(false)
+            {
+                return None;
+            }
+
+            let refresh_hz = modes_ref
+                .get(output_name)
+                .map(|mode| mode.vrefresh() as f64)
+                .or(Some(output.mode.vrefresh() as f64));
+            let interval = frame_interval_for_refresh_hz(refresh_hz);
+            let due = last_tick_ref
+                .get(output_name)
+                .is_none_or(|last| now.saturating_duration_since(*last) >= interval);
+            if !due {
+                return None;
+            }
+
+            last_tick_ref.insert(output.connector_name.clone(), now);
+            Some(output.connector_name.clone())
+        })
+        .collect()
+}

--- a/crates/halley-wl/src/backend/tty/stats.rs
+++ b/crates/halley-wl/src/backend/tty/stats.rs
@@ -1,0 +1,116 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+use eventline::debug;
+
+use super::drm::TtyFrameQueueReport;
+
+const FRAME_STATS_LOG_INTERVAL_SECS: u64 = 10;
+
+#[derive(Debug)]
+pub(super) struct TtyFrameStats {
+    last_report_at: Instant,
+    pub(super) queued_frames: u64,
+    pub(super) completed_vblanks: u64,
+    pub(super) page_flip_timeouts: u64,
+    pub(super) page_flip_recoveries: u64,
+    pub(super) vblank_mismatches: u64,
+    direct_scanout_frames: u64,
+    composed_frames: u64,
+    sync_wait_count: u64,
+    sync_wait_total_ns: u128,
+    max_sync_wait: Duration,
+}
+
+impl TtyFrameStats {
+    pub(super) fn new(now: Instant) -> Self {
+        Self {
+            last_report_at: now,
+            queued_frames: 0,
+            completed_vblanks: 0,
+            page_flip_timeouts: 0,
+            page_flip_recoveries: 0,
+            vblank_mismatches: 0,
+            direct_scanout_frames: 0,
+            composed_frames: 0,
+            sync_wait_count: 0,
+            sync_wait_total_ns: 0,
+            max_sync_wait: Duration::ZERO,
+        }
+    }
+}
+
+pub(super) fn record_tty_frame_queue(
+    frame_stats: Option<&Rc<RefCell<TtyFrameStats>>>,
+    report: &TtyFrameQueueReport,
+) {
+    let Some(frame_stats) = frame_stats else {
+        return;
+    };
+    if !report.queued {
+        return;
+    }
+
+    let mut stats = frame_stats.borrow_mut();
+    stats.queued_frames += 1;
+    if report.direct_scanout_active {
+        stats.direct_scanout_frames += 1;
+    }
+    if report.composed {
+        stats.composed_frames += 1;
+    }
+    if let Some(wait) = report.sync_wait {
+        stats.sync_wait_count += 1;
+        stats.sync_wait_total_ns += wait.as_nanos();
+        stats.max_sync_wait = stats.max_sync_wait.max(wait);
+    }
+}
+
+pub(super) fn maybe_log_tty_frame_stats(
+    frame_stats: Option<&Rc<RefCell<TtyFrameStats>>>,
+    output_frame_pending_since: &Rc<RefCell<HashMap<String, Instant>>>,
+    now: Instant,
+) {
+    let Some(frame_stats) = frame_stats else {
+        return;
+    };
+
+    let mut stats = frame_stats.borrow_mut();
+    if now.saturating_duration_since(stats.last_report_at)
+        < Duration::from_secs(FRAME_STATS_LOG_INTERVAL_SECS)
+    {
+        return;
+    }
+
+    let pending_since = output_frame_pending_since.borrow();
+    let pending_frames = pending_since.len();
+    let max_pending_age = pending_since
+        .values()
+        .map(|queued_at| now.saturating_duration_since(*queued_at))
+        .max()
+        .unwrap_or(Duration::ZERO);
+    let avg_sync_wait = if stats.sync_wait_count == 0 {
+        Duration::ZERO
+    } else {
+        Duration::from_nanos((stats.sync_wait_total_ns / stats.sync_wait_count as u128) as u64)
+    };
+
+    debug!(
+        "tty frame stats: queued={} completed_vblanks={} page_flip_timeouts={} page_flip_recoveries={} vblank_mismatches={} direct_scanout={} composed={} sync_waits={} avg_sync_wait={:?} max_sync_wait={:?} pending_frames={} max_pending_age={:?}",
+        stats.queued_frames,
+        stats.completed_vblanks,
+        stats.page_flip_timeouts,
+        stats.page_flip_recoveries,
+        stats.vblank_mismatches,
+        stats.direct_scanout_frames,
+        stats.composed_frames,
+        stats.sync_wait_count,
+        avg_sync_wait,
+        stats.max_sync_wait,
+        pending_frames,
+        max_pending_age
+    );
+    stats.last_report_at = now;
+}

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -152,6 +152,29 @@ pub(crate) fn focus_or_reveal_surface_node(
     }
 }
 
+pub(crate) fn focus_surface_node_without_reveal(
+    st: &mut Halley,
+    node_id: halley_core::field::NodeId,
+    now: Instant,
+) -> bool {
+    let Some(node) = st.model.field.node(node_id) else {
+        return false;
+    };
+    if node.kind != halley_core::field::NodeKind::Surface {
+        return false;
+    }
+    if node.state == halley_core::field::NodeState::Core {
+        return false;
+    }
+
+    let target_monitor = st.monitor_for_node_or_current(node_id);
+    if st.focused_monitor() != target_monitor {
+        st.focus_monitor_view(target_monitor.as_str(), now);
+    }
+    st.set_interaction_focus(Some(node_id), 30_000, now);
+    true
+}
+
 pub(crate) fn latest_surface_node(st: &Halley) -> Option<halley_core::field::NodeId> {
     st.last_input_surface_node_for_monitor(st.focused_monitor())
         .or_else(|| st.last_input_surface_node())
@@ -808,7 +831,10 @@ pub(crate) fn toggle_node_state(
 
 #[cfg(test)]
 mod tests {
-    use super::{maximize_target_for_monitor, toggle_node_maximize_state, toggle_node_state};
+    use super::{
+        focus_surface_node_without_reveal, maximize_target_for_monitor, toggle_node_maximize_state,
+        toggle_node_state,
+    };
     use crate::compositor::root::Halley;
     use crate::window::active_window_frame_pad_px;
     use smithay::reexports::wayland_server::Display;
@@ -829,6 +855,35 @@ mod tests {
             focus_ring: None,
         }];
         tuning
+    }
+
+    #[test]
+    fn activation_focus_does_not_pan_to_existing_surface() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        let id = st.model.field.spawn_surface(
+            "steam",
+            halley_core::field::Vec2 {
+                x: 1600.0,
+                y: 300.0,
+            },
+            halley_core::field::Vec2 {
+                x: 1400.0,
+                y: 700.0,
+            },
+        );
+        st.assign_node_to_monitor(id, "monitor_a");
+        let before = st.model.viewport.center;
+
+        assert!(focus_surface_node_without_reveal(
+            &mut st,
+            id,
+            Instant::now()
+        ));
+
+        assert_eq!(st.model.focus_state.primary_interaction_focus, Some(id));
+        assert_eq!(st.model.viewport.center, before);
+        assert!(st.input.interaction_state.viewport_pan_anim.is_none());
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -112,6 +112,23 @@ mod tests {
     use halley_core::field::Vec2;
     use smithay::reexports::wayland_server::Display;
 
+    fn single_monitor_tuning() -> halley_config::RuntimeTuning {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.tty_viewports = vec![halley_config::ViewportOutputConfig {
+            connector: "monitor_a".to_string(),
+            enabled: true,
+            offset_x: 0,
+            offset_y: 0,
+            width: 800,
+            height: 600,
+            refresh_rate: None,
+            transform_degrees: 0,
+            vrr: halley_config::ViewportVrrMode::Off,
+            focus_ring: None,
+        }];
+        tuning
+    }
+
     #[test]
     fn overlap_policy_focus_preserves_same_monitor_fullscreen_lock() {
         let mut tuning = halley_config::RuntimeTuning::default();
@@ -211,6 +228,124 @@ mod tests {
             Some(overlap),
             monitor.as_str()
         ));
+    }
+
+    #[test]
+    fn live_overlap_pauses_during_fullscreen_motion() {
+        let mut tuning = single_monitor_tuning();
+        tuning.physics_enabled = false;
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+
+        let a = state.model.field.spawn_surface(
+            "a",
+            Vec2 { x: 200.0, y: 200.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let b = state.model.field.spawn_surface(
+            "b",
+            Vec2 { x: 220.0, y: 220.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        state.assign_node_to_monitor(a, "monitor_a");
+        state.assign_node_to_monitor(b, "monitor_a");
+        let a_before = state.model.field.node(a).expect("a").pos;
+        let b_before = state.model.field.node(b).expect("b").pos;
+        let now = Instant::now();
+        state.model.fullscreen_state.fullscreen_motion.insert(
+            a,
+            crate::compositor::fullscreen::state::FullscreenMotion {
+                from: a_before,
+                to: Vec2 { x: 400.0, y: 300.0 },
+                start_ms: state.now_ms(now),
+                duration_ms: 320,
+            },
+        );
+
+        crate::frame_loop::tick_live_overlap(&mut state);
+
+        assert_eq!(state.model.field.node(a).expect("a").pos, a_before);
+        assert_eq!(state.model.field.node(b).expect("b").pos, b_before);
+    }
+
+    #[test]
+    fn fullscreen_exit_restores_displaced_nodes_after_motion() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut state = Halley::new_for_test(&dh, single_monitor_tuning());
+
+        let fullscreen = state.model.field.spawn_surface(
+            "fullscreen",
+            Vec2 { x: 140.0, y: 150.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let bystander = state.model.field.spawn_surface(
+            "bystander",
+            Vec2 { x: 520.0, y: 280.0 },
+            Vec2 { x: 220.0, y: 160.0 },
+        );
+        state.assign_node_to_monitor(fullscreen, "monitor_a");
+        state.assign_node_to_monitor(bystander, "monitor_a");
+        let _ = state.model.field.set_pinned(bystander, true);
+
+        let fullscreen_pos = state.model.field.node(fullscreen).expect("fullscreen").pos;
+        let bystander_pos = state.model.field.node(bystander).expect("bystander").pos;
+        let bystander_size = state
+            .model
+            .field
+            .node(bystander)
+            .expect("bystander")
+            .intrinsic_size;
+        let now = Instant::now();
+
+        state.enter_xdg_fullscreen(fullscreen, None, now);
+        state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
+
+        if let Some(space) = state.model.monitor_state.monitors.get_mut("monitor_a") {
+            space.viewport.center = Vec2 {
+                x: 1234.0,
+                y: -567.0,
+            };
+            space.camera_target_center = space.viewport.center;
+        }
+
+        assert_ne!(
+            state.model.field.node(bystander).expect("bystander").pos,
+            bystander_pos
+        );
+        assert!(state.model.field.node(bystander).expect("bystander").pinned);
+
+        state.exit_xdg_fullscreen(fullscreen, now + std::time::Duration::from_millis(300));
+        state.input.interaction_state.physics_velocity.insert(
+            bystander,
+            Vec2 {
+                x: 1200.0,
+                y: -800.0,
+            },
+        );
+        state.tick_fullscreen_motion(now + std::time::Duration::from_millis(700));
+
+        assert_eq!(
+            state.model.field.node(fullscreen).expect("fullscreen").pos,
+            fullscreen_pos
+        );
+        let restored_bystander = state.model.field.node(bystander).expect("bystander");
+        assert_eq!(restored_bystander.pos, bystander_pos);
+        assert_eq!(restored_bystander.intrinsic_size, bystander_size);
+        assert!(restored_bystander.pinned);
+        assert!(
+            !state
+                .model
+                .fullscreen_state
+                .fullscreen_restore
+                .contains_key(&bystander)
+        );
+        assert!(
+            !state
+                .input
+                .interaction_state
+                .physics_velocity
+                .contains_key(&bystander)
+        );
     }
 }
 
@@ -378,6 +513,38 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
         );
     }
 
+    fn fullscreen_restore_entries_for_monitor(
+        &self,
+        monitor_name: &str,
+        exclude_node: Option<NodeId>,
+    ) -> Vec<(
+        NodeId,
+        crate::compositor::fullscreen::state::FullscreenSessionEntry,
+    )> {
+        let (monitor_viewport_center, _) = self.fullscreen_monitor_view(monitor_name);
+        self.model
+            .fullscreen_state
+            .fullscreen_restore
+            .iter()
+            .filter(|&(&id, entry)| {
+                if exclude_node == Some(id) {
+                    return false;
+                }
+                let matches_saved_viewport =
+                    (entry.viewport_center.x - monitor_viewport_center.x).abs() < 1.0
+                        && (entry.viewport_center.y - monitor_viewport_center.y).abs() < 1.0;
+                let matches_assigned_monitor = self
+                    .model
+                    .monitor_state
+                    .node_monitor
+                    .get(&id)
+                    .is_some_and(|node_monitor| node_monitor == monitor_name);
+                matches_saved_viewport || matches_assigned_monitor
+            })
+            .map(|(&id, &entry)| (id, entry))
+            .collect()
+    }
+
     fn fullscreen_displaced_target(
         &self,
         pos: Vec2,
@@ -497,21 +664,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
         // Restore all nodes that were displaced when this monitor went fullscreen.
         // We identify bystanders as nodes in fullscreen_restore whose saved
         // viewport_center matches this monitor's viewport center.
-        let (monitor_viewport_center, _) = self.fullscreen_monitor_view(&monitor_name);
-        let restore_entries: Vec<(
-            NodeId,
-            crate::compositor::fullscreen::state::FullscreenSessionEntry,
-        )> = self
-            .model
-            .fullscreen_state
-            .fullscreen_restore
-            .iter()
-            .filter(|(_, entry)| {
-                (entry.viewport_center.x - monitor_viewport_center.x).abs() < 1.0
-                    && (entry.viewport_center.y - monitor_viewport_center.y).abs() < 1.0
-            })
-            .map(|(&id, &entry)| (id, entry))
-            .collect();
+        let restore_entries = self.fullscreen_restore_entries_for_monitor(&monitor_name, None);
 
         for (id, entry) in &restore_entries {
             let _ = self.model.field.set_pinned(*id, false);
@@ -570,6 +723,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
         if let Some(node) = self.model.field.node_mut(id) {
             node.intrinsic_size = entry.intrinsic_size;
         }
+        let _ = self.model.field.sync_active_footprint_to_intrinsic(id);
         if let Some(loc) = entry.bbox_loc {
             self.ui.render_state.cache.bbox_loc.insert(id, loc);
         } else {
@@ -725,6 +879,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
                     pinned: other.pinned,
                 },
             );
+            self.assign_node_to_monitor(other_id, monitor_name.as_str());
             let _ = self.model.field.set_pinned(other_id, false);
             self.queue_fullscreen_motion(
                 other_id,
@@ -779,22 +934,8 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
                 .remove(&monitor_name);
 
             // Restore only bystanders that were displaced for this monitor's fullscreen.
-            let (monitor_viewport_center, _) = self.fullscreen_monitor_view(&monitor_name);
-            let restore_entries: Vec<(
-                NodeId,
-                crate::compositor::fullscreen::state::FullscreenSessionEntry,
-            )> = self
-                .model
-                .fullscreen_state
-                .fullscreen_restore
-                .iter()
-                .filter(|&(&other_id, ref entry)| {
-                    other_id != id
-                        && (entry.viewport_center.x - monitor_viewport_center.x).abs() < 1.0
-                        && (entry.viewport_center.y - monitor_viewport_center.y).abs() < 1.0
-                })
-                .map(|(&other_id, &entry)| (other_id, entry))
-                .collect();
+            let restore_entries =
+                self.fullscreen_restore_entries_for_monitor(&monitor_name, Some(id));
 
             let now_ms = self.now_ms(now);
             for (other_id, entry) in restore_entries {
@@ -859,12 +1000,16 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             };
             let _ = self.model.field.carry(id, pos);
             if t >= 1.0 {
-                finished.push(id);
+                finished.push((id, motion));
             }
         }
 
-        for id in finished {
+        for (id, motion) in finished {
             self.model.fullscreen_state.fullscreen_motion.remove(&id);
+            if let Some(node) = self.model.field.node_mut(id) {
+                node.pos = motion.to;
+            }
+            self.input.interaction_state.physics_velocity.remove(&id);
             if let Some(entry) = self
                 .model
                 .fullscreen_state

--- a/crates/halley-wl/src/compositor/spawn/rules.rs
+++ b/crates/halley-wl/src/compositor/spawn/rules.rs
@@ -98,11 +98,13 @@ pub(crate) fn resolve_initial_window_intent_for_surface(
     surface: &WlSurface,
 ) -> InitialWindowIntent {
     let root = surface_tree_root(surface);
+    let is_dialog = surface_is_xdg_dialog(&root);
     resolve_initial_window_intent_from_identity(
         st,
         surface_app_id(&root),
         surface_title(&root),
         parent_node_for_surface(st, &root),
+        is_dialog,
     )
 }
 
@@ -111,15 +113,16 @@ pub(crate) fn resolve_initial_window_intent_from_identity(
     app_id: Option<String>,
     title: Option<String>,
     parent_node: Option<NodeId>,
+    is_dialog: bool,
 ) -> InitialWindowIntent {
-    let rule = matching_window_rule(st, app_id.as_deref(), title.as_deref());
+    let rule = matching_window_rule(st, app_id.as_deref(), title.as_deref(), is_dialog);
     InitialWindowIntent {
         app_id,
         title,
         parent_node,
         rule: rule.unwrap_or_default(),
         matched_rule: rule.is_some(),
-        is_transient: parent_node.is_some(),
+        is_transient: parent_node.is_some() || is_dialog,
         prefer_app_intent: rule
             .is_some_and(|rule| matches!(rule.spawn_placement, InitialWindowSpawnPlacement::App)),
     }
@@ -201,7 +204,12 @@ fn matching_user_window_rule<'a>(
 fn matching_builtin_window_rule(
     app_id: Option<&str>,
     title: Option<&str>,
+    is_dialog: bool,
 ) -> Option<ResolvedInitialWindowRule> {
+    if is_dialog {
+        return Some(builtin_float_center_overlap_rule());
+    }
+
     if app_id == Some("xdg-desktop-portal-gtk") && title.is_some_and(portal_dialog_title_matches) {
         return Some(builtin_float_center_overlap_rule());
     }
@@ -217,10 +225,11 @@ fn matching_window_rule(
     st: &Halley,
     app_id: Option<&str>,
     title: Option<&str>,
+    is_dialog: bool,
 ) -> Option<ResolvedInitialWindowRule> {
     matching_user_window_rule(st, app_id, title)
         .map(rule_match)
-        .or_else(|| matching_builtin_window_rule(app_id, title))
+        .or_else(|| matching_builtin_window_rule(app_id, title, is_dialog))
 }
 
 fn builtin_window_rule_may_match_later(app_id: Option<&str>, title: Option<&str>) -> bool {
@@ -240,6 +249,18 @@ fn parent_node_for_surface(st: &Halley, surface: &WlSurface) -> Option<NodeId> {
             })
     })?;
     st.model.surface_to_node.get(&parent_surface.id()).copied()
+}
+
+fn surface_is_xdg_dialog(surface: &WlSurface) -> bool {
+    with_states(surface, |states| {
+        states
+            .data_map
+            .get::<XdgToplevelSurfaceData>()
+            .is_some_and(|data| {
+                let guard = data.lock().expect("xdg toplevel surface data");
+                guard.modal || guard.parent.is_some()
+            })
+    })
 }
 
 fn surface_tree_root(surface: &WlSurface) -> WlSurface {
@@ -308,7 +329,7 @@ mod tests {
         ];
         let state = Halley::new_for_test(&dh, tuning);
 
-        let matched = matching_window_rule(&state, Some("firefox"), None).expect("match");
+        let matched = matching_window_rule(&state, Some("firefox"), None, false).expect("match");
         assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
         assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
     }
@@ -327,7 +348,7 @@ mod tests {
         let state = Halley::new_for_test(&dh, tuning);
 
         let matched =
-            matching_window_rule(&state, None, Some("Picture-in-Picture")).expect("match");
+            matching_window_rule(&state, None, Some("Picture-in-Picture"), false).expect("match");
         assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
     }
 
@@ -345,7 +366,7 @@ mod tests {
         let state = Halley::new_for_test(&dh, tuning);
 
         let matched =
-            matching_window_rule(&state, None, Some("Picture-in-Picture")).expect("match");
+            matching_window_rule(&state, None, Some("Picture-in-Picture"), false).expect("match");
         assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::None);
         assert_eq!(
             matched.spawn_placement,
@@ -362,9 +383,13 @@ mod tests {
         let dh = Display::<Halley>::new().expect("display").handle();
         let state = Halley::new_for_test(&dh, RuntimeTuning::default());
 
-        let matched =
-            matching_window_rule(&state, Some("xdg-desktop-portal-gtk"), Some("Open File"))
-                .expect("match");
+        let matched = matching_window_rule(
+            &state,
+            Some("xdg-desktop-portal-gtk"),
+            Some("Open File"),
+            false,
+        )
+        .expect("match");
         assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
         assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
         assert_eq!(
@@ -379,7 +404,7 @@ mod tests {
         let state = Halley::new_for_test(&dh, RuntimeTuning::default());
 
         let matched =
-            matching_window_rule(&state, None, Some("Picture-in-Picture")).expect("match");
+            matching_window_rule(&state, None, Some("Picture-in-Picture"), false).expect("match");
         assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
         assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
         assert_eq!(
@@ -424,7 +449,50 @@ mod tests {
         }];
         let state = Halley::new_for_test(&dh, tuning);
 
-        assert!(matching_window_rule(&state, None, Some("File Upload - Firefox")).is_some());
+        assert!(matching_window_rule(&state, None, Some("File Upload - Firefox"), false).is_some());
+    }
+
+    #[test]
+    fn builtin_xdg_dialogs_float_center_and_overlap() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let state = Halley::new_for_test(&dh, RuntimeTuning::default());
+
+        let matched = matching_window_rule(&state, Some("steam"), Some("Properties"), true)
+            .expect("dialog rule");
+
+        assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
+        assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
+        assert_eq!(
+            matched.cluster_participation,
+            InitialWindowClusterParticipation::Float
+        );
+    }
+
+    #[test]
+    fn user_rule_overrides_builtin_xdg_dialog_behavior() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut tuning = RuntimeTuning::default();
+        tuning.window_rules = vec![WindowRule {
+            app_ids: vec![WindowRulePattern::Exact("steam".to_string())],
+            titles: Vec::new(),
+            overlap_policy: InitialWindowOverlapPolicy::None,
+            spawn_placement: InitialWindowSpawnPlacement::Adjacent,
+            cluster_participation: InitialWindowClusterParticipation::Layout,
+        }];
+        let state = Halley::new_for_test(&dh, tuning);
+
+        let matched = matching_window_rule(&state, Some("steam"), Some("Properties"), true)
+            .expect("user rule");
+
+        assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::None);
+        assert_eq!(
+            matched.spawn_placement,
+            InitialWindowSpawnPlacement::Adjacent
+        );
+        assert_eq!(
+            matched.cluster_participation,
+            InitialWindowClusterParticipation::Layout
+        );
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
@@ -110,7 +110,8 @@ pub(crate) fn on_toplevel_destroyed(ctx: &mut SurfaceLifecycleCtx<'_>, surface: 
         && let (Some(closing_id), Some(focused_monitor)) = (closing_id, focused_monitor.as_deref())
     {
         let now = Instant::now();
-        let suppress_restore_pan = st.node_has_overlap_policy(closing_id);
+        let suppress_restore_pan =
+            st.node_has_overlap_policy(closing_id) || st.is_fullscreen_active(closing_id);
         if let Some(cid) = st.active_cluster_workspace_for_monitor(focused_monitor) {
             if matches!(
                 st.runtime.tuning.cluster_layout_kind(),

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
@@ -311,6 +311,15 @@ pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
     if let Some(node_id) = st.model.surface_to_node.get(&root_key).copied() {
         st.ui.render_state.mark_window_offscreen_dirty(node_id);
         refresh_node_identity_for_surface(st, &root_surface, "Window");
+        if st
+            .model
+            .fullscreen_state
+            .fullscreen_restore
+            .contains_key(&node_id)
+            && !st.is_fullscreen_active(node_id)
+        {
+            return;
+        }
         use smithay::desktop::utils::bbox_from_surface_tree;
         use smithay::wayland::shell::xdg::SurfaceCachedState;
 

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -751,9 +751,9 @@ mod tests {
 
     #[test]
     fn edge_pan_screen_speed_slows_down_when_zoomed_in() {
-        assert!((drag_edge_pan_screen_speed_pxps(0.5) - 132.0).abs() < 0.01);
-        assert!((drag_edge_pan_screen_speed_pxps(1.0) - 132.0).abs() < 0.01);
-        assert!((drag_edge_pan_screen_speed_pxps(1.25) - 105.6).abs() < 0.01);
+        assert!((drag_edge_pan_screen_speed_pxps(0.5) - 240.0).abs() < 0.01);
+        assert!((drag_edge_pan_screen_speed_pxps(1.0) - 240.0).abs() < 0.01);
+        assert!((drag_edge_pan_screen_speed_pxps(1.25) - 192.0).abs() < 0.01);
     }
 
     #[test]

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -435,6 +435,8 @@ pub(crate) fn tick_live_overlap(st: &mut Halley) {
     if st.input.interaction_state.suspend_state_checks
         || st.input.interaction_state.resize_active.is_some()
         || crate::compositor::workspace::state::maximize_animation_active(st)
+        || !st.model.fullscreen_state.fullscreen_motion.is_empty()
+        || !st.model.fullscreen_state.fullscreen_scale_anim.is_empty()
     {
         return;
     }

--- a/crates/halley-wl/src/input/pointer/focus/policy.rs
+++ b/crates/halley-wl/src/input/pointer/focus/policy.rs
@@ -26,13 +26,16 @@ pub(crate) fn apply_hover_focus_mode(
     let Some(node) = st.model.field.node(hit.node_id) else {
         return;
     };
-    if node.kind != halley_core::field::NodeKind::Surface
-        || !st.model.field.is_visible(hit.node_id)
-        || !matches!(
-            node.state,
-            halley_core::field::NodeState::Active | halley_core::field::NodeState::Drifting
-        )
+    if node.kind != halley_core::field::NodeKind::Surface || !st.model.field.is_visible(hit.node_id)
     {
+        return;
+    }
+    if !matches!(
+        node.state,
+        halley_core::field::NodeState::Active
+            | halley_core::field::NodeState::Drifting
+            | halley_core::field::NodeState::Node
+    ) {
         return;
     }
 

--- a/crates/halley-wl/src/input/pointer/motion/tests.rs
+++ b/crates/halley-wl/src/input/pointer/motion/tests.rs
@@ -53,6 +53,51 @@ fn hover_focus_mode_focuses_hovered_surface() {
 }
 
 #[test]
+fn hover_focus_mode_focuses_hovered_collapsed_surface_node() {
+    let dh = Display::<Halley>::new().expect("display").handle();
+    let mut tuning = single_monitor_tuning();
+    tuning.input.focus_mode = InputFocusMode::Hover;
+    let mut st = Halley::new_for_test(&dh, tuning);
+
+    let active = st.model.field.spawn_surface(
+        "active",
+        halley_core::field::Vec2 { x: 100.0, y: 100.0 },
+        halley_core::field::Vec2 { x: 320.0, y: 240.0 },
+    );
+    let collapsed = st.model.field.spawn_surface(
+        "collapsed",
+        halley_core::field::Vec2 { x: 500.0, y: 100.0 },
+        halley_core::field::Vec2 { x: 320.0, y: 240.0 },
+    );
+    st.assign_node_to_monitor(active, "monitor_a");
+    st.assign_node_to_monitor(collapsed, "monitor_a");
+    st.model
+        .field
+        .set_state(collapsed, halley_core::field::NodeState::Node);
+    st.set_interaction_focus(Some(active), 30_000, Instant::now());
+
+    super::focus::apply_hover_focus_mode(
+        &mut st,
+        Some(HitNode {
+            node_id: collapsed,
+            move_surface: false,
+            is_core: false,
+        }),
+        false,
+        Instant::now(),
+    );
+
+    assert_eq!(
+        st.model.focus_state.primary_interaction_focus,
+        Some(collapsed)
+    );
+    assert_eq!(
+        st.last_focused_surface_node_for_monitor("monitor_a"),
+        Some(collapsed)
+    );
+}
+
+#[test]
 fn click_focus_mode_keeps_hover_focus_disabled() {
     let dh = Display::<Halley>::new().expect("display").handle();
     let mut st = Halley::new_for_test(&dh, single_monitor_tuning());

--- a/crates/halley-wl/src/overlay/mod.rs
+++ b/crates/halley-wl/src/overlay/mod.rs
@@ -2,13 +2,11 @@ mod cluster_bloom;
 mod cluster_naming;
 mod screenshot;
 mod state;
+mod style;
 mod view;
 
 use std::error::Error;
 
-use halley_config::{
-    OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning, ShadowLayerConfig,
-};
 use smithay::{
     backend::renderer::{
         Color32F, Texture,
@@ -36,6 +34,13 @@ pub(crate) use state::{
     ClusterBloomAnimSnapshot, ClusterBloomAnimState, ExitConfirmOverlaySnapshot,
     ExitConfirmOverlayState, OverlayActionHint, OverlayBannerSnapshot, OverlayBannerState,
     OverlayToastSnapshot, OverlayToastState,
+};
+#[cfg(test)]
+use style::color_luminance;
+pub(crate) use style::overlay_fill_and_text_colors;
+use style::{
+    OverlayVisuals, overlay_accent_fill, overlay_text_color_for_fill, overlay_text_mix,
+    resolve_overlay_visuals,
 };
 pub(crate) use view::OverlayView;
 
@@ -82,180 +87,6 @@ const OVERFLOW_SCROLLBAR_PAD: i32 = 6;
 const OVERFLOW_REVEAL_ANIM_MS: u64 = 220;
 const OVERFLOW_REVEAL_SLIDE_PX: i32 = 28;
 const EXIT_CONFIRM_TITLE: &str = "Are you sure you want to leave?";
-
-#[derive(Clone, Copy)]
-struct OverlayRgb {
-    r: f32,
-    g: f32,
-    b: f32,
-}
-
-impl OverlayRgb {
-    fn alpha(self, alpha: f32) -> Color32F {
-        Color32F::new(self.r, self.g, self.b, alpha)
-    }
-
-    fn mix(self, other: Self, amount: f32) -> Self {
-        let t = amount.clamp(0.0, 1.0);
-        Self {
-            r: self.r + (other.r - self.r) * t,
-            g: self.g + (other.g - self.g) * t,
-            b: self.b + (other.b - self.b) * t,
-        }
-    }
-
-    fn luminance(self) -> f32 {
-        self.r * 0.2126 + self.g * 0.7152 + self.b * 0.0722
-    }
-}
-
-#[derive(Clone, Copy)]
-struct OverlayPalette {
-    fill: OverlayRgb,
-    text: OverlayRgb,
-    subtext: OverlayRgb,
-    key_fill: OverlayRgb,
-    key_text: OverlayRgb,
-    border: OverlayRgb,
-}
-
-#[derive(Clone, Copy)]
-struct OverlayVisuals {
-    rounded: bool,
-    border_px: f32,
-    shadow: ShadowLayerConfig,
-    palette: OverlayPalette,
-}
-
-const LIGHT_OVERLAY_FILL: OverlayRgb = OverlayRgb {
-    r: 0.92,
-    g: 0.95,
-    b: 0.98,
-};
-const DARK_OVERLAY_FILL: OverlayRgb = OverlayRgb {
-    r: 0.15,
-    g: 0.18,
-    b: 0.22,
-};
-const LIGHT_OVERLAY_TEXT: OverlayRgb = OverlayRgb {
-    r: 0.08,
-    g: 0.10,
-    b: 0.12,
-};
-const DARK_OVERLAY_TEXT: OverlayRgb = OverlayRgb {
-    r: 0.94,
-    g: 0.96,
-    b: 0.98,
-};
-
-fn resolve_overlay_base_background(mode: OverlayColorMode) -> OverlayRgb {
-    match mode {
-        OverlayColorMode::Auto | OverlayColorMode::Light => LIGHT_OVERLAY_FILL,
-        OverlayColorMode::Dark => DARK_OVERLAY_FILL,
-        OverlayColorMode::Fixed { r, g, b } => OverlayRgb { r, g, b },
-    }
-}
-
-fn resolve_overlay_base_text(mode: OverlayColorMode, background: OverlayRgb) -> OverlayRgb {
-    match mode {
-        OverlayColorMode::Auto => {
-            if background.luminance() < 0.45 {
-                DARK_OVERLAY_TEXT
-            } else {
-                LIGHT_OVERLAY_TEXT
-            }
-        }
-        OverlayColorMode::Light => LIGHT_OVERLAY_TEXT,
-        OverlayColorMode::Dark => DARK_OVERLAY_TEXT,
-        OverlayColorMode::Fixed { r, g, b } => OverlayRgb { r, g, b },
-    }
-}
-
-fn resolve_overlay_border_color(tuning: &RuntimeTuning) -> OverlayRgb {
-    let color = match tuning.overlay_style.border_source {
-        OverlayBorderSource::Primary => tuning.decorations.border.color_focused,
-        OverlayBorderSource::Secondary => {
-            if tuning.window_secondary_border_enabled() {
-                tuning.decorations.secondary_border.color_focused
-            } else {
-                tuning.decorations.border.color_focused
-            }
-        }
-    };
-    OverlayRgb {
-        r: color.r,
-        g: color.g,
-        b: color.b,
-    }
-}
-
-fn resolve_overlay_border_width(tuning: &RuntimeTuning) -> f32 {
-    if !tuning.overlay_style.borders {
-        return 0.0;
-    }
-    match tuning.overlay_style.border_source {
-        OverlayBorderSource::Primary => tuning.window_primary_border_size_px() as f32,
-        OverlayBorderSource::Secondary => {
-            if tuning.window_secondary_border_enabled() {
-                tuning.window_secondary_border_size_px() as f32
-            } else {
-                tuning.window_primary_border_size_px() as f32
-            }
-        }
-    }
-}
-
-fn resolve_overlay_visuals(tuning: &RuntimeTuning) -> OverlayVisuals {
-    let fill = resolve_overlay_base_background(tuning.overlay_style.background_color);
-    let text = resolve_overlay_base_text(tuning.overlay_style.text_color, fill);
-    let border = resolve_overlay_border_color(tuning);
-    OverlayVisuals {
-        rounded: matches!(tuning.overlay_style.shape, OverlayShape::Rounded),
-        border_px: resolve_overlay_border_width(tuning),
-        shadow: tuning.decorations.shadows.overlay,
-        palette: OverlayPalette {
-            fill,
-            text,
-            subtext: text.mix(fill, 0.20),
-            key_fill: fill.mix(text, 0.10),
-            key_text: text,
-            border,
-        },
-    }
-}
-
-pub(crate) fn overlay_fill_and_text_colors(tuning: &RuntimeTuning) -> (Color32F, Color32F) {
-    let visuals = resolve_overlay_visuals(tuning);
-    (
-        visuals.palette.fill.alpha(1.0),
-        visuals.palette.text.alpha(1.0),
-    )
-}
-
-fn color_luminance(color: Color32F) -> f32 {
-    color.r() * 0.2126 + color.g() * 0.7152 + color.b() * 0.0722
-}
-
-fn overlay_text_color_for_fill(fill: Color32F, alpha: f32) -> Color32F {
-    if color_luminance(fill) < 0.45 {
-        DARK_OVERLAY_TEXT.alpha(alpha)
-    } else {
-        LIGHT_OVERLAY_TEXT.alpha(alpha)
-    }
-}
-
-fn overlay_accent_fill(visuals: &OverlayVisuals, border_mix: f32, alpha: f32) -> Color32F {
-    visuals
-        .palette
-        .fill
-        .mix(visuals.palette.border, border_mix)
-        .alpha(alpha)
-}
-
-fn overlay_text_mix(mix: f32) -> f32 {
-    let t = ((mix - 0.10) / 0.90).clamp(0.0, 1.0);
-    t * t * (3.0 - 2.0 * t)
-}
 
 fn cluster_overflow_visibility_mix(overlay: &OverlayView<'_>, monitor: &str, now_ms: u64) -> f32 {
     let started_at_ms = overlay

--- a/crates/halley-wl/src/overlay/style.rs
+++ b/crates/halley-wl/src/overlay/style.rs
@@ -1,0 +1,182 @@
+use halley_config::{
+    OverlayBorderSource, OverlayColorMode, OverlayShape, RuntimeTuning, ShadowLayerConfig,
+};
+use smithay::backend::renderer::Color32F;
+
+#[derive(Clone, Copy)]
+pub(crate) struct OverlayRgb {
+    pub(crate) r: f32,
+    pub(crate) g: f32,
+    pub(crate) b: f32,
+}
+
+impl OverlayRgb {
+    pub(crate) fn alpha(self, alpha: f32) -> Color32F {
+        Color32F::new(self.r, self.g, self.b, alpha)
+    }
+
+    pub(crate) fn mix(self, other: Self, amount: f32) -> Self {
+        let t = amount.clamp(0.0, 1.0);
+        Self {
+            r: self.r + (other.r - self.r) * t,
+            g: self.g + (other.g - self.g) * t,
+            b: self.b + (other.b - self.b) * t,
+        }
+    }
+
+    pub(crate) fn luminance(self) -> f32 {
+        self.r * 0.2126 + self.g * 0.7152 + self.b * 0.0722
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct OverlayPalette {
+    pub(crate) fill: OverlayRgb,
+    pub(crate) text: OverlayRgb,
+    pub(crate) subtext: OverlayRgb,
+    pub(crate) key_fill: OverlayRgb,
+    pub(crate) key_text: OverlayRgb,
+    pub(crate) border: OverlayRgb,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct OverlayVisuals {
+    pub(crate) rounded: bool,
+    pub(crate) border_px: f32,
+    pub(crate) shadow: ShadowLayerConfig,
+    pub(crate) palette: OverlayPalette,
+}
+
+const LIGHT_OVERLAY_FILL: OverlayRgb = OverlayRgb {
+    r: 0.92,
+    g: 0.95,
+    b: 0.98,
+};
+const DARK_OVERLAY_FILL: OverlayRgb = OverlayRgb {
+    r: 0.15,
+    g: 0.18,
+    b: 0.22,
+};
+const LIGHT_OVERLAY_TEXT: OverlayRgb = OverlayRgb {
+    r: 0.08,
+    g: 0.10,
+    b: 0.12,
+};
+const DARK_OVERLAY_TEXT: OverlayRgb = OverlayRgb {
+    r: 0.94,
+    g: 0.96,
+    b: 0.98,
+};
+
+fn resolve_overlay_base_background(mode: OverlayColorMode) -> OverlayRgb {
+    match mode {
+        OverlayColorMode::Auto | OverlayColorMode::Light => LIGHT_OVERLAY_FILL,
+        OverlayColorMode::Dark => DARK_OVERLAY_FILL,
+        OverlayColorMode::Fixed { r, g, b } => OverlayRgb { r, g, b },
+    }
+}
+
+fn resolve_overlay_base_text(mode: OverlayColorMode, background: OverlayRgb) -> OverlayRgb {
+    match mode {
+        OverlayColorMode::Auto => {
+            if background.luminance() < 0.45 {
+                DARK_OVERLAY_TEXT
+            } else {
+                LIGHT_OVERLAY_TEXT
+            }
+        }
+        OverlayColorMode::Light => LIGHT_OVERLAY_TEXT,
+        OverlayColorMode::Dark => DARK_OVERLAY_TEXT,
+        OverlayColorMode::Fixed { r, g, b } => OverlayRgb { r, g, b },
+    }
+}
+
+fn resolve_overlay_border_color(tuning: &RuntimeTuning) -> OverlayRgb {
+    let color = match tuning.overlay_style.border_source {
+        OverlayBorderSource::Primary => tuning.decorations.border.color_focused,
+        OverlayBorderSource::Secondary => {
+            if tuning.window_secondary_border_enabled() {
+                tuning.decorations.secondary_border.color_focused
+            } else {
+                tuning.decorations.border.color_focused
+            }
+        }
+    };
+    OverlayRgb {
+        r: color.r,
+        g: color.g,
+        b: color.b,
+    }
+}
+
+fn resolve_overlay_border_width(tuning: &RuntimeTuning) -> f32 {
+    if !tuning.overlay_style.borders {
+        return 0.0;
+    }
+    match tuning.overlay_style.border_source {
+        OverlayBorderSource::Primary => tuning.window_primary_border_size_px() as f32,
+        OverlayBorderSource::Secondary => {
+            if tuning.window_secondary_border_enabled() {
+                tuning.window_secondary_border_size_px() as f32
+            } else {
+                tuning.window_primary_border_size_px() as f32
+            }
+        }
+    }
+}
+
+pub(crate) fn resolve_overlay_visuals(tuning: &RuntimeTuning) -> OverlayVisuals {
+    let fill = resolve_overlay_base_background(tuning.overlay_style.background_color);
+    let text = resolve_overlay_base_text(tuning.overlay_style.text_color, fill);
+    let border = resolve_overlay_border_color(tuning);
+    OverlayVisuals {
+        rounded: matches!(tuning.overlay_style.shape, OverlayShape::Rounded),
+        border_px: resolve_overlay_border_width(tuning),
+        shadow: tuning.decorations.shadows.overlay,
+        palette: OverlayPalette {
+            fill,
+            text,
+            subtext: text.mix(fill, 0.20),
+            key_fill: fill.mix(text, 0.10),
+            key_text: text,
+            border,
+        },
+    }
+}
+
+pub(crate) fn overlay_fill_and_text_colors(tuning: &RuntimeTuning) -> (Color32F, Color32F) {
+    let visuals = resolve_overlay_visuals(tuning);
+    (
+        visuals.palette.fill.alpha(1.0),
+        visuals.palette.text.alpha(1.0),
+    )
+}
+
+pub(crate) fn color_luminance(color: Color32F) -> f32 {
+    color.r() * 0.2126 + color.g() * 0.7152 + color.b() * 0.0722
+}
+
+pub(crate) fn overlay_text_color_for_fill(fill: Color32F, alpha: f32) -> Color32F {
+    if color_luminance(fill) < 0.45 {
+        DARK_OVERLAY_TEXT.alpha(alpha)
+    } else {
+        LIGHT_OVERLAY_TEXT.alpha(alpha)
+    }
+}
+
+pub(crate) fn overlay_accent_fill(
+    visuals: &OverlayVisuals,
+    border_mix: f32,
+    alpha: f32,
+) -> Color32F {
+    visuals
+        .palette
+        .fill
+        .mix(visuals.palette.border, border_mix)
+        .alpha(alpha)
+}
+
+pub(crate) fn overlay_text_mix(mix: f32) -> f32 {
+    let t = ((mix - 0.10) / 0.90).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}

--- a/crates/halley-wl/src/protocol/wayland/activation.rs
+++ b/crates/halley-wl/src/protocol/wayland/activation.rs
@@ -125,7 +125,7 @@ pub(crate) fn request_surface_activation(
 
     if let Some(id) = st.model.surface_to_node.get(&root.id()).copied() {
         let activated =
-            crate::compositor::actions::window::focus_or_reveal_surface_node(st, id, now);
+            crate::compositor::actions::window::focus_surface_node_without_reveal(st, id, now);
         debug!(
             "applied activation request token={} node={} surface={:?} activated={}",
             token,

--- a/crates/halley-wl/src/window/geometry.rs
+++ b/crates/halley-wl/src/window/geometry.rs
@@ -5,9 +5,23 @@ pub(super) fn sync_node_size_from_surface(
     node_id: halley_core::field::NodeId,
     wl: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
 ) -> Rectangle<i32, Logical> {
-    let bbox = snapshot_surface_geometry(st, node_id, wl);
+    let restoring_fullscreen = st
+        .model
+        .fullscreen_state
+        .fullscreen_restore
+        .contains_key(&node_id)
+        && !st.is_fullscreen_active(node_id);
+    let bbox = if restoring_fullscreen {
+        bbox_from_surface_tree(wl, (0, 0))
+    } else {
+        snapshot_surface_geometry(st, node_id, wl)
+    };
 
     if crate::compositor::surface::is_active_cluster_workspace_member(st, node_id) {
+        return bbox;
+    }
+
+    if restoring_fullscreen {
         return bbox;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes several long-standing Halley interaction issues around focus, viewport motion, redraw scheduling, and dialog placement.

The main theme is making focus and motion feel intentional: collapsed nodes can now receive hover focus, existing xdg-activation targets no longer yank the viewport around, fullscreen exit restore no longer fights with close-focus panning, animation redraws are prioritized correctly beside fullscreen video scanout, and dialogs now spawn as centered floating surfaces by default.

## Changes

### Hover focus on collapsed nodes

- Update pointer hover focus policy so visible surface nodes in `Node` state can receive hover focus.
- Previously, hover focus was limited to `Active` or `Drifting` surfaces.
- Add regression coverage proving a hovered collapsed node replaces the previously focused window and becomes the monitor's last focused surface.

### Fullscreen exit restore pan fix

- Suppress close-focus restore panning while the closing window is still the active fullscreen surface.
- Let fullscreen restore motion place displaced windows back without a competing viewport pan toward their temporary offscreen position.
- Prevent exiting games from flinging the viewport past the restored window.

### xdg-activation no longer pans to existing windows

- Route existing xdg-activation targets through `focus_surface_node_without_reveal` instead of `focus_or_reveal_surface_node`.
- The old path could queue a viewport reveal for existing surfaces.
- Large Steam windows hit that reveal case when Steam re-activated itself after clicking a cover, causing the field view to recenter unexpectedly.
- xdg-activation now focuses the target surface without panning, revealing, or centering it.

Changed files:
- `crates/halley-wl/src/protocol/wayland/activation.rs`
- `crates/halley-wl/src/compositor/actions/window.rs`

### TTY redraw scheduling

- Fix tty timer redraw eligibility so ready animation-active outputs can be serviced even when another output is due for fullscreen video scanout.
- Fullscreen YouTube/video could keep its output eligible for regular timer scanout while pan/zoom animation on another monitor waited behind it.
- The render path already prioritizes animation-active outputs once redraw work is queued, but the timer eligibility check could still wake only for the video output.
- Timer redraw eligibility now includes ready animation-active outputs in addition to due video outputs.
- Pan/zoom frames can now queue first through the existing render-order priority.

This does **not** change:
- direct scanout
- `HALLEY_FORCE_COMPOSED`
- `HALLEY_DISABLE_DIRECT_SCANOUT`
- sync waits
- frame stats

Also updates the changelog.

### Dialog spawn behavior

- Detect XDG dialogs from modal toplevel state or parent/transient relationships.
- Apply built-in dialog behavior unless overridden by user rules.
- Dialogs now default to:
  - `overlap-policy=all`
  - `spawn-placement=center`
  - `cluster-participation=float`
- Parented dialogs center over their parent window.
- Unparented dialogs fall back to the viewport center.

## Verification

- `cargo fmt --check`
- `cargo check -p halley-wl`
- `cargo test -p halley-wl input::pointer::motion::tests::hover_focus_mode`
- `cargo test -p halley-wl activation_focus_does_not_pan_to_existing_surface -- --nocapture`
- `cargo test -p halley-wl close_focus -- --nocapture`
- `cargo test -p halley-wl fullscreen_exit_restores_displaced_nodes_after_motion -- --nocapture`
- `cargo test -p halley-wl compositor::monitor::camera --lib`
- `cargo test -p halley-wl compositor::spawn::rules --lib`
- `cargo test -p halley-wl tiled_cluster_layout_participation_honors_layout_and_float --lib`

Full `cargo test -p halley-wl` result:
- 248 passing
- 1 unrelated existing failure:
  - `frame_loop::tests::edge_pan_screen_speed_slows_down_when_zoomed_in`