### PR TITLE
Fix fullscreen game input, presentation timing, popup routing, and spawn-pan edge cases

### DIFF
--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -184,6 +184,7 @@ fn queue_ready_tty_outputs(
                         .remove(output.connector_name.as_str());
                     if source == "timer" {
                         crate::frame_loop::send_frame_callbacks_for_output(st, output_name, now);
+                        crate::frame_loop::send_presentation_feedback_for_output(st, output_name);
                     }
                     continue;
                 }
@@ -201,6 +202,7 @@ fn queue_ready_tty_outputs(
                     .borrow_mut()
                     .insert(output.connector_name.clone(), now);
                 crate::frame_loop::send_frame_callbacks_for_output(st, output_name, now);
+                crate::frame_loop::send_presentation_feedback_for_output(st, output_name);
             }
         }
     }

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -478,6 +478,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                             debug!("draw failed: {}", err);
                         } else {
                             crate::frame_loop::send_frame_callbacks(st, now);
+                            crate::frame_loop::send_presentation_feedback_for_output(st, "winit-0");
                         }
                     }
                     WinitEvent::Resized { size, .. } => {
@@ -521,6 +522,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                             debug!("draw failed: {}", err);
                         } else {
                             crate::frame_loop::send_frame_callbacks(st, now);
+                            crate::frame_loop::send_presentation_feedback_for_output(st, "winit-0");
                         }
                     }
                     WinitEvent::Focus(false) => {

--- a/crates/halley-wl/src/compositor/focus/read.rs
+++ b/crates/halley-wl/src/compositor/focus/read.rs
@@ -375,7 +375,9 @@ pub(crate) fn maybe_pan_to_restored_focus_on_close(
 ) -> bool {
     match focus_read_context(st).close_restore_pan_plan(st, monitor, id) {
         CloseRestorePanPlan::None => false,
-        CloseRestorePanPlan::PanTo(target) => st.animate_viewport_center_to(target, now),
+        CloseRestorePanPlan::PanTo(target) => {
+            st.animate_viewport_center_to_on_monitor(monitor, target, now)
+        }
     }
 }
 

--- a/crates/halley-wl/src/compositor/focus/system.rs
+++ b/crates/halley-wl/src/compositor/focus/system.rs
@@ -356,7 +356,17 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
     }
 
     pub fn animate_viewport_center_to(&mut self, target_center: Vec2, now: Instant) -> bool {
-        self.animate_viewport_center_to_delayed(target_center, now, 0)
+        let monitor = self.model.monitor_state.current_monitor.clone();
+        self.animate_viewport_center_to_on_monitor_delayed(monitor.as_str(), target_center, now, 0)
+    }
+
+    pub fn animate_viewport_center_to_on_monitor(
+        &mut self,
+        monitor: &str,
+        target_center: Vec2,
+        now: Instant,
+    ) -> bool {
+        self.animate_viewport_center_to_on_monitor_delayed(monitor, target_center, now, 0)
     }
 
     pub fn animate_viewport_center_to_delayed(
@@ -365,13 +375,42 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
         now: Instant,
         delay_ms: u64,
     ) -> bool {
-        let from = self.model.viewport.center;
+        let monitor = self.model.monitor_state.current_monitor.clone();
+        self.animate_viewport_center_to_on_monitor_delayed(
+            monitor.as_str(),
+            target_center,
+            now,
+            delay_ms,
+        )
+    }
+
+    pub fn animate_viewport_center_to_on_monitor_delayed(
+        &mut self,
+        monitor: &str,
+        target_center: Vec2,
+        now: Instant,
+        delay_ms: u64,
+    ) -> bool {
+        if !self.model.monitor_state.monitors.contains_key(monitor) {
+            return false;
+        }
+        let from = if self.model.monitor_state.current_monitor == monitor {
+            self.model.viewport.center
+        } else {
+            self.model
+                .monitor_state
+                .monitors
+                .get(monitor)
+                .map(|space| space.viewport.center)
+                .unwrap_or(self.model.viewport.center)
+        };
         let dx = target_center.x - from.x;
         let dy = target_center.y - from.y;
         if dx.abs() < 0.25 && dy.abs() < 0.25 {
             return false;
         }
         self.input.interaction_state.viewport_pan_anim = Some(ViewportPanAnim {
+            monitor: monitor.to_string(),
             start_ms: self.now_ms(now),
             delay_ms,
             duration_ms: Self::VIEWPORT_PAN_DURATION_MS,
@@ -382,13 +421,39 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
     }
 
     pub(crate) fn tick_viewport_pan_animation(&mut self, now_ms: u64) {
-        let Some(anim) = &self.input.interaction_state.viewport_pan_anim else {
+        let Some(anim) = self.input.interaction_state.viewport_pan_anim.clone() else {
             return;
         };
+
+        if !self
+            .model
+            .monitor_state
+            .monitors
+            .contains_key(anim.monitor.as_str())
+        {
+            self.input.interaction_state.viewport_pan_anim = None;
+            return;
+        }
+
+        let set_center = |st: &mut Halley, center: Vec2| {
+            if st.model.monitor_state.current_monitor == anim.monitor {
+                st.model.viewport.center = center;
+                st.model.camera_target_center = center;
+                st.runtime.tuning.viewport_center = center;
+            }
+            if let Some(space) = st
+                .model
+                .monitor_state
+                .monitors
+                .get_mut(anim.monitor.as_str())
+            {
+                space.viewport.center = center;
+                space.camera_target_center = center;
+            }
+        };
+
         if now_ms <= anim.start_ms.saturating_add(anim.delay_ms) {
-            self.model.viewport.center = anim.from_center;
-            self.model.camera_target_center = self.model.viewport.center;
-            self.runtime.tuning.viewport_center = self.model.viewport.center;
+            set_center(self, anim.from_center);
             return;
         }
         let dur = anim.duration_ms.max(1);
@@ -399,12 +464,11 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
         } else {
             1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
         };
-        self.model.viewport.center = Vec2 {
+        let center = Vec2 {
             x: anim.from_center.x + (anim.to_center.x - anim.from_center.x) * e,
             y: anim.from_center.y + (anim.to_center.y - anim.from_center.y) * e,
         };
-        self.model.camera_target_center = self.model.viewport.center;
-        self.runtime.tuning.viewport_center = self.model.viewport.center;
+        set_center(self, center);
         if t >= 1.0 {
             self.input.interaction_state.viewport_pan_anim = None;
         }
@@ -474,6 +538,89 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn two_monitor_tuning() -> halley_config::RuntimeTuning {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.tty_viewports = vec![
+            halley_config::ViewportOutputConfig {
+                connector: "left".to_string(),
+                enabled: true,
+                offset_x: 0,
+                offset_y: 0,
+                width: 800,
+                height: 600,
+                refresh_rate: None,
+                transform_degrees: 0,
+                vrr: halley_config::ViewportVrrMode::Off,
+                focus_ring: None,
+            },
+            halley_config::ViewportOutputConfig {
+                connector: "right".to_string(),
+                enabled: true,
+                offset_x: 800,
+                offset_y: 0,
+                width: 800,
+                height: 600,
+                refresh_rate: None,
+                transform_degrees: 0,
+                vrr: halley_config::ViewportVrrMode::Off,
+                focus_ring: None,
+            },
+        ];
+        tuning
+    }
+
+    #[test]
+    fn viewport_pan_animation_stays_on_origin_monitor_after_monitor_switch() {
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, two_monitor_tuning());
+        let _ = state.activate_monitor("right");
+
+        let left_center = state
+            .model
+            .monitor_state
+            .monitors
+            .get("left")
+            .expect("left monitor")
+            .viewport
+            .center;
+        let target = Vec2 {
+            x: 1500.0,
+            y: 300.0,
+        };
+        let now = Instant::now();
+        assert!(state.animate_viewport_center_to(target, now));
+        assert_eq!(
+            state
+                .input
+                .interaction_state
+                .viewport_pan_anim
+                .as_ref()
+                .map(|anim| anim.monitor.as_str()),
+            Some("right")
+        );
+
+        let _ = state.activate_monitor("left");
+        state.tick_viewport_pan_animation(state.now_ms(now) + 1_000);
+
+        assert_eq!(state.model.viewport.center, left_center);
+        assert_eq!(
+            state
+                .model
+                .monitor_state
+                .monitors
+                .get("right")
+                .expect("right monitor")
+                .viewport
+                .center,
+            target
+        );
+
+        let _ = state.activate_monitor("right");
+        assert_eq!(state.model.viewport.center, target);
+    }
 
     #[test]
     fn last_input_surface_prefers_current_monitor_local_focus() {

--- a/crates/halley-wl/src/compositor/interaction/state.rs
+++ b/crates/halley-wl/src/compositor/interaction/state.rs
@@ -59,7 +59,9 @@ pub(crate) struct NodeMoveAnim {
     pub(crate) duration: Duration,
 }
 
+#[derive(Clone)]
 pub(crate) struct ViewportPanAnim {
+    pub(crate) monitor: String,
     pub(crate) start_ms: u64,
     pub(crate) delay_ms: u64,
     pub(crate) duration_ms: u64,

--- a/crates/halley-wl/src/compositor/platform.rs
+++ b/crates/halley-wl/src/compositor/platform.rs
@@ -20,6 +20,7 @@ use smithay::{
         idle_notify::IdleNotifierState,
         output::OutputManagerState,
         pointer_constraints::PointerConstraintsState,
+        presentation::PresentationState,
         relative_pointer::RelativePointerManagerState,
         selection::{
             data_device::DataDeviceState, primary_selection::PrimarySelectionState,
@@ -57,6 +58,7 @@ pub(crate) struct PlatformState {
     pub(crate) popup_manager: PopupManager,
     pub(crate) wlr_layer_shell_state: WlrLayerShellState,
     pub(crate) pointer_constraints_state: PointerConstraintsState,
+    pub(crate) presentation_state: PresentationState,
     pub(crate) relative_pointer_manager_state: RelativePointerManagerState,
     pub(crate) idle_notifier_state: IdleNotifierState<Halley>,
     pub(crate) drm_syncobj_state: Option<DrmSyncobjState>,
@@ -169,7 +171,9 @@ pub(crate) fn effective_cursor_image_status(st: &Halley) -> CursorImageStatus {
         .and_then(|pointer| pointer.current_focus())
         .is_some();
 
-    if let Some((_, locked)) = crate::compositor::interaction::pointer::active_constrained_pointer_surface(st) {
+    if let Some((_, locked)) =
+        crate::compositor::interaction::pointer::active_constrained_pointer_surface(st)
+    {
         if locked {
             return CursorImageStatus::Hidden;
         }

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1172,6 +1172,19 @@ impl Halley {
             .animate_viewport_center_to(target_center, now)
     }
 
+    pub fn animate_viewport_center_to_on_monitor(
+        &mut self,
+        monitor: &str,
+        target_center: Vec2,
+        now: Instant,
+    ) -> bool {
+        super::focus::system::focus_system_controller(self).animate_viewport_center_to_on_monitor(
+            monitor,
+            target_center,
+            now,
+        )
+    }
+
     pub fn animate_viewport_center_to_delayed(
         &mut self,
         target_center: Vec2,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -308,6 +308,7 @@ impl Halley {
                     applied_window_rules: HashMap::new(),
                     pending_rule_rechecks: HashSet::new(),
                     pending_initial_reveal: HashSet::new(),
+                    pending_pan_activate: None,
                 },
                 field: Field::new(),
                 viewport: primary_viewport,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -193,6 +193,10 @@ impl Halley {
                 popup_manager: PopupManager::default(),
                 wlr_layer_shell_state: WlrLayerShellState::new::<Halley>(dh),
                 pointer_constraints_state: PointerConstraintsState::new::<Halley>(dh),
+                presentation_state: smithay::wayland::presentation::PresentationState::new::<Halley>(
+                    dh,
+                    <smithay::utils::Monotonic as smithay::utils::ClockSource>::ID as u32,
+                ),
                 relative_pointer_manager_state: RelativePointerManagerState::new::<Halley>(dh),
                 idle_notifier_state: IdleNotifierState::new(dh, loop_handle),
                 drm_syncobj_state: None,

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -157,11 +157,35 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                 continue;
             }
 
+            let prev_monitor = self.model.monitor_state.current_monitor.clone();
+            let needs_monitor_switch = self
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&next.node_id)
+                .is_some_and(|m| *m != prev_monitor);
+
+            if needs_monitor_switch {
+                if let Some(spawn_monitor) = self
+                    .model
+                    .monitor_state
+                    .node_monitor
+                    .get(&next.node_id)
+                    .cloned()
+                {
+                    let _ = self.activate_monitor(spawn_monitor.as_str());
+                }
+            }
+
             let did_pan = self.animate_viewport_center_to_delayed(
                 next.target_center,
                 now,
                 Halley::VIEWPORT_PAN_PRELOAD_MS,
             );
+
+            if needs_monitor_switch {
+                let _ = self.activate_monitor(prev_monitor.as_str());
+            }
             self.model.spawn_state.active_spawn_pan =
                 Some(crate::compositor::spawn::state::ActiveSpawnPan {
                     node_id: next.node_id,

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -186,6 +186,31 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             if needs_monitor_switch {
                 let _ = self.activate_monitor(prev_monitor.as_str());
             }
+
+            let _ = self.model.field.set_detached(next.node_id, false);
+            let _ = self
+                .model
+                .field
+                .set_decay_level(next.node_id, DecayLevel::Hot);
+            if let Some(intrinsic_size) = self.model.field.node(next.node_id).map(|n| n.intrinsic_size)
+            {
+                self.model
+                    .workspace_state
+                    .last_active_size
+                    .insert(next.node_id, intrinsic_size);
+            }
+            let duration_ms = self.runtime.tuning.window_open_duration_ms();
+            if self.runtime.tuning.window_open_animation_enabled() {
+                crate::compositor::workspace::state::mark_active_transition(
+                    &mut **self,
+                    next.node_id,
+                    now,
+                    duration_ms,
+                );
+            }
+            self.record_focus_trail_visit(next.node_id);
+            self.model.focus_state.suppress_trail_record_once = true;
+
             self.model.spawn_state.active_spawn_pan =
                 Some(crate::compositor::spawn::state::ActiveSpawnPan {
                     node_id: next.node_id,
@@ -205,6 +230,15 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
     }
 
     pub(crate) fn tick_pending_spawn_pan(&mut self, now: Instant, now_ms: u64) {
+        if let Some((id, at_ms)) = self.model.spawn_state.pending_pan_activate {
+            if now_ms >= at_ms {
+                self.model.spawn_state.pending_pan_activate = None;
+                if self.model.field.node(id).is_some() {
+                    self.set_interaction_focus(Some(id), 30_000, now);
+                }
+            }
+        }
+
         let Some(active) = self.model.spawn_state.active_spawn_pan else {
             self.maybe_start_pending_spawn_pan(now);
             return;
@@ -223,34 +257,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             return;
         }
 
-        let _ = self.model.field.set_detached(active.node_id, false);
-        let _ = self
-            .model
-            .field
-            .set_decay_level(active.node_id, DecayLevel::Hot);
-        let intrinsic_size = self
-            .model
-            .field
-            .node(active.node_id)
-            .map(|node| node.intrinsic_size);
-        if let Some(intrinsic_size) = intrinsic_size {
-            self.model
-                .workspace_state
-                .last_active_size
-                .insert(active.node_id, intrinsic_size);
-        }
-        let duration_ms = self.runtime.tuning.window_open_duration_ms();
-        if self.runtime.tuning.window_open_animation_enabled() {
-            crate::compositor::workspace::state::mark_active_transition(
-                &mut **self,
-                active.node_id,
-                now,
-                duration_ms,
-            );
-        }
-        self.record_focus_trail_visit(active.node_id);
-        self.model.focus_state.suppress_trail_record_once = true;
-        self.set_interaction_focus(Some(active.node_id), 30_000, now);
+        self.model.spawn_state.pending_pan_activate = Some((active.node_id, now_ms + 16));
         self.model.spawn_state.active_spawn_pan = None;
         self.maybe_start_pending_spawn_pan(now);
     }

--- a/crates/halley-wl/src/compositor/spawn/rules.rs
+++ b/crates/halley-wl/src/compositor/spawn/rules.rs
@@ -108,7 +108,7 @@ pub(crate) fn resolve_initial_window_intent_for_surface(
     )
 }
 
-pub(crate) fn resolve_initial_window_intent_from_identity(
+fn resolve_initial_window_intent_from_identity(
     st: &Halley,
     app_id: Option<String>,
     title: Option<String>,
@@ -168,9 +168,19 @@ fn builtin_float_center_overlap_rule() -> ResolvedInitialWindowRule {
 }
 
 fn portal_dialog_title_matches(title: &str) -> bool {
-    ["File Upload", "Open File", "Save File", "Choose"]
-        .into_iter()
-        .any(|prefix| title.starts_with(prefix))
+    [
+        "File Upload",
+        "Open File",
+        "Save File",
+        "Save Image",
+        "Choose",
+    ]
+    .into_iter()
+    .any(|prefix| title.starts_with(prefix))
+}
+
+fn steam_startup_title_matches(title: &str) -> bool {
+    title == "Sign in to Steam"
 }
 
 fn matching_user_window_rule<'a>(
@@ -215,6 +225,10 @@ fn matching_builtin_window_rule(
     }
 
     if title == Some("Picture-in-Picture") {
+        return Some(builtin_float_center_overlap_rule());
+    }
+
+    if app_id == Some("steam") && title.is_some_and(|t| steam_startup_title_matches(t)) {
         return Some(builtin_float_center_overlap_rule());
     }
 
@@ -399,6 +413,26 @@ mod tests {
     }
 
     #[test]
+    fn builtin_portal_save_image_dialog_matches() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let state = Halley::new_for_test(&dh, RuntimeTuning::default());
+
+        let matched = matching_window_rule(
+            &state,
+            Some("xdg-desktop-portal-gtk"),
+            Some("Save Image - cow - Google Search"),
+            false,
+        )
+        .expect("match");
+        assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
+        assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
+        assert_eq!(
+            matched.cluster_participation,
+            InitialWindowClusterParticipation::Float
+        );
+    }
+
+    #[test]
     fn builtin_pip_matches() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let state = Halley::new_for_test(&dh, RuntimeTuning::default());
@@ -411,6 +445,30 @@ mod tests {
             matched.cluster_participation,
             InitialWindowClusterParticipation::Float
         );
+    }
+
+    #[test]
+    fn builtin_steam_startup_window_matches() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let state = Halley::new_for_test(&dh, RuntimeTuning::default());
+
+        let matched = matching_window_rule(&state, Some("steam"), Some("Sign in to Steam"), false)
+            .expect("steam startup rule");
+
+        assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::All);
+        assert_eq!(matched.spawn_placement, InitialWindowSpawnPlacement::Center);
+        assert_eq!(
+            matched.cluster_participation,
+            InitialWindowClusterParticipation::Float
+        );
+    }
+
+    #[test]
+    fn builtin_steam_rule_does_not_match_main_window() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let state = Halley::new_for_test(&dh, RuntimeTuning::default());
+
+        assert!(matching_window_rule(&state, Some("steam"), Some("Steam"), false).is_none());
     }
 
     #[test]
@@ -496,11 +554,55 @@ mod tests {
     }
 
     #[test]
+    fn user_rule_overrides_builtin_steam_startup_behavior() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut tuning = RuntimeTuning::default();
+        tuning.window_rules = vec![WindowRule {
+            app_ids: vec![WindowRulePattern::Exact("steam".to_string())],
+            titles: Vec::new(),
+            overlap_policy: InitialWindowOverlapPolicy::None,
+            spawn_placement: InitialWindowSpawnPlacement::Adjacent,
+            cluster_participation: InitialWindowClusterParticipation::Layout,
+        }];
+        let state = Halley::new_for_test(&dh, tuning);
+
+        let matched = matching_window_rule(&state, Some("steam"), Some("Sign in to Steam"), false)
+            .expect("user rule");
+
+        assert_eq!(matched.overlap_policy, InitialWindowOverlapPolicy::None);
+        assert_eq!(
+            matched.spawn_placement,
+            InitialWindowSpawnPlacement::Adjacent
+        );
+        assert_eq!(
+            matched.cluster_participation,
+            InitialWindowClusterParticipation::Layout
+        );
+    }
+
+    #[test]
     fn deferred_recheck_considers_builtin_title_rules() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let state = Halley::new_for_test(&dh, RuntimeTuning::default());
         let intent = InitialWindowIntent {
             app_id: Some("xdg-desktop-portal-gtk".to_string()),
+            title: None,
+            parent_node: None,
+            rule: ResolvedInitialWindowRule::default(),
+            matched_rule: false,
+            is_transient: false,
+            prefer_app_intent: false,
+        };
+
+        assert!(needs_deferred_rule_recheck(&state, &intent));
+    }
+
+    #[test]
+    fn deferred_recheck_considers_builtin_steam_rule() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let state = Halley::new_for_test(&dh, RuntimeTuning::default());
+        let intent = InitialWindowIntent {
+            app_id: Some("steam".to_string()),
             title: None,
             parent_node: None,
             rule: ResolvedInitialWindowRule::default(),

--- a/crates/halley-wl/src/compositor/spawn/state.rs
+++ b/crates/halley-wl/src/compositor/spawn/state.rs
@@ -98,6 +98,7 @@ pub(crate) struct SpawnState {
     pub(crate) applied_window_rules: HashMap<NodeId, AppliedInitialWindowRule>,
     pub(crate) pending_rule_rechecks: HashSet<NodeId>,
     pub(crate) pending_initial_reveal: HashSet<NodeId>,
+    pub(crate) pending_pan_activate: Option<(NodeId, u64)>,
 }
 
 pub(crate) fn is_persistent_rule_top(st: &Halley, node_id: NodeId) -> bool {

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
@@ -210,6 +210,9 @@ pub(super) fn reconcile_surface_bindings(st: &mut Halley) {
             st.model.spawn_state.applied_window_rules.remove(&id);
             st.model.spawn_state.pending_rule_rechecks.remove(&id);
             st.model.spawn_state.pending_initial_reveal.remove(&id);
+            if st.model.spawn_state.pending_pan_activate.is_some_and(|(nid, _)| nid == id) {
+                st.model.spawn_state.pending_pan_activate = None;
+            }
             st.model
                 .workspace_state
                 .active_transition_until_ms

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
@@ -455,6 +455,9 @@ pub(super) fn ensure_node_for_surface_impl(
         .unwrap_or(0);
     let defer_rule_resolution =
         crate::compositor::spawn::rules::needs_deferred_rule_recheck(st, &effective_intent);
+    let defer_steam =
+        !effective_intent.matched_rule && effective_intent.app_id.as_deref() == Some("steam");
+    let should_defer = defer_rule_resolution || defer_steam;
     if effective_intent.effective_overlap_policy()
         == halley_config::InitialWindowOverlapPolicy::None
         && !defer_rule_resolution
@@ -536,7 +539,7 @@ pub(super) fn ensure_node_for_surface_impl(
             .applied_window_rules
             .insert(id, effective_intent.applied_rule_for_node());
         let _ = st.raise_overlap_policy_node(id);
-    } else if defer_rule_resolution {
+    } else if should_defer {
         st.model.spawn_state.pending_rule_rechecks.insert(id);
         st.model.spawn_state.pending_initial_reveal.insert(id);
     }
@@ -558,7 +561,7 @@ pub(super) fn ensure_node_for_surface_impl(
             .animator
             .observe_field(&st.model.field, now);
     }
-    if defer_rule_resolution && !joined_active_cluster {
+    if should_defer && !joined_active_cluster {
         let _ = st.model.field.set_detached(id, true);
     }
     if let Some(cid) = active_cluster.filter(|_| joined_active_cluster) {

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -127,9 +127,24 @@ pub(crate) fn tty_output_animation_redraw_state(
         || !st.model.fullscreen_state.fullscreen_scale_anim.is_empty();
     let maximize_motion_active = crate::compositor::workspace::state::maximize_animation_active(st);
     let current_monitor = st.model.monitor_state.current_monitor.as_str();
-    let viewport_pan_active = monitor == current_monitor
-        && (st.input.interaction_state.viewport_pan_anim.is_some()
-            || !st.model.spawn_state.pending_spawn_pan_queue.is_empty());
+    let viewport_pan_active = st
+        .input
+        .interaction_state
+        .viewport_pan_anim
+        .as_ref()
+        .is_some_and(|anim| anim.monitor == monitor)
+        || st
+            .model
+            .spawn_state
+            .pending_spawn_pan_queue
+            .iter()
+            .any(|pan| {
+                st.model
+                    .monitor_state
+                    .node_monitor
+                    .get(&pan.node_id)
+                    .is_some_and(|node_monitor| node_monitor == monitor)
+            });
     let camera_smoothing_active = monitor == current_monitor
         && ((st.model.viewport.center.x - st.model.camera_target_center.x).abs() > 0.05
             || (st.model.viewport.center.y - st.model.camera_target_center.y).abs() > 0.05
@@ -677,11 +692,12 @@ mod tests {
     }
 
     #[test]
-    fn viewport_pan_only_marks_current_monitor_active() {
+    fn viewport_pan_only_marks_animation_monitor_active() {
         let mut state = multi_monitor_state();
         let _ = state.activate_monitor("right");
         state.input.interaction_state.viewport_pan_anim =
             Some(crate::compositor::interaction::state::ViewportPanAnim {
+                monitor: "right".to_string(),
                 start_ms: 0,
                 delay_ms: 0,
                 duration_ms: 120,
@@ -691,6 +707,7 @@ mod tests {
                     y: state.model.viewport.center.y,
                 },
             });
+        let _ = state.activate_monitor("left");
 
         let now = Instant::now();
         assert!(tty_output_animation_redraw_state(&state, "right", now).active);

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -1,12 +1,19 @@
 use std::collections::HashSet;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use halley_core::field::{NodeId, Vec2};
+use smithay::desktop::utils::{
+    OutputPresentationFeedback, take_presentation_feedback_surface_tree,
+};
 use smithay::desktop::{PopupKind, find_popup_root_surface};
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use smithay::reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface};
+use smithay::utils::{Clock, Monotonic};
 use smithay::wayland::compositor::{
     SurfaceAttributes, TraversalAction, with_surface_tree_downward,
 };
+use smithay::wayland::presentation::Refresh;
 
 use crate::animation::AnimStyle;
 use crate::compositor::monitor::camera::camera_controller;
@@ -490,6 +497,75 @@ pub(crate) fn send_frame_callbacks_for_output(st: &mut Halley, output_name: &str
             send_frames_surface_tree(popup.wl_surface(), time_ms);
         }
     }
+}
+
+pub(crate) fn send_presentation_feedback_for_output(st: &Halley, output_name: &str) {
+    let Some(output) = st.model.monitor_state.outputs.get(output_name).cloned() else {
+        return;
+    };
+
+    let mut feedback = OutputPresentationFeedback::new(&output);
+    let presentation_time = Clock::<Monotonic>::new().now();
+    let refresh = refresh_for_output(&output);
+
+    for layer in st.platform.wlr_layer_shell_state.layer_surfaces() {
+        let surface = layer.wl_surface();
+        if surface_on_output(st, surface, output_name) {
+            take_presentation_feedback_surface_tree(
+                surface,
+                &mut feedback,
+                |_, _| Some(output.clone()),
+                |_, _| wp_presentation_feedback::Kind::empty(),
+            );
+        }
+    }
+
+    for top in st.platform.xdg_shell_state.toplevel_surfaces() {
+        let surface = top.wl_surface();
+        if surface_on_output(st, surface, output_name) {
+            take_presentation_feedback_surface_tree(
+                surface,
+                &mut feedback,
+                |_, _| Some(output.clone()),
+                |_, _| wp_presentation_feedback::Kind::empty(),
+            );
+        }
+    }
+
+    for popup in st.platform.xdg_shell_state.popup_surfaces() {
+        let popup_kind = PopupKind::from(popup.clone());
+        let Ok(root) = find_popup_root_surface(&popup_kind) else {
+            continue;
+        };
+        if surface_on_output(st, &root, output_name) {
+            take_presentation_feedback_surface_tree(
+                popup.wl_surface(),
+                &mut feedback,
+                |_, _| Some(output.clone()),
+                |_, _| wp_presentation_feedback::Kind::empty(),
+            );
+        }
+    }
+
+    feedback.presented(
+        presentation_time,
+        refresh,
+        0,
+        wp_presentation_feedback::Kind::Vsync,
+    );
+}
+
+fn refresh_for_output(output: &Output) -> Refresh {
+    output
+        .current_mode()
+        .map(|mode| mode.refresh)
+        .filter(|refresh_millihz| *refresh_millihz > 0)
+        .map(|refresh_millihz| {
+            Refresh::fixed(Duration::from_nanos(
+                1_000_000_000_000u64 / refresh_millihz as u64,
+            ))
+        })
+        .unwrap_or(Refresh::Unknown)
 }
 
 fn surface_on_output(st: &Halley, surface: &WlSurface, output_name: &str) -> bool {

--- a/crates/halley-wl/src/input/pointer/focus/surface.rs
+++ b/crates/halley-wl/src/input/pointer/focus/surface.rs
@@ -1,11 +1,12 @@
 use std::time::Instant;
 
 use smithay::desktop::{
-    PopupManager, WindowSurfaceType,
+    PopupKind, PopupManager, WindowSurfaceType,
     utils::{bbox_from_surface_tree, under_from_surface_tree},
 };
-use smithay::reexports::wayland_server::Resource;
+use smithay::reexports::wayland_server::{Resource, protocol::wl_surface::WlSurface};
 use smithay::utils::{Logical, Point};
+use smithay::wayland::{compositor::get_role, shell::xdg::XDG_POPUP_ROLE};
 
 use crate::compositor::interaction::ResizeCtx;
 use crate::compositor::root::Halley;
@@ -40,6 +41,43 @@ fn clamp_layer_popup_origin(
     }
 
     (origin_x, origin_y)
+}
+
+fn popup_parent_surface(popup: &PopupKind) -> Option<WlSurface> {
+    match popup {
+        PopupKind::Xdg(popup) => popup.get_parent_surface(),
+        PopupKind::InputMethod(popup) => popup.get_parent().map(|parent| parent.surface.clone()),
+    }
+}
+
+fn popup_depth(st: &Halley, popup: &PopupKind) -> usize {
+    let mut depth = 0;
+    let mut parent = popup_parent_surface(popup);
+    while let Some(surface) = parent {
+        if get_role(&surface) != Some(XDG_POPUP_ROLE) {
+            break;
+        }
+        depth += 1;
+        parent = st
+            .platform
+            .popup_manager
+            .find_popup(&surface)
+            .and_then(|popup| popup_parent_surface(&popup));
+    }
+    depth
+}
+
+fn popups_top_to_bottom(st: &Halley, surface: &WlSurface) -> Vec<(PopupKind, Point<i32, Logical>)> {
+    let mut popups: Vec<_> = PopupManager::popups_for_surface(surface)
+        .enumerate()
+        .map(|(index, (popup, offset))| (popup_depth(st, &popup), index, popup, offset))
+        .collect();
+    popups.sort_by_key(|(depth, index, _, _)| (*depth, *index));
+    popups
+        .into_iter()
+        .rev()
+        .map(|(_, _, popup, offset)| (popup, offset))
+        .collect()
 }
 
 fn popup_focus_for_screen(
@@ -114,9 +152,7 @@ fn popup_focus_for_screen(
             });
         let parent_geo_loc = (parent_geo.0.round() as i32, parent_geo.1.round() as i32);
 
-        let mut popups: Vec<_> = PopupManager::popups_for_surface(&wl).collect();
-        popups.reverse();
-        for (popup, popup_offset) in popups {
+        for (popup, popup_offset) in popups_top_to_bottom(st, &wl) {
             let popup_geo = popup.geometry();
             let popup_sx = xform.origin_x
                 + ((parent_geo_loc.0 + popup_offset.x - popup_geo.loc.x) as f32 * scale).round();
@@ -210,9 +246,7 @@ pub(crate) fn layer_surface_focus_for_screen(
             continue;
         }
 
-        let mut popups: Vec<_> = PopupManager::popups_for_surface(&placement.wl_surface).collect();
-        popups.reverse();
-        for (popup, popup_offset) in popups {
+        for (popup, popup_offset) in popups_top_to_bottom(st, &placement.wl_surface) {
             let popup_geo = popup.geometry();
             let (popup_origin_x, popup_origin_y) = clamp_layer_popup_origin(
                 &popup,

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -120,7 +120,21 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
 
     let (desktop_hover, hover_focus_blocked) = {
         let ps = ctx.pointer_state.borrow();
-        routing::dispatch_pointer_motion(st, &ps, &routing, delta, delta_unaccel, time_usec, now)
+        match routing::dispatch_pointer_motion(
+            st,
+            &ps,
+            &routing,
+            delta,
+            delta_unaccel,
+            time_usec,
+            now,
+        ) {
+            routing::MotionDispatchResult::ConsumedByPointerConstraint => return,
+            routing::MotionDispatchResult::Forwarded {
+                desktop_hover,
+                hover_focus_blocked,
+            } => (desktop_hover, hover_focus_blocked),
+        }
     };
 
     let p = routing.world;

--- a/crates/halley-wl/src/input/pointer/motion/routing.rs
+++ b/crates/halley-wl/src/input/pointer/motion/routing.rs
@@ -21,6 +21,14 @@ pub(crate) struct MotionRoutingContext {
     pub local_sy: f32,
 }
 
+pub(super) enum MotionDispatchResult {
+    ConsumedByPointerConstraint,
+    Forwarded {
+        desktop_hover: bool,
+        hover_focus_blocked: bool,
+    },
+}
+
 pub(super) fn compute_motion_routing(
     st: &mut Halley,
     ps: &PointerState,
@@ -150,7 +158,7 @@ pub(super) fn dispatch_pointer_motion(
     delta_unaccel: (f64, f64),
     time_usec: u64,
     now: Instant,
-) -> (bool, bool) {
+) -> MotionDispatchResult {
     let mut desktop_hover = false;
     let mut hover_focus_blocked = false;
 
@@ -174,7 +182,7 @@ pub(super) fn dispatch_pointer_motion(
                 );
             }
             pointer.frame(st);
-            return (false, false);
+            return MotionDispatchResult::ConsumedByPointerConstraint;
         }
 
         let locked_surface = active_constraint
@@ -279,7 +287,7 @@ pub(super) fn dispatch_pointer_motion(
                     );
                 }
                 pointer.frame(st);
-                return (false, false);
+                return MotionDispatchResult::ConsumedByPointerConstraint;
             }
         }
 
@@ -322,7 +330,10 @@ pub(super) fn dispatch_pointer_motion(
         pointer.frame(st);
     }
 
-    (desktop_hover, hover_focus_blocked)
+    MotionDispatchResult::Forwarded {
+        desktop_hover,
+        hover_focus_blocked,
+    }
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/protocol/wayland/handlers.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers.rs
@@ -196,17 +196,11 @@ impl DrmSyncobjHandler for Halley {
 impl PointerConstraintsHandler for Halley {
     fn new_constraint(&mut self, surface: &WlSurface, pointer: &PointerHandle<Self>) {
         if pointer.current_focus().as_ref() != Some(surface) {
-            let mut is_ancestor = false;
-            if let Some(mut current) = pointer.current_focus() {
-                while let Some(parent) = get_parent(&current) {
-                    if parent == *surface {
-                        is_ancestor = true;
-                        break;
-                    }
-                    current = parent;
-                }
-            }
-            if is_ancestor {
+            let focus = pointer.current_focus();
+            let in_focused_tree = focus.as_ref().is_some_and(|focus| {
+                surface_is_ancestor_of(surface, focus) || surface_is_ancestor_of(focus, surface)
+            });
+            if in_focused_tree {
                 pointer.motion(
                     self,
                     Some((surface.clone(), pointer.current_location())),
@@ -242,6 +236,17 @@ impl PointerConstraintsHandler for Halley {
             location,
         );
     }
+}
+
+fn surface_is_ancestor_of(ancestor: &WlSurface, surface: &WlSurface) -> bool {
+    let mut current = surface.clone();
+    while let Some(parent) = get_parent(&current) {
+        if parent == *ancestor {
+            return true;
+        }
+        current = parent;
+    }
+    false
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/protocol/wayland/mod.rs
+++ b/crates/halley-wl/src/protocol/wayland/mod.rs
@@ -7,9 +7,9 @@ use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_cursor_shape, delegate_data_control, delegate_data_device,
     delegate_dmabuf, delegate_drm_syncobj, delegate_idle_notify, delegate_layer_shell,
-    delegate_output, delegate_pointer_constraints, delegate_primary_selection,
-    delegate_relative_pointer, delegate_seat, delegate_shm, delegate_viewporter,
-    delegate_xdg_activation, delegate_xdg_decoration, delegate_xdg_shell,
+    delegate_output, delegate_pointer_constraints, delegate_presentation,
+    delegate_primary_selection, delegate_relative_pointer, delegate_seat, delegate_shm,
+    delegate_viewporter, delegate_xdg_activation, delegate_xdg_decoration, delegate_xdg_shell,
     input::{Seat, SeatHandler, SeatState, pointer::CursorImageStatus},
     output::Output,
     reexports::wayland_server::{Client, Resource, backend::ObjectId, protocol::wl_seat},
@@ -63,3 +63,5 @@ mod screencopy;
 pub(crate) mod session_lock;
 
 pub use client_state::ClientState;
+
+delegate_presentation!(Halley);


### PR DESCRIPTION
### Summary

This PR stabilizes several Wayland/client interaction edge cases in Halley, especially around fullscreen games, gamescope, nested popups, Steam startup behavior, and multi-monitor spawn/restore pan animations.

The biggest fixes are:

- Properly consume constrained pointer motion so fullscreen games receive relative motion without Halley also treating the event as desktop pointer movement.
- Advertise `wp_presentation` and send presentation feedback so clients like gamescope do not fall back to X11.
- Route clicks to the topmost nested popup first, fixing Firefox nested/context-menu click-through issues.
- Handle Steam’s startup login window with a built-in float/center/overlap rule.
- Make spawn and close-restore viewport pans monitor-scoped so animations do not get retargeted by pointer activity on another output.

### Changes

#### Fullscreen game / constrained pointer handling

- Added an explicit pointer motion dispatch result for constraint-consumed events.
- Locked pointer motion now sends relative motion to the client and returns early.
- Confined pointer motion now returns early when movement is prevented by the constraint.
- Prevents Halley from updating desktop hover, focus, or pointer state for the same consumed event.
- Allows pointer constraints requested on ancestor or descendant surfaces in the focused surface tree.
- Retargets focus to the constrained surface before activation.

#### `wp_presentation` support

- Advertises the `wp_presentation` global.
- Adds `PresentationState` to `PlatformState` using a monotonic clock.
- Delegates presentation dispatch for Halley.
- Adds `send_presentation_feedback_for_output`.
- Collects pending presentation feedback from:
  - layer surface trees
  - xdg surface trees
  - popup surface trees
- Marks surfaces as presented after each rendered frame.
- Sends feedback from both TTY and winit paths.

#### Nested popup click routing

- Adds popup parent/depth helpers for tracked popup trees.
- Hit-tests deeper popups before parent popups.
- Preserves newer popup precedence at the same depth.
- Applies this ordering to both normal xdg popups and layer-surface popups.
- Fixes Firefox context-menu clicks passing through nested menus into bookmark folder items underneath.

#### Steam startup and dialog rules

- Adds a built-in rule for Steam’s startup login window:

  ```text
  app_id: steam
  title: Sign in to Steam