### PR TITLE
fix(wl): make initial window spawn placement anchor-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add `wp_presentation` support and send presentation feedback after TTY and winit frames so Wayland clients such as gamescope can receive frame timing instead of falling back to X11 behavior.
+- Add fractional scale protocol support, including DPI-based output scale guesses and preferred scale updates for surfaces as they move between monitors.
 - Add configurable Aperture placement for cursor-following, a fixed monitor, or every output, including per-output Aperture status IPC and CLI output.
 - Add `aperture-peek` styling for corner, rounded background, radius, and clock appearance, plus an `examples/aperture.rune` sample config.
 - Add user-pinned window/node/core support with default `mod+p`, `field.pins` badge styling, pinned Bearings visibility, and pin badge rendering from the bundled SVG asset.
@@ -15,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add strict config validation diagnostics for unknown Halley keys and invalid literals, with path, line, source text, and suggestions when available.
 
 ### Changed
+- Rework Xwayland socket startup around event-loop socket watchers, safer listener handoff, close-on-exec lock files, `-listenfd` capability detection, and portal `DISPLAY` activation environment export.
 - Rework `halley-aperture` standalone rendering to maintain per-output layer surfaces, redraw clocks on a timed Wayland poll loop, and keep animations advancing without busy sleeping.
 - Treat pinning as a property of the active entity by transferring pinned state from windows into clusters and collapsed cluster cores, keeping pinned core visibility and IPC state consistent across create, absorb, collapse, expand, and dissolve flows.
 - Move pure overlap contact physics into `halley-core` so the Wayland compositor only wires it into runtime state.
@@ -22,6 +24,13 @@ All notable changes to this project will be documented in this file.
 - Rename the default explicit field-drag pointer action from `field-jump` to `pan-field`, keeping `field-jump` and `drag-pan` as config aliases for compatibility.
 
 ### Fixed
+- Use the launch or window-rule spawn target monitor for initial `xdg_toplevel` configure bounds so new clients receive bounds for the output they will actually open on.
+- Prevent focus decay while spawn or open transitions are still active, avoiding premature collapse during window launch and reveal animations.
+- Preserve fullscreen and pointer state across monitor changes by separating soft fullscreen suspension from client fullscreen exits, refreshing pointer constraints from the last screen position, releasing constraints when crossing monitors, and keeping cursor surface output state current.
+- Smooth new-window reveal timing by waiting for committed geometry before starting open animations, preserving late rule rechecks, keeping offscreen spawn-panned windows detached until the pan reaches the reveal point, and scheduling delayed reveal timers.
+- Make initial spawn placement anchor-aware once real window geometry is known, including row-aware vertical placement, conservative open-animation extents, and anchored overlap resolution that keeps the focused anchor fixed while the new spawn yields.
+- Stabilize spawn patch placement by reanchoring patches on the focused window and resetting patch state when a monitor becomes empty.
+- Respect late user window rules in deferred rule rechecks and avoid resolving overlap for windows still pending their initial reveal.
 - Scope viewport pan animations to the monitor that created them so quick pointer movement to another output cannot retarget an in-flight spawn or close-restore pan and move the wrong monitor.
 - Defer spawn-pan focus activation until the tick after a spawn reveal pan completes, while applying reveal state immediately so new windows are undetached, hot, transition-tracked, and recorded in focus history as soon as the reveal begins.
 - Fix cross-monitor spawn reveal pans in click-to-focus mode by creating the pan from the spawn monitor's viewport center instead of whichever monitor was current when the reveal started.

--- a/crates/halley-wl/src/compositor/clusters/system/mutation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mutation.rs
@@ -1,6 +1,34 @@
 use super::*;
 
 impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
+    fn monitor_has_visible_surface_node(&self, monitor: &str) -> bool {
+        self.model.field.nodes().values().any(|node| {
+            node.kind == halley_core::field::NodeKind::Surface
+                && self.model.field.is_visible(node.id)
+                && self
+                    .model
+                    .monitor_state
+                    .node_monitor
+                    .get(&node.id)
+                    .is_some_and(|node_monitor| node_monitor == monitor)
+        })
+    }
+
+    fn reset_empty_monitor_spawn_state(&mut self, monitor: &str) {
+        if self.monitor_has_visible_surface_node(monitor) {
+            return;
+        }
+
+        let view_anchor = self.default_spawn_view_anchor_for_monitor(monitor);
+        let spawn = self.spawn_monitor_state_mut(monitor);
+        spawn.spawn_patch = None;
+        spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+        spawn.spawn_view_anchor = view_anchor;
+        spawn.spawn_focus_override = None;
+        spawn.spawn_pan_start_center = None;
+        self.model.focus_state.monitor_focus.remove(monitor);
+    }
+
     pub(super) fn cluster_mutation_controller(&mut self) -> ClusterMutationController<'_> {
         let crate::compositor::root::Halley {
             model,
@@ -60,6 +88,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
     }
 
     pub(crate) fn remove_node_from_field(&mut self, id: NodeId, now_ms: u64) -> bool {
+        let removed_monitor = self.model.monitor_state.node_monitor.get(&id).cloned();
         let stack_remove_transition = self
             .model
             .field
@@ -186,6 +215,10 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
                 let _ = self.sync_cluster_monitor(cid, None);
             }
             None => {}
+        }
+
+        if let Some(monitor) = removed_monitor {
+            self.reset_empty_monitor_spawn_state(monitor.as_str());
         }
 
         true

--- a/crates/halley-wl/src/compositor/focus/system.rs
+++ b/crates/halley-wl/src/compositor/focus/system.rs
@@ -331,15 +331,22 @@ impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
 
     pub(crate) fn note_pan_viewport_change(&mut self, _now: Instant) {
         let current_monitor = self.model.monitor_state.current_monitor.clone();
+        let spawn_pan_active = self.model.spawn_state.active_spawn_pan.is_some()
+            || !self.model.spawn_state.pending_spawn_pan_queue.is_empty()
+            || self.model.spawn_state.pending_pan_activate.is_some();
         if self
             .spawn_monitor_state(current_monitor.as_str())
             .spawn_anchor_mode
             == crate::compositor::spawn::state::SpawnAnchorMode::View
+            && !spawn_pan_active
         {
             self.spawn_monitor_state_mut(current_monitor.as_str())
                 .spawn_view_anchor = self.model.viewport.center;
         }
         self.request_maintenance();
+        if spawn_pan_active {
+            return;
+        }
         let Some(start_center) = self
             .spawn_monitor_state(current_monitor.as_str())
             .spawn_pan_start_center
@@ -593,6 +600,47 @@ mod tests {
             },
         ];
         tuning
+    }
+
+    #[test]
+    fn spawn_pan_does_not_clear_active_spawn_patch() {
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, halley_config::RuntimeTuning::default());
+        let monitor = state.model.monitor_state.current_monitor.clone();
+        let anchor = Vec2 { x: 0.0, y: 0.0 };
+        let id = state.model.field.spawn_surface(
+            "spawned",
+            Vec2 { x: 300.0, y: 0.0 },
+            Vec2 { x: 120.0, y: 90.0 },
+        );
+        state.assign_node_to_current_monitor(id);
+        state.update_spawn_patch(
+            monitor.as_str(),
+            anchor,
+            None,
+            anchor,
+            Vec2 { x: 1.0, y: 0.0 },
+        );
+        state.model.spawn_state.active_spawn_pan =
+            Some(crate::compositor::spawn::state::ActiveSpawnPan {
+                node_id: id,
+                pan_start_at_ms: 0,
+                reveal_at_ms: 0,
+            });
+        state.model.viewport.center = Vec2 { x: 300.0, y: 0.0 };
+
+        state.note_pan_viewport_change(Instant::now());
+
+        assert_eq!(
+            state
+                .spawn_monitor_state(monitor.as_str())
+                .spawn_patch
+                .as_ref()
+                .map(|patch| patch.anchor),
+            Some(anchor)
+        );
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/overlap/system/resolve.rs
+++ b/crates/halley-wl/src/compositor/overlap/system/resolve.rs
@@ -18,6 +18,36 @@ use super::{
     required_sep_y,
 };
 
+fn initial_spawn_authority_pair(st: &Halley, a: NodeId, b: NodeId) -> Option<(NodeId, NodeId)> {
+    if st
+        .model
+        .spawn_state
+        .initial_spawn_authority
+        .get(&a)
+        .is_some_and(|authority| authority.anchor_node == b)
+    {
+        return Some((a, b));
+    }
+    if st
+        .model
+        .spawn_state
+        .initial_spawn_authority
+        .get(&b)
+        .is_some_and(|authority| authority.anchor_node == a)
+    {
+        return Some((b, a));
+    }
+    None
+}
+
+fn is_initial_spawn_anchor(st: &Halley, id: NodeId) -> bool {
+    st.model
+        .spawn_state
+        .initial_spawn_authority
+        .values()
+        .any(|authority| authority.anchor_node == id)
+}
+
 fn resolve_static_surface_overlap(st: &mut Halley, ids: &[NodeId]) {
     let drag_authority = st.input.interaction_state.drag_authority_node;
 
@@ -39,12 +69,17 @@ fn resolve_static_surface_overlap(st: &mut Halley, ids: &[NodeId]) {
                     continue;
                 }
 
+                let authority = initial_spawn_authority_pair(st, a, b);
                 let a_locked = na.pinned
                     || st.input.interaction_state.resize_active == Some(a)
-                    || st.input.interaction_state.resize_static_node == Some(a);
+                    || st.input.interaction_state.resize_static_node == Some(a)
+                    || authority.is_some_and(|(_, anchor)| anchor == a)
+                    || is_initial_spawn_anchor(st, a);
                 let b_locked = nb.pinned
                     || st.input.interaction_state.resize_active == Some(b)
-                    || st.input.interaction_state.resize_static_node == Some(b);
+                    || st.input.interaction_state.resize_static_node == Some(b)
+                    || authority.is_some_and(|(_, anchor)| anchor == b)
+                    || is_initial_spawn_anchor(st, b);
                 if a_locked && b_locked {
                     continue;
                 }
@@ -241,7 +276,9 @@ pub(crate) fn resolve_surface_overlap(st: &mut Halley) {
         let Some(node) = st.model.field.node(id) else {
             continue;
         };
-        let pinned = node.pinned || st.input.interaction_state.resize_static_node == Some(id);
+        let pinned = node.pinned
+            || st.input.interaction_state.resize_static_node == Some(id)
+            || is_initial_spawn_anchor(st, id);
         if physics_inv_mass(st, id, pinned) <= 0.0 {
             continue;
         }
@@ -269,10 +306,15 @@ pub(crate) fn resolve_surface_overlap(st: &mut Halley) {
                     continue;
                 }
 
-                let a_pinned =
-                    na.pinned || st.input.interaction_state.resize_static_node == Some(a);
-                let b_pinned =
-                    nb.pinned || st.input.interaction_state.resize_static_node == Some(b);
+                let authority = initial_spawn_authority_pair(st, a, b);
+                let a_pinned = na.pinned
+                    || st.input.interaction_state.resize_static_node == Some(a)
+                    || authority.is_some_and(|(_, anchor)| anchor == a)
+                    || is_initial_spawn_anchor(st, a);
+                let b_pinned = nb.pinned
+                    || st.input.interaction_state.resize_static_node == Some(b)
+                    || authority.is_some_and(|(_, anchor)| anchor == b)
+                    || is_initial_spawn_anchor(st, b);
                 let inv_mass_a = physics_inv_mass(st, a, a_pinned);
                 let inv_mass_b = physics_inv_mass(st, b, b_pinned);
                 if inv_mass_a <= 0.0 && inv_mass_b <= 0.0 {
@@ -318,7 +360,9 @@ pub(crate) fn resolve_surface_overlap(st: &mut Halley) {
         let Some(node) = st.model.field.node(id) else {
             continue;
         };
-        let pinned = node.pinned || st.input.interaction_state.resize_static_node == Some(id);
+        let pinned = node.pinned
+            || st.input.interaction_state.resize_static_node == Some(id)
+            || is_initial_spawn_anchor(st, id);
         if st.input.interaction_state.drag_authority_node != Some(id)
             && let Some(pos) = positions.get(&id).copied()
         {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -313,6 +313,9 @@ impl Halley {
                     applied_window_rules: HashMap::new(),
                     pending_rule_rechecks: HashSet::new(),
                     pending_initial_reveal: HashSet::new(),
+                    pending_initial_spawn_placement: None,
+                    initial_spawn_placements: HashMap::new(),
+                    initial_spawn_authority: HashMap::new(),
                     pending_pan_activate: None,
                 },
                 field: Field::new(),
@@ -1438,6 +1441,11 @@ impl Halley {
     ) -> (String, Vec2, bool) {
         super::spawn::reveal::spawn_reveal_controller(self)
             .pick_spawn_position_with_intent(size, intent)
+    }
+
+    pub(crate) fn finalize_initial_spawn_position(&mut self, id: NodeId, size: Vec2) -> bool {
+        super::spawn::reveal::spawn_reveal_controller(self)
+            .finalize_initial_spawn_position(id, size)
     }
 
     #[allow(dead_code)]

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -626,13 +626,16 @@ mod tests {
         );
 
         let size = Vec2 { x: 120.0, y: 90.0 };
-        let existing = state
-            .model
-            .field
-            .spawn_surface("existing", Vec2 { x: 143.0, y: 0.0 }, size);
+        let right = state
+            .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: 1.0, y: 0.0 })
+            .expect("right spawn candidate");
+        let left = state
+            .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: -1.0, y: 0.0 })
+            .expect("left spawn candidate");
+        let existing = state.model.field.spawn_surface("existing", right, size);
         state.assign_node_to_current_monitor(existing);
         let (_, pos, needs_pan) = state.pick_spawn_position(size);
-        assert_eq!(pos, Vec2 { x: -143.0, y: 0.0 });
+        assert_eq!(pos, left);
         assert!(!needs_pan);
     }
 
@@ -1333,6 +1336,291 @@ mod tests {
 
         let chosen = state.pick_spawn_position(size).1;
         assert_eq!(chosen, down);
+    }
+
+    #[test]
+    fn focused_up_uses_current_row_height_not_focused_height() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let row_size = Vec2 { x: 120.0, y: 300.0 };
+        let focused = state
+            .model
+            .field
+            .spawn_surface("focused", Vec2 { x: 0.0, y: 0.0 }, size);
+        state.assign_node_to_current_monitor(focused);
+        state.set_interaction_focus(Some(focused), 30_000, Instant::now());
+
+        let mut row_ids = vec![focused];
+        for dir in [Vec2 { x: 1.0, y: 0.0 }, Vec2 { x: -1.0, y: 0.0 }] {
+            let pos = state
+                .spawn_candidate_for_focus_dir(focused, size, dir)
+                .expect("side candidate");
+            let id = state.model.field.spawn_surface("row", pos, row_size);
+            state.assign_node_to_current_monitor(id);
+            row_ids.push(id);
+        }
+
+        let focused_up = state
+            .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: 0.0, y: -1.0 })
+            .expect("focused up");
+        let frame_pad = active_window_frame_pad_px(&state.runtime.tuning) as f32;
+        let candidate_bottom = (size.y * 0.5 + frame_pad) * 1.08 + 4.0;
+        let row_top = row_ids
+            .iter()
+            .filter_map(|&id| {
+                state.model.field.node(id).map(|node| {
+                    let ext = state.surface_window_collision_extents(node);
+                    node.pos.y - (ext.top * 1.08 + 4.0)
+                })
+            })
+            .fold(f32::INFINITY, f32::min);
+        let expected_y = row_top - (state.non_overlap_gap_world() * 2.0 + 4.0) - candidate_bottom;
+
+        let (_, pos, _) = state.pick_spawn_position(size);
+
+        assert_eq!(focused_up.x, 0.0);
+        assert!((focused_up.y - expected_y).abs() < 0.5);
+        assert_eq!(pos.x, focused_up.x);
+        assert!(
+            (pos.y - expected_y).abs() < 0.5,
+            "pos={pos:?} expected_y={expected_y}"
+        );
+    }
+
+    #[test]
+    fn focused_down_uses_current_row_height_not_focused_height() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let row_size = Vec2 { x: 120.0, y: 300.0 };
+        let focused = state
+            .model
+            .field
+            .spawn_surface("focused", Vec2 { x: 0.0, y: 0.0 }, size);
+        state.assign_node_to_current_monitor(focused);
+        state.set_interaction_focus(Some(focused), 30_000, Instant::now());
+
+        let mut row_ids = vec![focused];
+        for dir in [Vec2 { x: 1.0, y: 0.0 }, Vec2 { x: -1.0, y: 0.0 }] {
+            let pos = state
+                .spawn_candidate_for_focus_dir(focused, size, dir)
+                .expect("side candidate");
+            let id = state.model.field.spawn_surface("row", pos, row_size);
+            state.assign_node_to_current_monitor(id);
+            row_ids.push(id);
+        }
+
+        let frame_pad = active_window_frame_pad_px(&state.runtime.tuning) as f32;
+        let candidate_top = (size.y * 0.5 + frame_pad) * 1.08 + 4.0;
+        let candidate_bottom = (size.y * 0.5 + frame_pad) * 1.08 + 4.0;
+        let row_top = row_ids
+            .iter()
+            .filter_map(|&id| {
+                state.model.field.node(id).map(|node| {
+                    let ext = state.surface_window_collision_extents(node);
+                    node.pos.y - (ext.top * 1.08 + 4.0)
+                })
+            })
+            .fold(f32::INFINITY, f32::min);
+        let row_bottom = row_ids
+            .iter()
+            .filter_map(|&id| {
+                state.model.field.node(id).map(|node| {
+                    let ext = state.surface_window_collision_extents(node);
+                    node.pos.y + (ext.bottom * 1.08 + 4.0)
+                })
+            })
+            .fold(f32::NEG_INFINITY, f32::max);
+        let expected_up_y =
+            row_top - (state.non_overlap_gap_world() * 2.0 + 4.0) - candidate_bottom;
+        let up_blocker = state.model.field.spawn_surface(
+            "up-blocker",
+            Vec2 {
+                x: 0.0,
+                y: expected_up_y,
+            },
+            size,
+        );
+        state.assign_node_to_current_monitor(up_blocker);
+
+        let focused_down = state
+            .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: 0.0, y: 1.0 })
+            .expect("focused down");
+        let expected_y = row_bottom + (state.non_overlap_gap_world() * 2.0 + 4.0) + candidate_top;
+
+        let (_, pos, _) = state.pick_spawn_position(size);
+
+        assert_eq!(focused_down.x, 0.0);
+        assert!((focused_down.y - expected_y).abs() < 0.5);
+        assert_eq!(pos.x, focused_down.x);
+        assert!(
+            (pos.y - expected_y).abs() < 0.5,
+            "pos={pos:?} expected_y={expected_y}"
+        );
+    }
+
+    #[test]
+    fn star_up_starts_short_row_above_current_row() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        {
+            let monitor = state.model.monitor_state.current_monitor.clone();
+            let spawn = state.spawn_monitor_state_mut(monitor.as_str());
+            spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+            spawn.spawn_view_anchor = Vec2 { x: 0.0, y: 0.0 };
+        }
+
+        let row_size = Vec2 { x: 120.0, y: 300.0 };
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let anchor = state
+            .model
+            .field
+            .spawn_surface("anchor", Vec2 { x: 0.0, y: 0.0 }, row_size);
+        state.assign_node_to_current_monitor(anchor);
+        for dir in [Vec2 { x: 1.0, y: 0.0 }, Vec2 { x: -1.0, y: 0.0 }] {
+            let pos = state
+                .spawn_candidate_for_focus_dir(anchor, size, dir)
+                .expect("side candidate");
+            let id = state.model.field.spawn_surface("side", pos, size);
+            state.assign_node_to_current_monitor(id);
+        }
+        let expected = state
+            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: 0.0, y: -1.0 })
+            .expect("up candidate");
+
+        let (_, pos, _) = state.pick_spawn_position(size);
+
+        assert_eq!(pos, expected);
+    }
+
+    #[test]
+    fn star_down_starts_short_row_below_current_row() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        {
+            let monitor = state.model.monitor_state.current_monitor.clone();
+            let spawn = state.spawn_monitor_state_mut(monitor.as_str());
+            spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+            spawn.spawn_view_anchor = Vec2 { x: 0.0, y: 0.0 };
+        }
+
+        let row_size = Vec2 { x: 120.0, y: 300.0 };
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let anchor = state
+            .model
+            .field
+            .spawn_surface("anchor", Vec2 { x: 0.0, y: 0.0 }, row_size);
+        state.assign_node_to_current_monitor(anchor);
+        for dir in [
+            Vec2 { x: 1.0, y: 0.0 },
+            Vec2 { x: -1.0, y: 0.0 },
+            Vec2 { x: 0.0, y: -1.0 },
+        ] {
+            let pos = state
+                .spawn_candidate_for_focus_dir(anchor, size, dir)
+                .expect("blocker candidate");
+            let id = state.model.field.spawn_surface("blocker", pos, size);
+            state.assign_node_to_current_monitor(id);
+        }
+        let expected = state
+            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: 0.0, y: 1.0 })
+            .expect("down candidate");
+
+        let (_, pos, _) = state.pick_spawn_position(size);
+
+        assert_eq!(pos, expected);
+    }
+
+    #[test]
+    fn focused_cardinal_spawn_candidates_include_frame_pad() {
+        let dirs = [
+            ("right", Vec2 { x: 1.0, y: 0.0 }),
+            ("left", Vec2 { x: -1.0, y: 0.0 }),
+            ("up", Vec2 { x: 0.0, y: -1.0 }),
+            ("down", Vec2 { x: 0.0, y: 1.0 }),
+        ];
+
+        for (name, dir) in dirs {
+            let tuning = halley_config::RuntimeTuning::default();
+            let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+                .expect("display")
+                .handle();
+            let mut state = Halley::new_for_test(&dh, tuning);
+
+            let size = Vec2 { x: 120.0, y: 90.0 };
+            let focused = state
+                .model
+                .field
+                .spawn_surface("focused", Vec2 { x: 0.0, y: 0.0 }, size);
+            state.assign_node_to_current_monitor(focused);
+            let _ = state
+                .model
+                .field
+                .set_state(focused, halley_core::field::NodeState::Active);
+            state.set_interaction_focus(Some(focused), 30_000, Instant::now());
+
+            let pos = state
+                .spawn_candidate_for_focus_dir(focused, size, dir)
+                .expect("spawn candidate");
+            let candidate = state.model.field.spawn_surface("candidate", pos, size);
+            state.assign_node_to_current_monitor(candidate);
+            let _ = state
+                .model
+                .field
+                .set_state(candidate, halley_core::field::NodeState::Active);
+
+            let focused_node = state.model.field.node(focused).expect("focused");
+            let candidate_node = state.model.field.node(candidate).expect("candidate");
+            let focused_ext = state.surface_window_collision_extents(focused_node);
+            let candidate_ext = state.surface_window_collision_extents(candidate_node);
+            let gap = state.non_overlap_gap_world();
+            let req_x = state.required_sep_x(
+                focused_node.pos.x,
+                focused_ext,
+                candidate_node.pos.x,
+                candidate_ext,
+                gap,
+            );
+            let req_y = state.required_sep_y(
+                focused_node.pos.y,
+                focused_ext,
+                candidate_node.pos.y,
+                candidate_ext,
+                gap,
+            );
+            let dx = (candidate_node.pos.x - focused_node.pos.x).abs();
+            let dy = (candidate_node.pos.y - focused_node.pos.y).abs();
+
+            assert!(
+                dx >= req_x || dy >= req_y,
+                "{name} candidate should not overlap with frame padding: dx={dx}, dy={dy}, req_x={req_x}, req_y={req_y}"
+            );
+        }
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -702,12 +702,11 @@ mod tests {
             assert_eq!(pos, expected);
             let id = state.model.field.spawn_surface("spawned", pos, size);
             state.assign_node_to_current_monitor(id);
-            state.set_interaction_focus(Some(id), 30_000, Instant::now());
         }
     }
 
     #[test]
-    fn auto_focused_spawn_does_not_move_patch_anchor() {
+    fn focused_spawn_reanchors_default_patch() {
         let tuning = halley_config::RuntimeTuning::default();
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
@@ -730,14 +729,17 @@ mod tests {
         state.set_interaction_focus(Some(second_id), 30_000, Instant::now());
         let third = state.pick_spawn_position(size).1;
         let offsets = state.star_candidate_offsets(size);
+        let third_expected = state
+            .right_spawn_candidate_for_focus(second_id, size)
+            .expect("right of focused spawn");
 
         assert_eq!(first, offsets[0]);
         assert_eq!(second, offsets[1]);
-        assert_eq!(third, offsets[2]);
+        assert_eq!(third, third_expected);
     }
 
     #[test]
-    fn live_sequential_spawns_return_to_left_arm_after_right2() {
+    fn stable_center_focus_returns_to_left_arm_after_right2() {
         let tuning = halley_config::RuntimeTuning::default();
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
@@ -750,13 +752,18 @@ mod tests {
         };
         let size = Vec2 { x: 120.0, y: 90.0 };
         let expected = state.star_candidate_offsets(size);
+        let first = state.pick_spawn_position(size).1;
+        assert_eq!(first, expected[0], "spawn index 0");
+        let first_id = state.model.field.spawn_surface("spawned", first, size);
+        state.assign_node_to_current_monitor(first_id);
+        state.set_interaction_focus(Some(first_id), 30_000, Instant::now());
 
-        for (index, expected_pos) in expected.iter().copied().take(7).enumerate() {
+        for (index, expected_pos) in expected.iter().copied().take(7).enumerate().skip(1) {
             let (_, pos, _) = state.pick_spawn_position(size);
             assert_eq!(pos, expected_pos, "spawn index {index}");
             let id = state.model.field.spawn_surface("spawned", pos, size);
             state.assign_node_to_current_monitor(id);
-            state.set_interaction_focus(Some(id), 30_000, Instant::now());
+            state.set_interaction_focus(Some(first_id), 30_000, Instant::now());
         }
     }
 
@@ -1062,7 +1069,7 @@ mod tests {
     }
 
     #[test]
-    fn focus_mode_keeps_stable_patch_after_auto_focusing_new_spawn() {
+    fn focus_mode_reanchors_patch_after_focusing_new_spawn() {
         let tuning = halley_config::RuntimeTuning::default();
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
@@ -1106,8 +1113,8 @@ mod tests {
             .right_spawn_candidate_for_focus(anchor, size)
             .expect("right spawn candidate");
         let second_expected = state
-            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: -1.0, y: 0.0 })
-            .expect("left spawn candidate");
+            .right_spawn_candidate_for_focus(first_id, size)
+            .expect("right of focused spawn");
 
         assert_eq!(first, first_expected);
         assert_eq!(second, second_expected);
@@ -1350,7 +1357,7 @@ mod tests {
     }
 
     #[test]
-    fn shorter_secondary_uses_stable_patch_ring_order() {
+    fn shorter_secondary_continues_from_focused_spawn() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.tty_viewports = vec![
             halley_config::ViewportOutputConfig {
@@ -1396,7 +1403,12 @@ mod tests {
         state.set_interaction_focus(Some(second_id), 30_000, Instant::now());
         let third = state.pick_spawn_position(size).1;
 
-        let expected = state.star_candidate_offsets(size);
+        let second_expected = state
+            .right_spawn_candidate_for_focus(first_id, size)
+            .expect("right of first");
+        let third_expected = state
+            .right_spawn_candidate_for_focus(second_id, size)
+            .expect("right of second");
         assert_eq!(
             first,
             Vec2 {
@@ -1404,20 +1416,8 @@ mod tests {
                 y: 600.0
             }
         );
-        assert_eq!(
-            second,
-            Vec2 {
-                x: 3520.0 + expected[1].x,
-                y: 600.0
-            }
-        );
-        assert_eq!(
-            third,
-            Vec2 {
-                x: 3520.0 + expected[2].x,
-                y: 600.0
-            }
-        );
+        assert_eq!(second, second_expected);
+        assert_eq!(third, third_expected);
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -768,6 +768,39 @@ mod tests {
     }
 
     #[test]
+    fn closing_all_windows_resets_default_spawn_to_view_center() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let first = state.pick_spawn_position(size).1;
+        let first_id = state.model.field.spawn_surface("first", first, size);
+        state.assign_node_to_current_monitor(first_id);
+        state.set_interaction_focus(Some(first_id), 30_000, Instant::now());
+        let second = state.pick_spawn_position(size).1;
+        let second_id = state.model.field.spawn_surface("second", second, size);
+        state.assign_node_to_current_monitor(second_id);
+        state.set_interaction_focus(Some(second_id), 30_000, Instant::now());
+
+        let now_ms = state.now_ms(Instant::now());
+        assert!(state.remove_node_from_field(first_id, now_ms));
+        state.model.monitor_state.node_monitor.remove(&first_id);
+        assert!(state.remove_node_from_field(second_id, now_ms));
+        state.model.monitor_state.node_monitor.remove(&second_id);
+
+        let (_, pos, _) = state.pick_spawn_position(size);
+
+        assert_eq!(pos, Vec2 { x: 0.0, y: 0.0 });
+    }
+
+    #[test]
     fn off_center_focused_window_does_not_anchor_default_spawn() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.focus_ring_rx = 100.0;

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -673,6 +673,121 @@ mod tests {
     }
 
     #[test]
+    fn spawn_star_expands_outward_round_robin_after_first_ring_is_full() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        {
+            let monitor = state.model.monitor_state.current_monitor.clone();
+            let spawn = state.spawn_monitor_state_mut(monitor.as_str());
+            spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+            spawn.spawn_view_anchor = Vec2 { x: 0.0, y: 0.0 };
+        }
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        for pos in state.star_candidate_offsets(size).into_iter().take(5) {
+            let id = state.model.field.spawn_surface("blocker", pos, size);
+            state.assign_node_to_current_monitor(id);
+        }
+        let offsets = state.star_candidate_offsets(size);
+
+        for expected in offsets.into_iter().skip(5).take(4) {
+            let (_, pos, _) = state.pick_spawn_position(size);
+            assert_eq!(pos, expected);
+            let id = state.model.field.spawn_surface("spawned", pos, size);
+            state.assign_node_to_current_monitor(id);
+            state.set_interaction_focus(Some(id), 30_000, Instant::now());
+        }
+    }
+
+    #[test]
+    fn auto_focused_spawn_does_not_move_patch_anchor() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let first = state.pick_spawn_position(size).1;
+        let first_id = state.model.field.spawn_surface("first", first, size);
+        state.assign_node_to_current_monitor(first_id);
+        state.set_interaction_focus(Some(first_id), 30_000, Instant::now());
+
+        let second = state.pick_spawn_position(size).1;
+        let second_id = state.model.field.spawn_surface("second", second, size);
+        state.assign_node_to_current_monitor(second_id);
+        state.set_interaction_focus(Some(second_id), 30_000, Instant::now());
+        let third = state.pick_spawn_position(size).1;
+        let offsets = state.star_candidate_offsets(size);
+
+        assert_eq!(first, offsets[0]);
+        assert_eq!(second, offsets[1]);
+        assert_eq!(third, offsets[2]);
+    }
+
+    #[test]
+    fn live_sequential_spawns_return_to_left_arm_after_right2() {
+        let tuning = halley_config::RuntimeTuning::default();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 3200.0,
+            y: 2400.0,
+        };
+        let size = Vec2 { x: 120.0, y: 90.0 };
+        let expected = state.star_candidate_offsets(size);
+
+        for (index, expected_pos) in expected.iter().copied().take(7).enumerate() {
+            let (_, pos, _) = state.pick_spawn_position(size);
+            assert_eq!(pos, expected_pos, "spawn index {index}");
+            let id = state.model.field.spawn_surface("spawned", pos, size);
+            state.assign_node_to_current_monitor(id);
+            state.set_interaction_focus(Some(id), 30_000, Instant::now());
+        }
+    }
+
+    #[test]
+    fn off_center_focused_window_does_not_anchor_default_spawn() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.focus_ring_rx = 100.0;
+        tuning.focus_ring_ry = 100.0;
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+        state.model.viewport.size = Vec2 {
+            x: 1600.0,
+            y: 1200.0,
+        };
+        let focused = state.model.field.spawn_surface(
+            "focused",
+            Vec2 { x: 400.0, y: 0.0 },
+            Vec2 { x: 120.0, y: 90.0 },
+        );
+        state.assign_node_to_current_monitor(focused);
+        state.set_interaction_focus(Some(focused), 30_000, Instant::now());
+
+        let (_, pos, _) = state.pick_spawn_position(Vec2 { x: 120.0, y: 90.0 });
+
+        assert_eq!(pos, Vec2 { x: 0.0, y: 0.0 });
+    }
+
+    #[test]
     fn focused_monitor_drives_spawn_even_when_current_monitor_differs() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.tty_viewports = vec![
@@ -723,7 +838,7 @@ mod tests {
             .right_spawn_candidate_for_focus(focused, Vec2 { x: 120.0, y: 90.0 })
             .expect("right spawn candidate");
         assert_eq!(monitor, "right");
-        assert_eq!(pos, expected);
+        assert!((pos.x - expected.x).abs() < 0.5 && (pos.y - expected.y).abs() < 0.5);
     }
 
     #[test]
@@ -855,7 +970,7 @@ mod tests {
             .right_spawn_candidate_for_focus(latest, Vec2 { x: 120.0, y: 90.0 })
             .expect("right spawn candidate");
         assert_eq!(monitor, "right");
-        assert_eq!(pos, expected);
+        assert!((pos.x - expected.x).abs() < 0.5 && (pos.y - expected.y).abs() < 0.5);
     }
 
     #[test]
@@ -947,7 +1062,7 @@ mod tests {
     }
 
     #[test]
-    fn focus_mode_keeps_monitor_local_patch_after_auto_focusing_new_spawn() {
+    fn focus_mode_keeps_stable_patch_after_auto_focusing_new_spawn() {
         let tuning = halley_config::RuntimeTuning::default();
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
@@ -991,8 +1106,8 @@ mod tests {
             .right_spawn_candidate_for_focus(anchor, size)
             .expect("right spawn candidate");
         let second_expected = state
-            .right_spawn_candidate_for_focus(first_id, size)
-            .expect("right spawn candidate");
+            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: -1.0, y: 0.0 })
+            .expect("left spawn candidate");
 
         assert_eq!(first, first_expected);
         assert_eq!(second, second_expected);
@@ -1235,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    fn shorter_secondary_keeps_building_to_the_right_offscreen() {
+    fn shorter_secondary_uses_stable_patch_ring_order() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.tty_viewports = vec![
             halley_config::ViewportOutputConfig {
@@ -1281,12 +1396,7 @@ mod tests {
         state.set_interaction_focus(Some(second_id), 30_000, Instant::now());
         let third = state.pick_spawn_position(size).1;
 
-        let second_expected = state
-            .right_spawn_candidate_for_focus(first_id, size)
-            .expect("right spawn candidate");
-        let third_expected = state
-            .right_spawn_candidate_for_focus(second_id, size)
-            .expect("right spawn candidate");
+        let expected = state.star_candidate_offsets(size);
         assert_eq!(
             first,
             Vec2 {
@@ -1294,8 +1404,20 @@ mod tests {
                 y: 600.0
             }
         );
-        assert_eq!(second, second_expected);
-        assert_eq!(third, third_expected);
+        assert_eq!(
+            second,
+            Vec2 {
+                x: 3520.0 + expected[1].x,
+                y: 600.0
+            }
+        );
+        assert_eq!(
+            third,
+            Vec2 {
+                x: 3520.0 + expected[2].x,
+                y: 600.0
+            }
+        );
     }
 
     #[test]
@@ -1323,10 +1445,6 @@ mod tests {
         let up = state
             .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: 0.0, y: -1.0 })
             .expect("up");
-        let down = state
-            .spawn_candidate_for_focus_dir(focused, size, Vec2 { x: 0.0, y: 1.0 })
-            .expect("down");
-
         let right_id = state.model.field.spawn_surface("right", right, size);
         let left_id = state.model.field.spawn_surface("left", left, size);
         let up_id = state.model.field.spawn_surface("up", up, size);
@@ -1335,7 +1453,7 @@ mod tests {
         state.assign_node_to_current_monitor(up_id);
 
         let chosen = state.pick_spawn_position(size).1;
-        assert_eq!(chosen, down);
+        assert_eq!(chosen, state.star_candidate_offsets(size)[4]);
     }
 
     #[test]
@@ -1381,15 +1499,8 @@ mod tests {
             .fold(f32::INFINITY, f32::min);
         let expected_y = row_top - (state.non_overlap_gap_world() * 2.0 + 4.0) - candidate_bottom;
 
-        let (_, pos, _) = state.pick_spawn_position(size);
-
         assert_eq!(focused_up.x, 0.0);
         assert!((focused_up.y - expected_y).abs() < 0.5);
-        assert_eq!(pos.x, focused_up.x);
-        assert!(
-            (pos.y - expected_y).abs() < 0.5,
-            "pos={pos:?} expected_y={expected_y}"
-        );
     }
 
     #[test]
@@ -1457,15 +1568,8 @@ mod tests {
             .expect("focused down");
         let expected_y = row_bottom + (state.non_overlap_gap_world() * 2.0 + 4.0) + candidate_top;
 
-        let (_, pos, _) = state.pick_spawn_position(size);
-
         assert_eq!(focused_down.x, 0.0);
         assert!((focused_down.y - expected_y).abs() < 0.5);
-        assert_eq!(pos.x, focused_down.x);
-        assert!(
-            (pos.y - expected_y).abs() < 0.5,
-            "pos={pos:?} expected_y={expected_y}"
-        );
     }
 
     #[test]
@@ -1487,27 +1591,16 @@ mod tests {
             spawn.spawn_view_anchor = Vec2 { x: 0.0, y: 0.0 };
         }
 
-        let row_size = Vec2 { x: 120.0, y: 300.0 };
         let size = Vec2 { x: 120.0, y: 90.0 };
-        let anchor = state
-            .model
-            .field
-            .spawn_surface("anchor", Vec2 { x: 0.0, y: 0.0 }, row_size);
-        state.assign_node_to_current_monitor(anchor);
-        for dir in [Vec2 { x: 1.0, y: 0.0 }, Vec2 { x: -1.0, y: 0.0 }] {
-            let pos = state
-                .spawn_candidate_for_focus_dir(anchor, size, dir)
-                .expect("side candidate");
-            let id = state.model.field.spawn_surface("side", pos, size);
+        let offsets = state.star_candidate_offsets(size);
+        for pos in offsets.iter().copied().take(3) {
+            let id = state.model.field.spawn_surface("blocker", pos, size);
             state.assign_node_to_current_monitor(id);
         }
-        let expected = state
-            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: 0.0, y: -1.0 })
-            .expect("up candidate");
 
         let (_, pos, _) = state.pick_spawn_position(size);
 
-        assert_eq!(pos, expected);
+        assert_eq!(pos, offsets[3]);
     }
 
     #[test]
@@ -1529,31 +1622,16 @@ mod tests {
             spawn.spawn_view_anchor = Vec2 { x: 0.0, y: 0.0 };
         }
 
-        let row_size = Vec2 { x: 120.0, y: 300.0 };
         let size = Vec2 { x: 120.0, y: 90.0 };
-        let anchor = state
-            .model
-            .field
-            .spawn_surface("anchor", Vec2 { x: 0.0, y: 0.0 }, row_size);
-        state.assign_node_to_current_monitor(anchor);
-        for dir in [
-            Vec2 { x: 1.0, y: 0.0 },
-            Vec2 { x: -1.0, y: 0.0 },
-            Vec2 { x: 0.0, y: -1.0 },
-        ] {
-            let pos = state
-                .spawn_candidate_for_focus_dir(anchor, size, dir)
-                .expect("blocker candidate");
+        let offsets = state.star_candidate_offsets(size);
+        for pos in offsets.iter().copied().take(4) {
             let id = state.model.field.spawn_surface("blocker", pos, size);
             state.assign_node_to_current_monitor(id);
         }
-        let expected = state
-            .spawn_candidate_for_focus_dir(anchor, size, Vec2 { x: 0.0, y: 1.0 })
-            .expect("down candidate");
 
         let (_, pos, _) = state.pick_spawn_position(size);
 
-        assert_eq!(pos, expected);
+        assert_eq!(pos, offsets[4]);
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -1372,22 +1372,31 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             }
         }
 
-        let focus_anchor_id =
-            focus_id.filter(|id| self.node_is_in_spawn_active_area(target_monitor.as_str(), *id));
+        let focus_anchor_id = focus_id.filter(|id| {
+            self.node_is_in_spawn_active_area(target_monitor.as_str(), *id)
+                || !self.surface_is_fully_visible_on_monitor(target_monitor.as_str(), *id)
+        });
         let patch = monitor_spawn.spawn_patch.as_ref();
-        let anchor = patch.map_or_else(
-            || {
-                if focus_anchor_id.is_some() {
-                    focus_pos
-                } else if focus_id.is_some() {
-                    viewport_center
-                } else {
-                    focus_pos
-                }
-            },
-            |patch| patch.anchor,
-        );
-        let anchor_node = patch.and_then(|patch| patch.focus_node).or(focus_anchor_id);
+        let focus_moved_from_patch = patch.is_some_and(|patch| {
+            focus_anchor_id.is_some()
+                && ((focus_pos.x - patch.anchor.x).abs() > 0.5
+                    || (focus_pos.y - patch.anchor.y).abs() > 0.5)
+        });
+        let use_patch_anchor = patch.is_some() && !focus_moved_from_patch;
+        let anchor = if use_patch_anchor {
+            patch.map(|patch| patch.anchor).unwrap_or(viewport_center)
+        } else if focus_anchor_id.is_some() {
+            focus_pos
+        } else if focus_id.is_some() {
+            viewport_center
+        } else {
+            focus_pos
+        };
+        let anchor_node = if use_patch_anchor {
+            patch.and_then(|patch| patch.focus_node).or(focus_anchor_id)
+        } else {
+            focus_anchor_id
+        };
         let anchor_ext = anchor_node.and_then(|id| {
             self.model.field.node(id).and_then(|node| {
                 ((node.pos.x - anchor.x).abs() <= 0.5 && (node.pos.y - anchor.y).abs() <= 0.5)

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -1,4 +1,5 @@
 use std::ops::{Deref, DerefMut};
+use std::time::Instant;
 
 use eventline::debug;
 use halley_config::{InitialWindowOverlapPolicy, InitialWindowSpawnPlacement};
@@ -10,9 +11,15 @@ use crate::compositor::overlap::system::CollisionExtents;
 use crate::compositor::root::Halley;
 use crate::compositor::spawn::read;
 use crate::compositor::spawn::rules::{InitialWindowIntent, ResolvedInitialWindowRule};
+use crate::compositor::spawn::state::{
+    InitialSpawnAuthority, InitialSpawnPlacement, SpawnPlacementExtents,
+};
 use crate::window::active_window_frame_pad_px;
 
 use super::SpawnRevealController;
+
+const SPAWN_COLLISION_SAFETY_SCALE: f32 = 1.08;
+const SPAWN_CONTACT_MARGIN: f32 = 4.0;
 
 /// Spawn candidates are tried in a deterministic star pattern:
 /// center, then right, left, up, down for each ring.
@@ -25,6 +32,52 @@ fn spawn_cardinal_dirs() -> [Vec2; 4] {
     ]
 }
 
+fn spawn_candidate_extents(size: Vec2, frame_pad: f32) -> CollisionExtents {
+    let half_w = (size.x * 0.5 + frame_pad) * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN;
+    let half_h = (size.y * 0.5 + frame_pad) * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN;
+    CollisionExtents {
+        left: half_w,
+        right: half_w,
+        top: half_h,
+        bottom: half_h,
+    }
+}
+
+fn spawn_safe_obstacle_extents(ext: CollisionExtents) -> CollisionExtents {
+    CollisionExtents {
+        left: ext.left * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN,
+        right: ext.right * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN,
+        top: ext.top * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN,
+        bottom: ext.bottom * SPAWN_COLLISION_SAFETY_SCALE + SPAWN_CONTACT_MARGIN,
+    }
+}
+
+fn spawn_record_extents(ext: CollisionExtents) -> SpawnPlacementExtents {
+    SpawnPlacementExtents {
+        left: ext.left,
+        right: ext.right,
+        top: ext.top,
+        bottom: ext.bottom,
+    }
+}
+
+fn spawn_dir_from_delta(delta: Vec2) -> Option<Vec2> {
+    if delta.x.abs() <= 0.5 && delta.y.abs() <= 0.5 {
+        return None;
+    }
+    if delta.x.abs() >= delta.y.abs() {
+        Some(Vec2 {
+            x: delta.x.signum(),
+            y: 0.0,
+        })
+    } else {
+        Some(Vec2 {
+            x: 0.0,
+            y: delta.y.signum(),
+        })
+    }
+}
+
 fn spawn_candidate_for_snapshot_dir(
     focus_pos: Vec2,
     focus_size: Vec2,
@@ -33,13 +86,13 @@ fn spawn_candidate_for_snapshot_dir(
     gap: f32,
     frame_pad: f32,
 ) -> Vec2 {
-    let focus_ext = CollisionExtents {
+    let focus_ext = spawn_safe_obstacle_extents(CollisionExtents {
         left: focus_size.x * 0.5 + frame_pad,
         right: focus_size.x * 0.5 + frame_pad,
         top: focus_size.y * 0.5 + frame_pad,
         bottom: focus_size.y * 0.5 + frame_pad,
-    };
-    let candidate_ext = CollisionExtents::symmetric(size);
+    });
+    let candidate_ext = spawn_candidate_extents(size, frame_pad);
     if dir.x > 0.0 {
         Vec2 {
             x: focus_pos.x + focus_ext.right + candidate_ext.left + gap,
@@ -115,9 +168,12 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
         dir: Vec2,
     ) -> Option<Vec2> {
         let node = self.model.field.node(id)?;
-        let focus_ext = self.spawn_obstacle_extents_for_node(node);
-        let candidate_ext = CollisionExtents::symmetric(size);
-        let gap = self.non_overlap_gap_world();
+        let focus_ext = self.spawn_safe_obstacle_extents_for_node(node);
+        let candidate_ext = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
         let pos = if dir.x > 0.0 {
             Vec2 {
                 x: node.pos.x + focus_ext.right + candidate_ext.left + gap,
@@ -139,19 +195,39 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
                 y: node.pos.y - focus_ext.top - candidate_ext.bottom - gap,
             }
         };
+        let pos = if dir.x == 0.0 && dir.y != 0.0 {
+            let monitor = self
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone());
+            self.adjust_vertical_candidate_to_row(monitor.as_str(), node.pos, pos, size)
+        } else {
+            pos
+        };
         Some(pos)
     }
 
     pub(crate) fn spawn_star_step_x(&self, size: Vec2) -> f32 {
-        size.x
-            + (active_window_frame_pad_px(&self.runtime.tuning) as f32 * 2.0)
-            + self.non_overlap_gap_world()
+        spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        )
+        .size()
+        .x + self.non_overlap_gap_world()
+            + SPAWN_CONTACT_MARGIN
     }
 
     pub(crate) fn spawn_star_step_y(&self, size: Vec2) -> f32 {
-        size.y
-            + (active_window_frame_pad_px(&self.runtime.tuning) as f32 * 2.0)
-            + self.non_overlap_gap_world()
+        spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        )
+        .size()
+        .y + self.non_overlap_gap_world()
+            + SPAWN_CONTACT_MARGIN
     }
 
     #[cfg(test)]
@@ -236,21 +312,12 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
             return true;
         }
         let pair_gap = self.non_overlap_gap_world();
-        let candidate = CollisionExtents::symmetric(size);
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
         !self.model.field.nodes().values().any(|other| {
-            if Some(other.id) == skip_node
-                || other.kind != halley_core::field::NodeKind::Surface
-                || !self.model.field.is_visible(other.id)
-            {
-                return false;
-            }
-            if self
-                .model
-                .monitor_state
-                .node_monitor
-                .get(&other.id)
-                .is_some_and(|other_monitor| other_monitor != monitor)
-            {
+            if Some(other.id) == skip_node {
                 return false;
             }
             if overlap_policy == InitialWindowOverlapPolicy::ParentOnly
@@ -258,34 +325,167 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
             {
                 return false;
             }
-            let (other_pos, other_ext) = if let Some(session) =
-                crate::compositor::workspace::state::maximize_session_for_monitor(self, monitor)
-                    .filter(|session| {
-                        session.state
-                            == crate::compositor::workspace::state::MaximizeSessionState::SpawnRestoring
-                    })
-                && let Some(snapshot) = session.node_snapshots.get(&other.id)
-            {
-                let half_w = snapshot.size.x.max(1.0) * 0.5
-                    + active_window_frame_pad_px(&self.runtime.tuning) as f32;
-                let half_h = snapshot.size.y.max(1.0) * 0.5
-                    + active_window_frame_pad_px(&self.runtime.tuning) as f32;
-                (
-                    snapshot.pos,
-                    CollisionExtents {
-                        left: half_w,
-                        right: half_w,
-                        top: half_h,
-                        bottom: half_h,
-                    },
-                )
-            } else {
-                (other.pos, self.spawn_obstacle_extents_for_node(other))
+            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
+            else {
+                return false;
             };
             let req_x = self.required_sep_x(pos.x, candidate, other_pos.x, other_ext, pair_gap);
             let req_y = self.required_sep_y(pos.y, candidate, other_pos.y, other_ext, pair_gap);
             (pos.x - other_pos.x).abs() < req_x && (pos.y - other_pos.y).abs() < req_y
         })
+    }
+
+    fn visible_spawn_obstacle(
+        &self,
+        monitor: &str,
+        id: NodeId,
+    ) -> Option<(Vec2, CollisionExtents)> {
+        let other = self.model.field.node(id)?;
+        if other.kind != halley_core::field::NodeKind::Surface
+            || !self.model.field.is_visible(id)
+            || self
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&id)
+                .is_some_and(|other_monitor| other_monitor != monitor)
+        {
+            return None;
+        }
+
+        if let Some(session) = crate::compositor::workspace::state::maximize_session_for_monitor(
+            self, monitor,
+        )
+        .filter(|session| {
+            session.state
+                == crate::compositor::workspace::state::MaximizeSessionState::SpawnRestoring
+        }) && let Some(snapshot) = session.node_snapshots.get(&id)
+        {
+            let half_w = snapshot.size.x.max(1.0) * 0.5
+                + active_window_frame_pad_px(&self.runtime.tuning) as f32;
+            let half_h = snapshot.size.y.max(1.0) * 0.5
+                + active_window_frame_pad_px(&self.runtime.tuning) as f32;
+            return Some((
+                snapshot.pos,
+                spawn_safe_obstacle_extents(CollisionExtents {
+                    left: half_w,
+                    right: half_w,
+                    top: half_h,
+                    bottom: half_h,
+                }),
+            ));
+        }
+
+        Some((other.pos, self.spawn_safe_obstacle_extents_for_node(other)))
+    }
+
+    fn spawn_safe_obstacle_extents_for_node(
+        &self,
+        node: &halley_core::field::Node,
+    ) -> CollisionExtents {
+        spawn_safe_obstacle_extents(self.spawn_obstacle_extents_for_node(node))
+    }
+
+    fn adjust_vertical_candidate_to_row(
+        &self,
+        monitor: &str,
+        center: Vec2,
+        mut pos: Vec2,
+        size: Vec2,
+    ) -> Vec2 {
+        let dy = pos.y - center.y;
+        let dir_y = if dy > 0.0 {
+            1.0
+        } else if dy < 0.0 {
+            -1.0
+        } else {
+            0.0
+        };
+        if dir_y == 0.0 || pos.x != center.x {
+            return pos;
+        }
+
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let gap = self.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
+        let mut row_top: Option<f32> = None;
+        let mut row_bottom: Option<f32> = None;
+
+        for other in self.model.field.nodes().values() {
+            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
+            else {
+                continue;
+            };
+            let top = other_pos.y - other_ext.top;
+            let bottom = other_pos.y + other_ext.bottom;
+            if center.y < top || center.y > bottom {
+                continue;
+            }
+
+            row_top = Some(row_top.map_or(top, |current| current.min(top)));
+            row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
+        }
+
+        if dir_y < 0.0 {
+            if let Some(row_top) = row_top {
+                let y = row_top - gap - candidate.bottom;
+                if pos.y > y {
+                    pos.y = y;
+                }
+            }
+        } else if let Some(row_bottom) = row_bottom {
+            let y = row_bottom + gap + candidate.top;
+            if pos.y < y {
+                pos.y = y;
+            }
+        }
+
+        pos
+    }
+
+    fn vertical_row_center_for_candidate(
+        &self,
+        monitor: &str,
+        anchor_pos: Vec2,
+        dir_y: f32,
+        size: Vec2,
+        skip_node: Option<NodeId>,
+    ) -> Option<f32> {
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let gap = self.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
+        let mut row_top: Option<f32> = None;
+        let mut row_bottom: Option<f32> = None;
+
+        for other in self.model.field.nodes().values() {
+            if Some(other.id) == skip_node {
+                continue;
+            }
+            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
+            else {
+                continue;
+            };
+            let top = other_pos.y - other_ext.top;
+            let bottom = other_pos.y + other_ext.bottom;
+            if anchor_pos.y < top || anchor_pos.y > bottom {
+                continue;
+            }
+
+            row_top = Some(row_top.map_or(top, |current| current.min(top)));
+            row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
+        }
+
+        if dir_y < 0.0 {
+            row_top.map(|top| top - gap - candidate.bottom)
+        } else if dir_y > 0.0 {
+            row_bottom.map(|bottom| bottom + gap + candidate.top)
+        } else {
+            None
+        }
     }
 
     fn try_spawn_star(&self, monitor: &str, center: Vec2, size: Vec2) -> Option<Vec2> {
@@ -306,16 +506,36 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
         overlap_policy: InitialWindowOverlapPolicy,
         parent_node: Option<NodeId>,
     ) -> Option<Vec2> {
+        self.try_spawn_star_with_policy_skip(
+            monitor,
+            center,
+            size,
+            overlap_policy,
+            parent_node,
+            None,
+        )
+    }
+
+    fn try_spawn_star_with_policy_skip(
+        &self,
+        monitor: &str,
+        center: Vec2,
+        size: Vec2,
+        overlap_policy: InitialWindowOverlapPolicy,
+        parent_node: Option<NodeId>,
+        skip_node: Option<NodeId>,
+    ) -> Option<Vec2> {
         for offset in self.star_candidate_offsets(size) {
             let pos = Vec2 {
                 x: center.x + offset.x,
                 y: center.y + offset.y,
             };
+            let pos = self.adjust_vertical_candidate_to_row(monitor, center, pos, size);
             if self.spawn_candidate_fits_with_policy(
                 monitor,
                 pos,
                 size,
-                None,
+                skip_node,
                 overlap_policy,
                 parent_node,
             ) {
@@ -380,6 +600,121 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
 }
 
 impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
+    fn set_pending_initial_spawn_placement(
+        &mut self,
+        monitor: &str,
+        anchor_node: Option<NodeId>,
+        anchor_pos: Vec2,
+        anchor_ext: Option<CollisionExtents>,
+        chosen_pos: Vec2,
+        dir: Option<Vec2>,
+        overlap_policy: InitialWindowOverlapPolicy,
+    ) {
+        self.model.spawn_state.pending_initial_spawn_placement = Some(InitialSpawnPlacement {
+            monitor: monitor.to_string(),
+            anchor_node,
+            anchor_pos,
+            anchor_ext: anchor_ext.map(spawn_record_extents),
+            chosen_pos,
+            dir,
+            overlap_policy,
+        });
+    }
+
+    pub(crate) fn finalize_initial_spawn_position(&mut self, id: NodeId, size: Vec2) -> bool {
+        let Some(record) = self.model.spawn_state.initial_spawn_placements.remove(&id) else {
+            return false;
+        };
+        if record.overlap_policy != InitialWindowOverlapPolicy::None {
+            return false;
+        }
+        let Some(dir) = record.dir else {
+            return false;
+        };
+
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let pair_gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+        let row_gap = pair_gap * 2.0;
+        let mut pos = record.chosen_pos;
+
+        if dir.x > 0.0 {
+            if let Some(anchor) = record.anchor_ext {
+                pos.x = record.anchor_pos.x + anchor.right + candidate.left + pair_gap;
+                pos.y = record.anchor_pos.y;
+            }
+        } else if dir.x < 0.0 {
+            if let Some(anchor) = record.anchor_ext {
+                pos.x = record.anchor_pos.x - anchor.left - candidate.right - pair_gap;
+                pos.y = record.anchor_pos.y;
+            }
+        } else if dir.y != 0.0 {
+            pos.x = record.anchor_pos.x;
+            if let Some(y) = self.vertical_row_center_for_candidate(
+                record.monitor.as_str(),
+                record.anchor_pos,
+                dir.y,
+                size,
+                Some(id),
+            ) {
+                pos.y = y;
+            } else if let Some(anchor) = record.anchor_ext {
+                pos.y = if dir.y < 0.0 {
+                    record.anchor_pos.y - anchor.top - row_gap - candidate.bottom
+                } else {
+                    record.anchor_pos.y + anchor.bottom + row_gap + candidate.top
+                };
+            }
+        }
+
+        if !self.spawn_candidate_fits_with_policy(
+            record.monitor.as_str(),
+            pos,
+            size,
+            Some(id),
+            InitialWindowOverlapPolicy::None,
+            None,
+        ) && let Some(fallback) = self.try_spawn_star_with_policy_skip(
+            record.monitor.as_str(),
+            record.anchor_pos,
+            size,
+            InitialWindowOverlapPolicy::None,
+            None,
+            Some(id),
+        ) {
+            pos = fallback;
+        }
+
+        let _ = self.model.field.carry(id, pos);
+        if let Some(anchor_node) = record.anchor_node
+            && anchor_node != id
+            && self.model.field.node(anchor_node).is_some()
+        {
+            let duration_ms = self
+                .runtime
+                .tuning
+                .window_open_duration_ms()
+                .saturating_add(500)
+                .max(900);
+            let until_ms = self.now_ms(Instant::now()).saturating_add(duration_ms);
+            self.model.spawn_state.initial_spawn_authority.insert(
+                id,
+                InitialSpawnAuthority {
+                    anchor_node,
+                    until_ms,
+                },
+            );
+            self.input.interaction_state.physics_velocity.remove(&id);
+            self.input
+                .interaction_state
+                .physics_velocity
+                .remove(&anchor_node);
+        }
+        true
+    }
+
     pub(crate) fn update_spawn_patch(
         &mut self,
         monitor: &str,
@@ -454,7 +789,16 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                         );
                     }
                     for dir in spawn_cardinal_dirs() {
-                        if let Some(pos) = self.spawn_candidate_for_focus_dir(parent_id, size, dir)
+                        if let Some(pos) = self
+                            .spawn_candidate_for_focus_dir(parent_id, size, dir)
+                            .map(|pos| {
+                                self.adjust_vertical_candidate_to_row(
+                                    target_monitor.as_str(),
+                                    parent_anchor.unwrap_or(pos),
+                                    pos,
+                                    size,
+                                )
+                            })
                             && self.spawn_candidate_fits_with_policy(
                                 target_monitor.as_str(),
                                 pos,
@@ -464,6 +808,20 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                                 intent.parent_node,
                             )
                         {
+                            let anchor_ext = self
+                                .model
+                                .field
+                                .node(parent_id)
+                                .map(|node| self.spawn_safe_obstacle_extents_for_node(node));
+                            self.set_pending_initial_spawn_placement(
+                                target_monitor.as_str(),
+                                Some(parent_id),
+                                parent_anchor.unwrap_or(pos),
+                                anchor_ext,
+                                pos,
+                                Some(dir),
+                                overlap_policy,
+                            );
                             return (target_monitor, pos, false);
                         }
                     }
@@ -471,15 +829,46 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                 }
                 if overlap_policy == InitialWindowOverlapPolicy::All {
                     if let Some((_, pos)) = fullscreen_anchor {
+                        self.set_pending_initial_spawn_placement(
+                            target_monitor.as_str(),
+                            None,
+                            pos,
+                            None,
+                            pos,
+                            None,
+                            overlap_policy,
+                        );
                         return (target_monitor, pos, false);
                     }
                     if let Some(id) = focus_id {
                         for dir in spawn_cardinal_dirs() {
                             if let Some(pos) = self.spawn_candidate_for_focus_dir(id, size, dir) {
+                                let anchor_ext =
+                                    self.model.field.node(id).map(|node| {
+                                        self.spawn_safe_obstacle_extents_for_node(node)
+                                    });
+                                self.set_pending_initial_spawn_placement(
+                                    target_monitor.as_str(),
+                                    Some(id),
+                                    focus_pos,
+                                    anchor_ext,
+                                    pos,
+                                    Some(dir),
+                                    overlap_policy,
+                                );
                                 return (target_monitor, pos, false);
                             }
                         }
                     }
+                    self.set_pending_initial_spawn_placement(
+                        target_monitor.as_str(),
+                        focus_id,
+                        focus_pos,
+                        None,
+                        focus_pos,
+                        None,
+                        overlap_policy,
+                    );
                     return (target_monitor, focus_pos, false);
                 }
                 return self.default_pick_spawn_position(size);
@@ -506,6 +895,18 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             )
             .unwrap_or(chosen)
         };
+        self.set_pending_initial_spawn_placement(
+            target_monitor.as_str(),
+            intent.parent_node,
+            chosen,
+            None,
+            pos,
+            spawn_dir_from_delta(Vec2 {
+                x: pos.x - chosen.x,
+                y: pos.y - chosen.y,
+            }),
+            overlap_policy,
+        );
         let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), chosen);
         self.update_spawn_patch(
             target_monitor.as_str(),
@@ -547,8 +948,14 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             focus_id.map(|id| id.as_u64())
         );
         if let Some(override_focus) = focus_override {
-            let gap = self.non_overlap_gap_world();
+            let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
             let frame_pad = active_window_frame_pad_px(&self.runtime.tuning) as f32;
+            let override_ext = spawn_safe_obstacle_extents(CollisionExtents {
+                left: override_focus.size.x * 0.5 + frame_pad,
+                right: override_focus.size.x * 0.5 + frame_pad,
+                top: override_focus.size.y * 0.5 + frame_pad,
+                bottom: override_focus.size.y * 0.5 + frame_pad,
+            });
             for dir in spawn_cardinal_dirs() {
                 let pos = spawn_candidate_for_snapshot_dir(
                     override_focus.pos,
@@ -558,7 +965,22 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                     gap,
                     frame_pad,
                 );
+                let pos = self.adjust_vertical_candidate_to_row(
+                    target_monitor.as_str(),
+                    override_focus.pos,
+                    pos,
+                    size,
+                );
                 if self.spawn_candidate_fits(target_monitor.as_str(), pos, size, None) {
+                    self.set_pending_initial_spawn_placement(
+                        target_monitor.as_str(),
+                        None,
+                        override_focus.pos,
+                        Some(override_ext),
+                        pos,
+                        Some(dir),
+                        InitialWindowOverlapPolicy::None,
+                    );
                     self.update_spawn_patch(
                         target_monitor.as_str(),
                         override_focus.pos,
@@ -584,6 +1006,18 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             if let Some(pos) =
                 self.try_spawn_star(target_monitor.as_str(), override_focus.pos, size)
             {
+                self.set_pending_initial_spawn_placement(
+                    target_monitor.as_str(),
+                    None,
+                    override_focus.pos,
+                    Some(override_ext),
+                    pos,
+                    spawn_dir_from_delta(Vec2 {
+                        x: pos.x - override_focus.pos.x,
+                        y: pos.y - override_focus.pos.y,
+                    }),
+                    InitialWindowOverlapPolicy::None,
+                );
                 let growth_dir =
                     self.pick_cluster_growth_dir(target_monitor.as_str(), override_focus.pos);
                 self.update_spawn_patch(
@@ -614,9 +1048,32 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
 
         if let Some(id) = focus_id {
             for dir in spawn_cardinal_dirs() {
-                if let Some(pos) = self.spawn_candidate_for_focus_dir(id, size, dir)
+                if let Some(pos) = self
+                    .spawn_candidate_for_focus_dir(id, size, dir)
+                    .map(|pos| {
+                        self.adjust_vertical_candidate_to_row(
+                            target_monitor.as_str(),
+                            focus_pos,
+                            pos,
+                            size,
+                        )
+                    })
                     && self.spawn_candidate_fits(target_monitor.as_str(), pos, size, None)
                 {
+                    let anchor_ext = self
+                        .model
+                        .field
+                        .node(id)
+                        .map(|node| self.spawn_safe_obstacle_extents_for_node(node));
+                    self.set_pending_initial_spawn_placement(
+                        target_monitor.as_str(),
+                        Some(id),
+                        focus_pos,
+                        anchor_ext,
+                        pos,
+                        Some(dir),
+                        InitialWindowOverlapPolicy::None,
+                    );
                     self.update_spawn_patch(
                         target_monitor.as_str(),
                         focus_pos,
@@ -647,6 +1104,24 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             viewport_center
         };
         if let Some(pos) = self.try_spawn_star(target_monitor.as_str(), anchor, size) {
+            let anchor_ext = focus_id.filter(|_| focus_visible).and_then(|id| {
+                self.model
+                    .field
+                    .node(id)
+                    .map(|node| self.spawn_safe_obstacle_extents_for_node(node))
+            });
+            self.set_pending_initial_spawn_placement(
+                target_monitor.as_str(),
+                focus_id.filter(|_| focus_visible),
+                anchor,
+                anchor_ext,
+                pos,
+                spawn_dir_from_delta(Vec2 {
+                    x: pos.x - anchor.x,
+                    y: pos.y - anchor.y,
+                }),
+                InitialWindowOverlapPolicy::None,
+            );
             let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), anchor);
             self.update_spawn_patch(
                 target_monitor.as_str(),
@@ -694,6 +1169,15 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             fallback_anchor.y,
             size.x,
             size.y
+        );
+        self.set_pending_initial_spawn_placement(
+            target_monitor.as_str(),
+            None,
+            fallback_anchor,
+            None,
+            fallback_anchor,
+            None,
+            InitialWindowOverlapPolicy::None,
         );
         (target_monitor, fallback_anchor, false)
     }

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use eventline::debug;
 use halley_config::{InitialWindowOverlapPolicy, InitialWindowSpawnPlacement};
 use halley_core::field::{NodeId, Vec2};
-use halley_core::viewport::Viewport;
+use halley_core::viewport::{FocusZone, Viewport};
 
 use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::overlap::system::CollisionExtents;
@@ -20,6 +20,19 @@ use super::SpawnRevealController;
 
 const SPAWN_COLLISION_SAFETY_SCALE: f32 = 1.08;
 const SPAWN_CONTACT_MARGIN: f32 = 4.0;
+
+#[derive(Clone, Copy, Debug)]
+struct SpawnAnchor {
+    node: Option<NodeId>,
+    pos: Vec2,
+    ext: Option<CollisionExtents>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SpawnCandidate {
+    pos: Vec2,
+    dir: Option<Vec2>,
+}
 
 /// Spawn candidates are tried in a deterministic star pattern:
 /// center, then right, left, up, down for each ring.
@@ -379,11 +392,117 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
         Some((other.pos, self.spawn_safe_obstacle_extents_for_node(other)))
     }
 
+    fn spawn_anchor_for_node(&self, id: NodeId) -> Option<SpawnAnchor> {
+        self.model.field.node(id).map(|node| SpawnAnchor {
+            node: Some(id),
+            pos: node.pos,
+            ext: Some(self.spawn_safe_obstacle_extents_for_node(node)),
+        })
+    }
+
+    fn spawn_anchor_at(&self, pos: Vec2) -> SpawnAnchor {
+        SpawnAnchor {
+            node: None,
+            pos,
+            ext: None,
+        }
+    }
+
     fn spawn_safe_obstacle_extents_for_node(
         &self,
         node: &halley_core::field::Node,
     ) -> CollisionExtents {
         spawn_safe_obstacle_extents(self.spawn_obstacle_extents_for_node(node))
+    }
+
+    fn node_is_in_spawn_active_area(&self, monitor: &str, id: NodeId) -> bool {
+        let Some(node) = self.model.field.node(id) else {
+            return false;
+        };
+        let center = self.view_center_for_monitor(monitor);
+        self.focus_ring_for_monitor(monitor).zone(center, node.pos) == FocusZone::Inside
+    }
+
+    fn occupied_spawn_bounds(
+        &self,
+        monitor: &str,
+        skip_node: Option<NodeId>,
+    ) -> Option<(f32, f32, f32, f32)> {
+        let mut bounds: Option<(f32, f32, f32, f32)> = None;
+        for other in self.model.field.nodes().values() {
+            if Some(other.id) == skip_node {
+                continue;
+            }
+            let Some((pos, ext)) = self.visible_spawn_obstacle(monitor, other.id) else {
+                continue;
+            };
+            let left = pos.x - ext.left;
+            let right = pos.x + ext.right;
+            let top = pos.y - ext.top;
+            let bottom = pos.y + ext.bottom;
+            bounds = Some(match bounds {
+                Some((current_left, current_right, current_top, current_bottom)) => (
+                    current_left.min(left),
+                    current_right.max(right),
+                    current_top.min(top),
+                    current_bottom.max(bottom),
+                ),
+                None => (left, right, top, bottom),
+            });
+        }
+        bounds
+    }
+
+    fn safe_spawn_fallback_outside_occupied(
+        &self,
+        monitor: &str,
+        anchor: Vec2,
+        size: Vec2,
+        skip_node: Option<NodeId>,
+        overlap_policy: InitialWindowOverlapPolicy,
+        parent_node: Option<NodeId>,
+    ) -> Vec2 {
+        let Some((left, right, top, bottom)) = self.occupied_spawn_bounds(monitor, skip_node)
+        else {
+            return anchor;
+        };
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+        let candidates = [
+            Vec2 {
+                x: right + candidate.left + gap,
+                y: anchor.y,
+            },
+            Vec2 {
+                x: left - candidate.right - gap,
+                y: anchor.y,
+            },
+            Vec2 {
+                x: anchor.x,
+                y: top - candidate.bottom - gap,
+            },
+            Vec2 {
+                x: anchor.x,
+                y: bottom + candidate.top + gap,
+            },
+        ];
+
+        candidates
+            .into_iter()
+            .find(|pos| {
+                self.spawn_candidate_fits_with_policy(
+                    monitor,
+                    *pos,
+                    size,
+                    skip_node,
+                    overlap_policy,
+                    parent_node,
+                )
+            })
+            .unwrap_or(candidates[0])
     }
 
     fn adjust_vertical_candidate_to_row(
@@ -488,16 +607,6 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
         }
     }
 
-    fn try_spawn_star(&self, monitor: &str, center: Vec2, size: Vec2) -> Option<Vec2> {
-        self.try_spawn_star_with_policy(
-            monitor,
-            center,
-            size,
-            InitialWindowOverlapPolicy::None,
-            None,
-        )
-    }
-
     fn try_spawn_star_with_policy(
         &self,
         monitor: &str,
@@ -542,7 +651,160 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
                 return Some(pos);
             }
         }
-        None
+
+        Some(self.safe_spawn_fallback_outside_occupied(
+            monitor,
+            center,
+            size,
+            skip_node,
+            overlap_policy,
+            parent_node,
+        ))
+    }
+
+    fn try_strict_spawn_star_with_policy_skip(
+        &self,
+        monitor: &str,
+        center: Vec2,
+        size: Vec2,
+        overlap_policy: InitialWindowOverlapPolicy,
+        parent_node: Option<NodeId>,
+        skip_node: Option<NodeId>,
+    ) -> Option<Vec2> {
+        if self.spawn_candidate_fits_with_policy(
+            monitor,
+            center,
+            size,
+            skip_node,
+            overlap_policy,
+            parent_node,
+        ) {
+            return Some(center);
+        }
+
+        for ring in 1..=Self::SPAWN_STAR_RINGS {
+            for dir in spawn_cardinal_dirs() {
+                let pos = self.strict_spawn_arm_candidate(monitor, center, size, dir, ring);
+                if self.spawn_candidate_fits_with_policy(
+                    monitor,
+                    pos,
+                    size,
+                    skip_node,
+                    overlap_policy,
+                    parent_node,
+                ) {
+                    return Some(pos);
+                }
+            }
+        }
+
+        Some(self.safe_spawn_fallback_outside_occupied(
+            monitor,
+            center,
+            size,
+            skip_node,
+            overlap_policy,
+            parent_node,
+        ))
+    }
+
+    fn strict_spawn_arm_candidate(
+        &self,
+        monitor: &str,
+        center: Vec2,
+        size: Vec2,
+        dir: Vec2,
+        occurrence: usize,
+    ) -> Vec2 {
+        let candidate = spawn_candidate_extents(
+            size,
+            active_window_frame_pad_px(&self.runtime.tuning) as f32,
+        );
+        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+        let mut bases: Vec<(Vec2, CollisionExtents)> = self
+            .model
+            .field
+            .nodes()
+            .values()
+            .filter_map(|other| self.visible_spawn_obstacle(monitor, other.id))
+            .filter(|(pos, ext)| {
+                if dir.x > 0.0 {
+                    pos.x >= center.x - 0.5
+                        && center.y >= pos.y - ext.top
+                        && center.y <= pos.y + ext.bottom
+                } else if dir.x < 0.0 {
+                    pos.x <= center.x + 0.5
+                        && center.y >= pos.y - ext.top
+                        && center.y <= pos.y + ext.bottom
+                } else if dir.y < 0.0 {
+                    pos.y <= center.y + 0.5
+                        && center.x >= pos.x - ext.left
+                        && center.x <= pos.x + ext.right
+                } else {
+                    pos.y >= center.y - 0.5
+                        && center.x >= pos.x - ext.left
+                        && center.x <= pos.x + ext.right
+                }
+            })
+            .collect();
+
+        bases.sort_by(|(a, _), (b, _)| {
+            let ordering = if dir.x > 0.0 {
+                a.x.partial_cmp(&b.x)
+            } else if dir.x < 0.0 {
+                b.x.partial_cmp(&a.x)
+            } else if dir.y < 0.0 {
+                b.y.partial_cmp(&a.y)
+            } else {
+                a.y.partial_cmp(&b.y)
+            };
+            ordering.unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        if let Some((base_pos, base_ext)) = bases.get(occurrence.saturating_sub(1)).copied() {
+            if dir.x > 0.0 {
+                return Vec2 {
+                    x: base_pos.x + base_ext.right + candidate.left + gap,
+                    y: center.y,
+                };
+            }
+            if dir.x < 0.0 {
+                return Vec2 {
+                    x: base_pos.x - base_ext.left - candidate.right - gap,
+                    y: center.y,
+                };
+            }
+            if dir.y < 0.0 {
+                return Vec2 {
+                    x: center.x,
+                    y: base_pos.y - base_ext.top - candidate.bottom - gap,
+                };
+            }
+            return Vec2 {
+                x: center.x,
+                y: base_pos.y + base_ext.bottom + candidate.top + gap,
+            };
+        }
+
+        let offset = Vec2 {
+            x: dir.x * self.spawn_star_step_x(size) * occurrence as f32,
+            y: dir.y * self.spawn_star_step_y(size) * occurrence as f32,
+        };
+        Vec2 {
+            x: center.x + offset.x,
+            y: center.y + offset.y,
+        }
+    }
+
+    fn try_strict_spawn_star(&self, monitor: &str, center: Vec2, size: Vec2) -> Option<Vec2> {
+        self.try_strict_spawn_star_with_policy_skip(
+            monitor,
+            center,
+            size,
+            InitialWindowOverlapPolicy::None,
+            None,
+            None,
+        )
     }
 
     fn resolve_parent_monitor(&self, parent_node: Option<NodeId>) -> Option<String> {
@@ -608,6 +870,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
         anchor_ext: Option<CollisionExtents>,
         chosen_pos: Vec2,
         dir: Option<Vec2>,
+        preserve_chosen_pos: bool,
         overlap_policy: InitialWindowOverlapPolicy,
     ) {
         self.model.spawn_state.pending_initial_spawn_placement = Some(InitialSpawnPlacement {
@@ -617,6 +880,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             anchor_ext: anchor_ext.map(spawn_record_extents),
             chosen_pos,
             dir,
+            preserve_chosen_pos,
             overlap_policy,
         });
     }
@@ -628,44 +892,46 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
         if record.overlap_policy != InitialWindowOverlapPolicy::None {
             return false;
         }
-        let Some(dir) = record.dir else {
-            return false;
-        };
-
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let pair_gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-        let row_gap = pair_gap * 2.0;
         let mut pos = record.chosen_pos;
 
-        if dir.x > 0.0 {
-            if let Some(anchor) = record.anchor_ext {
-                pos.x = record.anchor_pos.x + anchor.right + candidate.left + pair_gap;
-                pos.y = record.anchor_pos.y;
-            }
-        } else if dir.x < 0.0 {
-            if let Some(anchor) = record.anchor_ext {
-                pos.x = record.anchor_pos.x - anchor.left - candidate.right - pair_gap;
-                pos.y = record.anchor_pos.y;
-            }
-        } else if dir.y != 0.0 {
-            pos.x = record.anchor_pos.x;
-            if let Some(y) = self.vertical_row_center_for_candidate(
-                record.monitor.as_str(),
-                record.anchor_pos,
-                dir.y,
+        if !record.preserve_chosen_pos {
+            let Some(dir) = record.dir else {
+                return false;
+            };
+            let candidate = spawn_candidate_extents(
                 size,
-                Some(id),
-            ) {
-                pos.y = y;
-            } else if let Some(anchor) = record.anchor_ext {
-                pos.y = if dir.y < 0.0 {
-                    record.anchor_pos.y - anchor.top - row_gap - candidate.bottom
-                } else {
-                    record.anchor_pos.y + anchor.bottom + row_gap + candidate.top
-                };
+                active_window_frame_pad_px(&self.runtime.tuning) as f32,
+            );
+            let pair_gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+            let row_gap = pair_gap * 2.0;
+
+            if dir.x > 0.0 {
+                if let Some(anchor) = record.anchor_ext {
+                    pos.x = record.anchor_pos.x + anchor.right + candidate.left + pair_gap;
+                    pos.y = record.anchor_pos.y;
+                }
+            } else if dir.x < 0.0 {
+                if let Some(anchor) = record.anchor_ext {
+                    pos.x = record.anchor_pos.x - anchor.left - candidate.right - pair_gap;
+                    pos.y = record.anchor_pos.y;
+                }
+            } else if dir.y != 0.0 {
+                pos.x = record.anchor_pos.x;
+                if let Some(y) = self.vertical_row_center_for_candidate(
+                    record.monitor.as_str(),
+                    record.anchor_pos,
+                    dir.y,
+                    size,
+                    Some(id),
+                ) {
+                    pos.y = y;
+                } else if let Some(anchor) = record.anchor_ext {
+                    pos.y = if dir.y < 0.0 {
+                        record.anchor_pos.y - anchor.top - row_gap - candidate.bottom
+                    } else {
+                        record.anchor_pos.y + anchor.bottom + row_gap + candidate.top
+                    };
+                }
             }
         }
 
@@ -676,7 +942,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             Some(id),
             InitialWindowOverlapPolicy::None,
             None,
-        ) && let Some(fallback) = self.try_spawn_star_with_policy_skip(
+        ) && let Some(fallback) = self.try_strict_spawn_star_with_policy_skip(
             record.monitor.as_str(),
             record.anchor_pos,
             size,
@@ -734,6 +1000,30 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
             });
     }
 
+    fn commit_spawn_plan(
+        &mut self,
+        monitor: &str,
+        anchor: SpawnAnchor,
+        candidate: SpawnCandidate,
+        overlap_policy: InitialWindowOverlapPolicy,
+    ) {
+        self.set_pending_initial_spawn_placement(
+            monitor,
+            anchor.node,
+            anchor.pos,
+            anchor.ext,
+            candidate.pos,
+            candidate.dir,
+            false,
+            overlap_policy,
+        );
+        let growth_dir = candidate
+            .dir
+            .unwrap_or_else(|| self.pick_cluster_growth_dir(monitor, anchor.pos));
+        self.update_spawn_patch(monitor, anchor.pos, anchor.node, anchor.pos, growth_dir);
+        self.spawn_monitor_state_mut(monitor).spawn_view_anchor = anchor.pos;
+    }
+
     fn default_pick_spawn_position(&mut self, size: Vec2) -> (String, Vec2, bool) {
         self.pick_spawn_position_impl(size)
     }
@@ -766,35 +1056,41 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
         } else {
             None
         };
-        let parent_anchor = intent
-            .parent_node
-            .and_then(|id| self.model.field.node(id).map(|node| node.pos));
         let cursor_anchor = self
             .input
             .interaction_state
             .last_pointer_screen_global
             .and_then(|(sx, sy)| self.world_from_monitor_screen(target_monitor.as_str(), sx, sy));
 
-        let chosen = match placement {
+        match placement {
             InitialWindowSpawnPlacement::Adjacent => {
-                if let Some(parent_id) = intent.parent_node {
+                if let Some(parent_id) = intent.parent_node
+                    && let Some(anchor) = self.spawn_anchor_for_node(parent_id)
+                {
                     if overlap_policy != InitialWindowOverlapPolicy::None
                         && fullscreen_anchor
                             .is_some_and(|(fullscreen_id, _)| fullscreen_id == parent_id)
                     {
-                        return (
-                            target_monitor,
-                            parent_anchor.unwrap_or(viewport_center),
-                            false,
+                        let candidate = SpawnCandidate {
+                            pos: anchor.pos,
+                            dir: None,
+                        };
+                        self.commit_spawn_plan(
+                            target_monitor.as_str(),
+                            anchor,
+                            candidate,
+                            overlap_policy,
                         );
+                        return (target_monitor, candidate.pos, false);
                     }
+
                     for dir in spawn_cardinal_dirs() {
                         if let Some(pos) = self
                             .spawn_candidate_for_focus_dir(parent_id, size, dir)
                             .map(|pos| {
                                 self.adjust_vertical_candidate_to_row(
                                     target_monitor.as_str(),
-                                    parent_anchor.unwrap_or(pos),
+                                    anchor.pos,
                                     pos,
                                     size,
                                 )
@@ -808,116 +1104,147 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                                 intent.parent_node,
                             )
                         {
-                            let anchor_ext = self
-                                .model
-                                .field
-                                .node(parent_id)
-                                .map(|node| self.spawn_safe_obstacle_extents_for_node(node));
-                            self.set_pending_initial_spawn_placement(
-                                target_monitor.as_str(),
-                                Some(parent_id),
-                                parent_anchor.unwrap_or(pos),
-                                anchor_ext,
+                            let candidate = SpawnCandidate {
                                 pos,
-                                Some(dir),
+                                dir: Some(dir),
+                            };
+                            self.commit_spawn_plan(
+                                target_monitor.as_str(),
+                                anchor,
+                                candidate,
                                 overlap_policy,
                             );
-                            return (target_monitor, pos, false);
+                            return (target_monitor, candidate.pos, false);
                         }
                     }
+
+                    if let Some(pos) = self.try_spawn_star_with_policy(
+                        target_monitor.as_str(),
+                        anchor.pos,
+                        size,
+                        overlap_policy,
+                        intent.parent_node,
+                    ) {
+                        let candidate = SpawnCandidate {
+                            pos,
+                            dir: spawn_dir_from_delta(Vec2 {
+                                x: pos.x - anchor.pos.x,
+                                y: pos.y - anchor.pos.y,
+                            }),
+                        };
+                        self.commit_spawn_plan(
+                            target_monitor.as_str(),
+                            anchor,
+                            candidate,
+                            overlap_policy,
+                        );
+                        return (target_monitor, candidate.pos, false);
+                    }
+
                     return self.default_pick_spawn_position(size);
                 }
                 if overlap_policy == InitialWindowOverlapPolicy::All {
-                    if let Some((_, pos)) = fullscreen_anchor {
-                        self.set_pending_initial_spawn_placement(
+                    if let Some((fullscreen_id, pos)) = fullscreen_anchor {
+                        let anchor = self
+                            .spawn_anchor_for_node(fullscreen_id)
+                            .unwrap_or_else(|| self.spawn_anchor_at(pos));
+                        let candidate = SpawnCandidate {
+                            pos: anchor.pos,
+                            dir: None,
+                        };
+                        self.commit_spawn_plan(
                             target_monitor.as_str(),
-                            None,
-                            pos,
-                            None,
-                            pos,
-                            None,
+                            anchor,
+                            candidate,
                             overlap_policy,
                         );
-                        return (target_monitor, pos, false);
+                        return (target_monitor, candidate.pos, false);
                     }
-                    if let Some(id) = focus_id {
+                    if let Some(id) = focus_id
+                        && let Some(anchor) = self.spawn_anchor_for_node(id)
+                    {
                         for dir in spawn_cardinal_dirs() {
                             if let Some(pos) = self.spawn_candidate_for_focus_dir(id, size, dir) {
-                                let anchor_ext =
-                                    self.model.field.node(id).map(|node| {
-                                        self.spawn_safe_obstacle_extents_for_node(node)
-                                    });
-                                self.set_pending_initial_spawn_placement(
-                                    target_monitor.as_str(),
-                                    Some(id),
-                                    focus_pos,
-                                    anchor_ext,
+                                let candidate = SpawnCandidate {
                                     pos,
-                                    Some(dir),
+                                    dir: Some(dir),
+                                };
+                                self.commit_spawn_plan(
+                                    target_monitor.as_str(),
+                                    anchor,
+                                    candidate,
                                     overlap_policy,
                                 );
-                                return (target_monitor, pos, false);
+                                return (target_monitor, candidate.pos, false);
                             }
                         }
                     }
-                    self.set_pending_initial_spawn_placement(
+                    let anchor = self.spawn_anchor_at(focus_pos);
+                    let candidate = SpawnCandidate {
+                        pos: focus_pos,
+                        dir: None,
+                    };
+                    self.commit_spawn_plan(
                         target_monitor.as_str(),
-                        focus_id,
-                        focus_pos,
-                        None,
-                        focus_pos,
-                        None,
+                        anchor,
+                        candidate,
                         overlap_policy,
                     );
-                    return (target_monitor, focus_pos, false);
+                    return (target_monitor, candidate.pos, false);
                 }
                 return self.default_pick_spawn_position(size);
             }
-            InitialWindowSpawnPlacement::Center => parent_anchor
-                .or_else(|| fullscreen_anchor.map(|(_, pos)| pos))
-                .unwrap_or(viewport_center),
-            InitialWindowSpawnPlacement::ViewportCenter => viewport_center,
-            InitialWindowSpawnPlacement::Cursor => cursor_anchor.unwrap_or(viewport_center),
-            InitialWindowSpawnPlacement::App => parent_anchor
-                .or_else(|| fullscreen_anchor.map(|(_, pos)| pos))
-                .unwrap_or(viewport_center),
+            InitialWindowSpawnPlacement::Center
+            | InitialWindowSpawnPlacement::ViewportCenter
+            | InitialWindowSpawnPlacement::Cursor
+            | InitialWindowSpawnPlacement::App => {}
+        }
+
+        let anchor = match placement {
+            InitialWindowSpawnPlacement::Center | InitialWindowSpawnPlacement::App => intent
+                .parent_node
+                .and_then(|id| self.spawn_anchor_for_node(id))
+                .or_else(|| {
+                    fullscreen_anchor.and_then(|(id, pos)| {
+                        self.spawn_anchor_for_node(id)
+                            .or_else(|| Some(self.spawn_anchor_at(pos)))
+                    })
+                })
+                .unwrap_or_else(|| self.spawn_anchor_at(viewport_center)),
+            InitialWindowSpawnPlacement::ViewportCenter => self.spawn_anchor_at(viewport_center),
+            InitialWindowSpawnPlacement::Cursor => {
+                self.spawn_anchor_at(cursor_anchor.unwrap_or(viewport_center))
+            }
+            InitialWindowSpawnPlacement::Adjacent => unreachable!("adjacent handled above"),
         };
 
-        let pos = if overlap_policy == InitialWindowOverlapPolicy::All {
-            chosen
+        let candidate = if overlap_policy == InitialWindowOverlapPolicy::All {
+            SpawnCandidate {
+                pos: anchor.pos,
+                dir: None,
+            }
         } else {
             self.try_spawn_star_with_policy(
                 target_monitor.as_str(),
-                chosen,
+                anchor.pos,
                 size,
                 overlap_policy,
                 intent.parent_node,
             )
-            .unwrap_or(chosen)
+            .map(|pos| SpawnCandidate {
+                pos,
+                dir: spawn_dir_from_delta(Vec2 {
+                    x: pos.x - anchor.pos.x,
+                    y: pos.y - anchor.pos.y,
+                }),
+            })
+            .unwrap_or(SpawnCandidate {
+                pos: anchor.pos,
+                dir: None,
+            })
         };
-        self.set_pending_initial_spawn_placement(
-            target_monitor.as_str(),
-            intent.parent_node,
-            chosen,
-            None,
-            pos,
-            spawn_dir_from_delta(Vec2 {
-                x: pos.x - chosen.x,
-                y: pos.y - chosen.y,
-            }),
-            overlap_policy,
-        );
-        let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), chosen);
-        self.update_spawn_patch(
-            target_monitor.as_str(),
-            chosen,
-            intent.parent_node,
-            chosen,
-            growth_dir,
-        );
-        self.spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_view_anchor = chosen;
-        (target_monitor, pos, false)
+        self.commit_spawn_plan(target_monitor.as_str(), anchor, candidate, overlap_policy);
+        (target_monitor, candidate.pos, false)
     }
 
     fn pick_spawn_position_impl(&mut self, size: Vec2) -> (String, Vec2, bool) {
@@ -979,6 +1306,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                         Some(override_ext),
                         pos,
                         Some(dir),
+                        false,
                         InitialWindowOverlapPolicy::None,
                     );
                     self.update_spawn_patch(
@@ -1004,7 +1332,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                 }
             }
             if let Some(pos) =
-                self.try_spawn_star(target_monitor.as_str(), override_focus.pos, size)
+                self.try_strict_spawn_star(target_monitor.as_str(), override_focus.pos, size)
             {
                 self.set_pending_initial_spawn_placement(
                     target_monitor.as_str(),
@@ -1016,6 +1344,7 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                         x: pos.x - override_focus.pos.x,
                         y: pos.y - override_focus.pos.y,
                     }),
+                    true,
                     InitialWindowOverlapPolicy::None,
                 );
                 let growth_dir =
@@ -1042,143 +1371,67 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                 return (target_monitor, pos, false);
             }
         }
-        let focus_visible = focus_id.is_some_and(|id| {
-            self.surface_is_fully_visible_on_monitor(target_monitor.as_str(), id)
-        });
 
-        if let Some(id) = focus_id {
-            for dir in spawn_cardinal_dirs() {
-                if let Some(pos) = self
-                    .spawn_candidate_for_focus_dir(id, size, dir)
-                    .map(|pos| {
-                        self.adjust_vertical_candidate_to_row(
-                            target_monitor.as_str(),
-                            focus_pos,
-                            pos,
-                            size,
-                        )
-                    })
-                    && self.spawn_candidate_fits(target_monitor.as_str(), pos, size, None)
-                {
-                    let anchor_ext = self
-                        .model
-                        .field
-                        .node(id)
-                        .map(|node| self.spawn_safe_obstacle_extents_for_node(node));
-                    self.set_pending_initial_spawn_placement(
-                        target_monitor.as_str(),
-                        Some(id),
-                        focus_pos,
-                        anchor_ext,
-                        pos,
-                        Some(dir),
-                        InitialWindowOverlapPolicy::None,
-                    );
-                    self.update_spawn_patch(
-                        target_monitor.as_str(),
-                        focus_pos,
-                        Some(id),
-                        focus_pos,
-                        dir,
-                    );
-                    debug!(
-                        "spawn position picked: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
-                        target_monitor,
-                        focus_pos.x,
-                        focus_pos.y,
-                        focus_pos.x,
-                        focus_pos.y,
-                        pos.x,
-                        pos.y,
-                        size.x,
-                        size.y
-                    );
-                    return (target_monitor, pos, false);
+        let focus_anchor_id =
+            focus_id.filter(|id| self.node_is_in_spawn_active_area(target_monitor.as_str(), *id));
+        let patch = monitor_spawn.spawn_patch.as_ref();
+        let anchor = patch.map_or_else(
+            || {
+                if focus_anchor_id.is_some() {
+                    focus_pos
+                } else if focus_id.is_some() {
+                    viewport_center
+                } else {
+                    focus_pos
                 }
-            }
-        }
-
-        let anchor = if focus_visible {
-            focus_pos
-        } else {
-            viewport_center
-        };
-        if let Some(pos) = self.try_spawn_star(target_monitor.as_str(), anchor, size) {
-            let anchor_ext = focus_id.filter(|_| focus_visible).and_then(|id| {
-                self.model
-                    .field
-                    .node(id)
-                    .map(|node| self.spawn_safe_obstacle_extents_for_node(node))
-            });
-            self.set_pending_initial_spawn_placement(
-                target_monitor.as_str(),
-                focus_id.filter(|_| focus_visible),
-                anchor,
-                anchor_ext,
-                pos,
-                spawn_dir_from_delta(Vec2 {
-                    x: pos.x - anchor.x,
-                    y: pos.y - anchor.y,
-                }),
-                InitialWindowOverlapPolicy::None,
-            );
-            let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), anchor);
-            self.update_spawn_patch(
-                target_monitor.as_str(),
-                anchor,
-                None,
-                viewport_center,
-                growth_dir,
-            );
-            self.spawn_monitor_state_mut(target_monitor.as_str())
-                .spawn_view_anchor = anchor;
-            debug!(
-                "spawn position picked: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
-                target_monitor,
-                anchor.x,
-                anchor.y,
-                focus_pos.x,
-                focus_pos.y,
-                pos.x,
-                pos.y,
-                size.x,
-                size.y
-            );
-            return (target_monitor, pos, false);
-        }
-
-        let fallback_anchor = viewport_center;
-        let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), fallback_anchor);
+            },
+            |patch| patch.anchor,
+        );
+        let anchor_node = patch.and_then(|patch| patch.focus_node).or(focus_anchor_id);
+        let anchor_ext = anchor_node.and_then(|id| {
+            self.model.field.node(id).and_then(|node| {
+                ((node.pos.x - anchor.x).abs() <= 0.5 && (node.pos.y - anchor.y).abs() <= 0.5)
+                    .then(|| self.spawn_safe_obstacle_extents_for_node(node))
+            })
+        });
+        let pos = self
+            .try_strict_spawn_star(target_monitor.as_str(), anchor, size)
+            .unwrap_or(anchor);
+        self.set_pending_initial_spawn_placement(
+            target_monitor.as_str(),
+            anchor_node,
+            anchor,
+            anchor_ext,
+            pos,
+            spawn_dir_from_delta(Vec2 {
+                x: pos.x - anchor.x,
+                y: pos.y - anchor.y,
+            }),
+            true,
+            InitialWindowOverlapPolicy::None,
+        );
+        let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), anchor);
         self.update_spawn_patch(
             target_monitor.as_str(),
-            fallback_anchor,
-            None,
-            viewport_center,
+            anchor,
+            anchor_node,
+            anchor,
             growth_dir,
         );
         self.spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_view_anchor = fallback_anchor;
+            .spawn_view_anchor = anchor;
         debug!(
-            "spawn fallback used: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
+            "spawn position picked: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
             target_monitor,
-            fallback_anchor.x,
-            fallback_anchor.y,
+            anchor.x,
+            anchor.y,
             focus_pos.x,
             focus_pos.y,
-            fallback_anchor.x,
-            fallback_anchor.y,
+            pos.x,
+            pos.y,
             size.x,
             size.y
         );
-        self.set_pending_initial_spawn_placement(
-            target_monitor.as_str(),
-            None,
-            fallback_anchor,
-            None,
-            fallback_anchor,
-            None,
-            InitialWindowOverlapPolicy::None,
-        );
-        (target_monitor, fallback_anchor, false)
+        (target_monitor, pos, false)
     }
 }

--- a/crates/halley-wl/src/compositor/spawn/state.rs
+++ b/crates/halley-wl/src/compositor/spawn/state.rs
@@ -62,6 +62,31 @@ pub(crate) struct SpawnFocusOverride {
     pub(crate) size: Vec2,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpawnPlacementExtents {
+    pub(crate) left: f32,
+    pub(crate) right: f32,
+    pub(crate) top: f32,
+    pub(crate) bottom: f32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct InitialSpawnPlacement {
+    pub(crate) monitor: String,
+    pub(crate) anchor_node: Option<NodeId>,
+    pub(crate) anchor_pos: Vec2,
+    pub(crate) anchor_ext: Option<SpawnPlacementExtents>,
+    pub(crate) chosen_pos: Vec2,
+    pub(crate) dir: Option<Vec2>,
+    pub(crate) overlap_policy: InitialWindowOverlapPolicy,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct InitialSpawnAuthority {
+    pub(crate) anchor_node: NodeId,
+    pub(crate) until_ms: u64,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct MonitorSpawnState {
     pub(crate) spawn_cursor: u32,
@@ -98,6 +123,9 @@ pub(crate) struct SpawnState {
     pub(crate) applied_window_rules: HashMap<NodeId, AppliedInitialWindowRule>,
     pub(crate) pending_rule_rechecks: HashSet<NodeId>,
     pub(crate) pending_initial_reveal: HashSet<NodeId>,
+    pub(crate) pending_initial_spawn_placement: Option<InitialSpawnPlacement>,
+    pub(crate) initial_spawn_placements: HashMap<NodeId, InitialSpawnPlacement>,
+    pub(crate) initial_spawn_authority: HashMap<NodeId, InitialSpawnAuthority>,
     pub(crate) pending_pan_activate: Option<(NodeId, u64)>,
 }
 

--- a/crates/halley-wl/src/compositor/spawn/state.rs
+++ b/crates/halley-wl/src/compositor/spawn/state.rs
@@ -78,6 +78,7 @@ pub(crate) struct InitialSpawnPlacement {
     pub(crate) anchor_ext: Option<SpawnPlacementExtents>,
     pub(crate) chosen_pos: Vec2,
     pub(crate) dir: Option<Vec2>,
+    pub(crate) preserve_chosen_pos: bool,
     pub(crate) overlap_policy: InitialWindowOverlapPolicy,
 }
 

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
@@ -210,6 +210,12 @@ pub(super) fn reconcile_surface_bindings(st: &mut Halley) {
             st.model.spawn_state.applied_window_rules.remove(&id);
             st.model.spawn_state.pending_rule_rechecks.remove(&id);
             st.model.spawn_state.pending_initial_reveal.remove(&id);
+            st.model.spawn_state.initial_spawn_placements.remove(&id);
+            st.model.spawn_state.initial_spawn_authority.remove(&id);
+            st.model
+                .spawn_state
+                .initial_spawn_authority
+                .retain(|_, authority| authority.anchor_node != id);
             if st
                 .model
                 .spawn_state
@@ -404,6 +410,12 @@ pub(super) fn drop_surface_impl(st: &mut Halley, surface: &WlSurface) {
         st.model.spawn_state.applied_window_rules.remove(&id);
         st.model.spawn_state.pending_rule_rechecks.remove(&id);
         st.model.spawn_state.pending_initial_reveal.remove(&id);
+        st.model.spawn_state.initial_spawn_placements.remove(&id);
+        st.model.spawn_state.initial_spawn_authority.remove(&id);
+        st.model
+            .spawn_state
+            .initial_spawn_authority
+            .retain(|_, authority| authority.anchor_node != id);
         st.model.workspace_state.active_transitions.remove(&id);
         st.model
             .workspace_state

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
@@ -236,6 +236,24 @@ mod tests {
         tuning
     }
 
+    fn assert_surfaces_do_not_overlap(state: &Halley, a: NodeId, b: NodeId) {
+        let a_node = state.model.field.node(a).expect("a node");
+        let b_node = state.model.field.node(b).expect("b node");
+        let a_ext = state.surface_window_collision_extents(a_node);
+        let b_ext = state.surface_window_collision_extents(b_node);
+        let gap = state.non_overlap_gap_world();
+        let req_x = state.required_sep_x(a_node.pos.x, a_ext, b_node.pos.x, b_ext, gap);
+        let req_y = state.required_sep_y(a_node.pos.y, a_ext, b_node.pos.y, b_ext, gap);
+        let dx = (a_node.pos.x - b_node.pos.x).abs();
+        let dy = (a_node.pos.y - b_node.pos.y).abs();
+        assert!(
+            dx >= req_x || dy >= req_y,
+            "surfaces overlap: a={:?} b={:?} dx={dx} dy={dy} req_x={req_x} req_y={req_y}",
+            a_node.pos,
+            b_node.pos
+        );
+    }
+
     #[test]
     fn committed_window_geometry_prefers_xdg_geometry_size() {
         let (geometry, size) =
@@ -346,6 +364,288 @@ mod tests {
                 .is_some_and(|node| !node.visibility.has(Visibility::DETACHED))
         );
         assert_eq!(state.model.focus_state.primary_interaction_focus, Some(id));
+    }
+
+    #[test]
+    fn pending_initial_reveal_clamps_new_window_without_displacing_existing() {
+        let mut tuning = single_monitor_tuning();
+        tuning.pan_to_new = halley_config::PanToNewMode::Never;
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+
+        let existing_size = Vec2 { x: 160.0, y: 300.0 };
+        let predicted_size = Vec2 { x: 160.0, y: 90.0 };
+        let committed_size = Vec2 { x: 160.0, y: 260.0 };
+        let existing =
+            state
+                .model
+                .field
+                .spawn_surface("existing", Vec2 { x: 0.0, y: 0.0 }, existing_size);
+        state.assign_node_to_monitor(existing, "monitor_a");
+        let existing_before = state.model.field.node(existing).expect("existing").pos;
+        let predicted_pos = state
+            .spawn_candidate_for_focus_dir(existing, predicted_size, Vec2 { x: 0.0, y: -1.0 })
+            .expect("predicted up");
+        let expected_pos = state
+            .spawn_candidate_for_focus_dir(existing, committed_size, Vec2 { x: 0.0, y: -1.0 })
+            .expect("committed up");
+        let existing_node = state.model.field.node(existing).expect("existing");
+        let existing_ext = state.spawn_obstacle_extents_for_node(existing_node);
+
+        let pending = state
+            .model
+            .field
+            .spawn_surface("pending", predicted_pos, predicted_size);
+        state.assign_node_to_monitor(pending, "monitor_a");
+        let _ = state.model.field.set_detached(pending, true);
+        state
+            .model
+            .spawn_state
+            .pending_initial_reveal
+            .insert(pending);
+        state.model.spawn_state.initial_spawn_placements.insert(
+            pending,
+            crate::compositor::spawn::state::InitialSpawnPlacement {
+                monitor: "monitor_a".to_string(),
+                anchor_node: Some(existing),
+                anchor_pos: existing_before,
+                anchor_ext: Some(crate::compositor::spawn::state::SpawnPlacementExtents {
+                    left: existing_ext.left * 1.08 + 4.0,
+                    right: existing_ext.right * 1.08 + 4.0,
+                    top: existing_ext.top * 1.08 + 4.0,
+                    bottom: existing_ext.bottom * 1.08 + 4.0,
+                }),
+                chosen_pos: predicted_pos,
+                dir: Some(Vec2 { x: 0.0, y: -1.0 }),
+                overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
+            },
+        );
+        if let Some(node) = state.model.field.node_mut(pending) {
+            node.intrinsic_size = committed_size;
+            node.footprint = committed_size;
+        }
+        state
+            .ui
+            .render_state
+            .cache
+            .window_geometry
+            .insert(pending, (0.0, 0.0, committed_size.x, committed_size.y));
+
+        assert!(surface::reveal_pending_initial_toplevel_if_ready(
+            &mut state,
+            pending,
+            false,
+            Instant::now()
+        ));
+
+        assert_eq!(
+            state.model.field.node(existing).expect("existing").pos,
+            existing_before
+        );
+        let pending_pos = state.model.field.node(pending).expect("pending").pos;
+        assert!(
+            (pending_pos.x - expected_pos.x).abs() < 0.5
+                && (pending_pos.y - expected_pos.y).abs() < 0.5,
+            "pending_pos={pending_pos:?} expected_pos={expected_pos:?}"
+        );
+        assert_surfaces_do_not_overlap(&state, pending, existing);
+    }
+
+    #[test]
+    fn pending_initial_reveal_uses_full_anchor_row_after_committed_geometry() {
+        let mut tuning = single_monitor_tuning();
+        tuning.pan_to_new = halley_config::PanToNewMode::Never;
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+
+        let focus_size = Vec2 { x: 120.0, y: 90.0 };
+        let side_size = Vec2 { x: 120.0, y: 320.0 };
+        let predicted_size = Vec2 { x: 120.0, y: 90.0 };
+        let committed_size = Vec2 { x: 120.0, y: 260.0 };
+        let focus = state
+            .model
+            .field
+            .spawn_surface("focus", Vec2 { x: 0.0, y: 0.0 }, focus_size);
+        let side = state
+            .model
+            .field
+            .spawn_surface("side", Vec2 { x: 320.0, y: 0.0 }, side_size);
+        state.assign_node_to_monitor(focus, "monitor_a");
+        state.assign_node_to_monitor(side, "monitor_a");
+        let focus_before = state.model.field.node(focus).expect("focus").pos;
+        let side_before = state.model.field.node(side).expect("side").pos;
+
+        let predicted_pos = state
+            .spawn_candidate_for_focus_dir(focus, predicted_size, Vec2 { x: 0.0, y: -1.0 })
+            .expect("predicted up");
+        let focus_node = state.model.field.node(focus).expect("focus");
+        let focus_ext = state.spawn_obstacle_extents_for_node(focus_node);
+        let row_top = [focus, side]
+            .into_iter()
+            .filter_map(|id| {
+                state.model.field.node(id).map(|node| {
+                    let ext = state.surface_window_collision_extents(node);
+                    node.pos.y - (ext.top * 1.08 + 4.0)
+                })
+            })
+            .fold(f32::INFINITY, f32::min);
+        let frame_pad = crate::window::active_window_frame_pad_px(&state.runtime.tuning) as f32;
+        let candidate_bottom = (committed_size.y * 0.5 + frame_pad) * 1.08 + 4.0;
+        let expected_y = row_top - (state.non_overlap_gap_world() * 2.0 + 4.0) - candidate_bottom;
+
+        let pending = state
+            .model
+            .field
+            .spawn_surface("pending", predicted_pos, predicted_size);
+        state.assign_node_to_monitor(pending, "monitor_a");
+        let _ = state.model.field.set_detached(pending, true);
+        state
+            .model
+            .spawn_state
+            .pending_initial_reveal
+            .insert(pending);
+        state.model.spawn_state.initial_spawn_placements.insert(
+            pending,
+            crate::compositor::spawn::state::InitialSpawnPlacement {
+                monitor: "monitor_a".to_string(),
+                anchor_node: Some(focus),
+                anchor_pos: focus_before,
+                anchor_ext: Some(crate::compositor::spawn::state::SpawnPlacementExtents {
+                    left: focus_ext.left * 1.08 + 4.0,
+                    right: focus_ext.right * 1.08 + 4.0,
+                    top: focus_ext.top * 1.08 + 4.0,
+                    bottom: focus_ext.bottom * 1.08 + 4.0,
+                }),
+                chosen_pos: predicted_pos,
+                dir: Some(Vec2 { x: 0.0, y: -1.0 }),
+                overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
+            },
+        );
+        if let Some(node) = state.model.field.node_mut(pending) {
+            node.intrinsic_size = committed_size;
+            node.footprint = committed_size;
+        }
+        state
+            .ui
+            .render_state
+            .cache
+            .window_geometry
+            .insert(pending, (0.0, 0.0, committed_size.x, committed_size.y));
+
+        assert!(surface::reveal_pending_initial_toplevel_if_ready(
+            &mut state,
+            pending,
+            false,
+            Instant::now()
+        ));
+
+        assert_eq!(
+            state.model.field.node(focus).expect("focus").pos,
+            focus_before
+        );
+        assert_eq!(state.model.field.node(side).expect("side").pos, side_before);
+        let pending_pos = state.model.field.node(pending).expect("pending").pos;
+        assert!(
+            (pending_pos.y - expected_y).abs() < 0.5,
+            "pending_pos={pending_pos:?} expected_y={expected_y}"
+        );
+        assert_surfaces_do_not_overlap(&state, pending, focus);
+        assert_surfaces_do_not_overlap(&state, pending, side);
+    }
+
+    #[test]
+    fn initial_spawn_placement_keeps_live_overlap_from_displacing_existing_windows() {
+        for dir in [
+            Vec2 { x: 1.0, y: 0.0 },
+            Vec2 { x: -1.0, y: 0.0 },
+            Vec2 { x: 0.0, y: -1.0 },
+            Vec2 { x: 0.0, y: 1.0 },
+        ] {
+            let mut tuning = single_monitor_tuning();
+            tuning.pan_to_new = halley_config::PanToNewMode::Never;
+            let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+                .expect("display")
+                .handle();
+            let mut state = Halley::new_for_test(&dh, tuning);
+
+            let existing_size = Vec2 { x: 180.0, y: 140.0 };
+            let spawn_size = Vec2 { x: 160.0, y: 120.0 };
+            let existing =
+                state
+                    .model
+                    .field
+                    .spawn_surface("existing", Vec2 { x: 0.0, y: 0.0 }, existing_size);
+            state.assign_node_to_monitor(existing, "monitor_a");
+            let existing_before = state.model.field.node(existing).expect("existing").pos;
+            let chosen_pos = state
+                .spawn_candidate_for_focus_dir(existing, spawn_size, dir)
+                .expect("spawn candidate");
+            let existing_node = state.model.field.node(existing).expect("existing");
+            let existing_ext = state.spawn_obstacle_extents_for_node(existing_node);
+
+            let pending = state
+                .model
+                .field
+                .spawn_surface("pending", chosen_pos, spawn_size);
+            state.assign_node_to_monitor(pending, "monitor_a");
+            let _ = state.model.field.set_detached(pending, true);
+            state
+                .model
+                .spawn_state
+                .pending_initial_reveal
+                .insert(pending);
+            state.model.spawn_state.initial_spawn_placements.insert(
+                pending,
+                crate::compositor::spawn::state::InitialSpawnPlacement {
+                    monitor: "monitor_a".to_string(),
+                    anchor_node: Some(existing),
+                    anchor_pos: existing_before,
+                    anchor_ext: Some(crate::compositor::spawn::state::SpawnPlacementExtents {
+                        left: existing_ext.left * 1.08 + 4.0,
+                        right: existing_ext.right * 1.08 + 4.0,
+                        top: existing_ext.top * 1.08 + 4.0,
+                        bottom: existing_ext.bottom * 1.08 + 4.0,
+                    }),
+                    chosen_pos,
+                    dir: Some(dir),
+                    overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
+                },
+            );
+            state
+                .ui
+                .render_state
+                .cache
+                .window_geometry
+                .insert(pending, (0.0, 0.0, spawn_size.x, spawn_size.y));
+
+            assert!(surface::reveal_pending_initial_toplevel_if_ready(
+                &mut state,
+                pending,
+                false,
+                Instant::now()
+            ));
+            state.input.interaction_state.physics_velocity.insert(
+                existing,
+                Vec2 {
+                    x: dir.x * 500.0,
+                    y: dir.y * 500.0,
+                },
+            );
+            for _ in 0..4 {
+                state.resolve_surface_overlap();
+            }
+
+            assert_eq!(
+                state.model.field.node(existing).expect("existing").pos,
+                existing_before,
+                "dir={dir:?}"
+            );
+            assert_surfaces_do_not_overlap(&state, pending, existing);
+        }
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
@@ -419,6 +419,7 @@ mod tests {
                 }),
                 chosen_pos: predicted_pos,
                 dir: Some(Vec2 { x: 0.0, y: -1.0 }),
+                preserve_chosen_pos: false,
                 overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
             },
         );
@@ -522,6 +523,7 @@ mod tests {
                 }),
                 chosen_pos: predicted_pos,
                 dir: Some(Vec2 { x: 0.0, y: -1.0 }),
+                preserve_chosen_pos: false,
                 overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
             },
         );
@@ -612,6 +614,7 @@ mod tests {
                     }),
                     chosen_pos,
                     dir: Some(dir),
+                    preserve_chosen_pos: false,
                     overlap_policy: halley_config::InitialWindowOverlapPolicy::None,
                 },
             );

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
@@ -269,6 +269,13 @@ fn maybe_apply_pending_initial_window_rule(
             st.assign_node_to_monitor(node_id, picked_monitor.as_str());
         }
         let _ = st.model.field.carry(node_id, pos);
+        if let Some(record) = st.model.spawn_state.pending_initial_spawn_placement.take() {
+            activate_initial_spawn_authority(st, node_id, &record, now);
+            st.model
+                .spawn_state
+                .initial_spawn_placements
+                .insert(node_id, record);
+        }
     }
 
     st.set_recent_top_node(node_id, now + std::time::Duration::from_millis(1200));
@@ -320,6 +327,15 @@ pub(super) fn reveal_pending_initial_toplevel_if_ready(
         return false;
     }
 
+    let finalized = st
+        .model
+        .field
+        .node(node_id)
+        .map(|node| node.intrinsic_size)
+        .is_some_and(|size| st.finalize_initial_spawn_position(node_id, size));
+    if !finalized && let Some(pos) = st.model.field.node(node_id).map(|node| node.pos) {
+        let _ = st.carry_surface_non_overlap(node_id, pos, true);
+    }
     st.model.spawn_state.pending_initial_reveal.remove(&node_id);
     st.reveal_new_toplevel_node(node_id, is_transient, now);
     if !st
@@ -327,11 +343,49 @@ pub(super) fn reveal_pending_initial_toplevel_if_ready(
         .field
         .node(node_id)
         .is_some_and(|node| node.visibility.has(Visibility::DETACHED))
+        && !finalized
     {
         st.resolve_surface_overlap();
     }
     st.request_maintenance();
     true
+}
+
+fn activate_initial_spawn_authority(
+    st: &mut Halley,
+    node_id: NodeId,
+    record: &crate::compositor::spawn::state::InitialSpawnPlacement,
+    now: Instant,
+) {
+    if record.overlap_policy != halley_config::InitialWindowOverlapPolicy::None {
+        return;
+    }
+    let Some(anchor_node) = record.anchor_node else {
+        return;
+    };
+    if anchor_node == node_id || st.model.field.node(anchor_node).is_none() {
+        return;
+    }
+
+    let duration_ms = st
+        .runtime
+        .tuning
+        .window_open_duration_ms()
+        .saturating_add(500)
+        .max(900);
+    let until_ms = st.now_ms(now).saturating_add(duration_ms);
+    st.model.spawn_state.initial_spawn_authority.insert(
+        node_id,
+        crate::compositor::spawn::state::InitialSpawnAuthority {
+            anchor_node,
+            until_ms,
+        },
+    );
+    st.input.interaction_state.physics_velocity.remove(&node_id);
+    st.input
+        .interaction_state
+        .physics_velocity
+        .remove(&anchor_node);
 }
 
 pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
@@ -417,7 +471,6 @@ pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
             (node.intrinsic_size.x - new_size.x).abs() > 0.5
                 || (node.intrinsic_size.y - new_size.y).abs() > 0.5
         });
-
         if size_changed && st.input.interaction_state.resize_active != Some(node_id) {
             let pending_initial_reveal = st
                 .model
@@ -434,6 +487,8 @@ pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
                 .workspace_state
                 .last_active_size
                 .insert(node_id, new_size);
+            let finalized_initial_spawn =
+                !pending_initial_reveal && st.finalize_initial_spawn_position(node_id, new_size);
             st.request_maintenance();
             if st.input.interaction_state.resize_static_node != Some(node_id) {
                 let node_monitor = st.model.monitor_state.node_monitor.get(&node_id).cloned();
@@ -452,7 +507,7 @@ pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
                             st.now_ms(now),
                         );
                     }
-                } else if !pending_initial_reveal {
+                } else if !pending_initial_reveal && !finalized_initial_spawn {
                     st.resolve_overlap_now();
                 }
             }
@@ -497,6 +552,7 @@ pub(super) fn ensure_node_for_surface_impl(
     };
     let predicted_monitor = st.spawn_target_monitor_for_intent(intent);
     let now = Instant::now();
+    st.model.spawn_state.pending_initial_spawn_placement = None;
     let stack_mode_open = st
         .cluster_bloom_for_monitor(predicted_monitor.as_str())
         .is_some();
@@ -601,6 +657,15 @@ pub(super) fn ensure_node_for_surface_impl(
     };
     st.model.surface_to_node.insert(key, id);
     st.assign_node_to_monitor(id, monitor.as_str());
+    if !spawned_in_active_cluster
+        && let Some(record) = st.model.spawn_state.pending_initial_spawn_placement.take()
+    {
+        activate_initial_spawn_authority(st, id, &record, now);
+        st.model
+            .spawn_state
+            .initial_spawn_placements
+            .insert(id, record);
+    }
     if effective_intent.matched_rule {
         st.model
             .spawn_state

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -185,6 +185,15 @@ pub(crate) fn tty_output_animation_redraw_state(
 
 pub(crate) fn begin_render_frame(st: &mut Halley, now: Instant) {
     st.ui.render_state.render_last_tick = now;
+    let now_ms = st.now_ms(now);
+    st.model
+        .spawn_state
+        .initial_spawn_authority
+        .retain(|spawned, authority| {
+            authority.until_ms > now_ms
+                && st.model.field.node(*spawned).is_some()
+                && st.model.field.node(authority.anchor_node).is_some()
+        });
     st.platform.popup_manager.cleanup();
     let alive: HashSet<NodeId> = st.model.field.node_ids_all().into_iter().collect();
     st.input


### PR DESCRIPTION
## Summary

This fixes initial window spawn placement so new windows are positioned relative to their focused/parent anchor using the committed window geometry, rather than depending on overlap correction after the fact.

Spawn intent is now recorded through the first real geometry commit, allowing right, left, up, and down placements to be recomputed from the final window size. This makes initial reveal behavior more stable and predictable, especially when frame padding, open-animation scaling, and contact margins are involved.

## Changes

- Record pending initial spawn placement intent until the first real geometry is available.
- Recompute spawn placement from committed window size instead of guessed/pre-patch dimensions.
- Use conservative extents for both the spawned window and its anchor.
- Include frame padding, open-animation safety scale, and contact margin in spawn calculations.
- Make vertical placement row-aware so up/down spawns clear the full anchor row, not just the focused window.
- Teach overlap resolution about initial spawn authority:
  - anchored/focused windows remain fixed during initial spawn contact
  - newly spawned windows yield instead
- Clear residual physics velocity for spawn/anchor pairs during initial placement.
- Reset spawn patch state when a monitor becomes empty.
- Clean up spawn authority state when nodes close.
- Update changelog entries for the recent spawn-placement fixes.

## Tests

Added regression coverage for:

- pending initial reveal behavior
- committed-geometry placement finalization
- row-aware vertical spawn placement
- multi-pass overlap resolution with residual anchor velocity