### PR TITLE
fix(wl): make maximize and fullscreen presentation-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ All notable changes to this project will be documented in this file.
 - Preserve existing keyboard focus for overlay/popup text input instead of restoring last input focus on every unbound typing key.
 - Keep maximized windows active when new or transferred windows overlap them, while allowing click raise, trail navigation, and focus cycling to bring maximized windows forward again through normal stacking.
 - Preserve the original active-window position for delayed manual collapses so the first collapse over another window visibly slides the resulting node out from under the blocker.
+- Apply the same collapsed-node placement and slide animation to automatic active-window-limit and focus-ring decay collapses.
+- Let active-window-limit collapse enforcement run during visual active-transition animations so the first automatic collapse resolves without waiting for later pointer movement.
 - Remove initial-spawn push-away authority so opening a new expanded window does not shove existing expanded windows out of the way.
 - Limit new-window reveal panning to the one case where a pinned landmark blocks the current spawn center.
 - Apply live config reloads directly and force active window render caches/full redraw after reload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.3.0] - 2026-05-30
 
 ### Added
 - Add `wp_presentation` support and send presentation feedback after TTY and winit frames so Wayland clients such as gamescope can receive frame timing instead of falling back to X11 behavior.
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Add `field.pins.background-colour` for configuring the circular pin badge background independently from the pin glyph colour.
 - Add top-right config error overlays for startup, manual reload, IPC reload, and file-watch reload failures, including scrollable diagnostics, hover pause, right-click dismissal, wheel and shift-wheel scrolling, and configurable `overlays.error-colour` styling.
 - Add strict config validation diagnostics for unknown Halley keys and invalid literals, with path, line, source text, and suggestions when available.
+- Add a selectable `animations.window-close.style "fade"` close animation that fades captured closing windows without shrinking them.
 
 ### Changed
 - Switch the field placement model so expanded windows may overlap other expanded windows while collapsed nodes and core landmarks remain non-overlapping map objects; pinned landmarks remain solid blockers during spawn, drag, and resize.
@@ -101,6 +102,7 @@ All notable changes to this project will be documented in this file.
 - Prevent right-click holds on empty field space from starting a camera pan.
 - Make overlap-policy windows stack like normal windows, drawing and hit-testing the clicked or newest overlapped window on top while hover focus does not raise it.
 - Animate unpinned collapsed nodes sliding out from under explicitly spawned or resized active windows while keeping logical overlap resolution immediate.
+- Delay manual-collapse node slide-out until the captured close animation finishes, so noding an overlapped behind window visibly slides the collapsed marker out instead of snapping under the closing snapshot.
 
 ## [v0.2.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - Draw active-window pin badges with the owning window's z-order, matching borders instead of staying globally above overlapping windows.
 - Preserve existing keyboard focus for overlay/popup text input instead of restoring last input focus on every unbound typing key.
 - Keep maximized windows active when new or transferred windows overlap them, while allowing click raise, trail navigation, and focus cycling to bring maximized windows forward again through normal stacking.
+- Preserve the original active-window position for delayed manual collapses so the first collapse over another window visibly slides the resulting node out from under the blocker.
 - Remove initial-spawn push-away authority so opening a new expanded window does not shove existing expanded windows out of the way.
 - Limit new-window reveal panning to the one case where a pinned landmark blocks the current spawn center.
 - Apply live config reloads directly and force active window render caches/full redraw after reload.
@@ -66,6 +67,7 @@ All notable changes to this project will be documented in this file.
 - Keep Steam's built-in startup/login overlap behavior from leaking onto the main Steam client by expiring the startup rule once the surface no longer matches the login window.
 - Route layer-shell commits through the monitor assigned to that layer surface so layer state updates no longer use the wrong active monitor context.
 - Throttle TTY redraws and frame callbacks per output so fullscreen/video timer frames and cursor motion avoid unnecessary cross-monitor redraw work.
+- Reduce per-output render work by filtering active surfaces before sorting/syncing them and scoping maximize animation redraws to the affected monitor.
 - Use the launch or window-rule spawn target monitor for initial `xdg_toplevel` configure bounds so new clients receive bounds for the output they will actually open on.
 - Prevent focus decay while spawn or open transitions are still active, avoiding premature collapse during window launch and reveal animations.
 - Preserve fullscreen and pointer state across monitor changes by separating soft fullscreen suspension from client fullscreen exits, refreshing pointer constraints from the last screen position, releasing constraints when crossing monitors, and keeping cursor surface output state current.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Add top-right config error overlays for startup, manual reload, IPC reload, and file-watch reload failures, including scrollable diagnostics, hover pause, right-click dismissal, wheel and shift-wheel scrolling, and configurable `overlays.error-colour` styling.
 - Add strict config validation diagnostics for unknown Halley keys and invalid literals, with path, line, source text, and suggestions when available.
 - Add a selectable `animations.window-close.style "fade"` close animation that fades captured closing windows without shrinking them.
+- Add visual-only maximize/unmaximize animation using `animations.maximize`, preserving field geometry while tweening the presented rect.
 
 ### Changed
 - Switch the field placement model so expanded windows may overlap other expanded windows while collapsed nodes and core landmarks remain non-overlapping map objects; pinned landmarks remain solid blockers during spawn, drag, and resize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Move pure overlap contact physics into `halley-core` so the Wayland compositor only wires it into runtime state.
 - Remove empty npm package manifests from the repository root.
 - Rename the default explicit field-drag pointer action from `field-jump` to `pan-field`, keeping `field-jump` and `drag-pan` as config aliases for compatibility.
+- Treat maximize and fullscreen as presentation states: they now preserve field geometry, do not shove other windows or pinned landmarks, and participate in normal focus/raise ordering so other windows can appear above them until the maximized/fullscreen window is explicitly raised again.
 
 ### Fixed
 - Keep window borders at the same z-depth as their owning window so a background window's border cannot draw over the foreground window.
@@ -43,7 +44,7 @@ All notable changes to this project will be documented in this file.
 - Make dragged collapsed nodes/cores slide along expanded-window edges and flip sides only after crossing the window midpoint instead of snapping into corners.
 - Draw active-window pin badges with the owning window's z-order, matching borders instead of staying globally above overlapping windows.
 - Preserve existing keyboard focus for overlay/popup text input instead of restoring last input focus on every unbound typing key.
-- End a monitor's active maximize session when an external active window is moved onto that monitor, so transferred windows cannot sit above a still-maximized target.
+- Keep maximized windows active when new or transferred windows overlap them, while allowing click raise, trail navigation, and focus cycling to bring maximized windows forward again through normal stacking.
 - Remove initial-spawn push-away authority so opening a new expanded window does not shove existing expanded windows out of the way.
 - Limit new-window reveal panning to the one case where a pinned landmark blocks the current spawn center.
 - Apply live config reloads directly and force active window render caches/full redraw after reload.

--- a/crates/halley-config/src/layout/runtime.rs
+++ b/crates/halley-config/src/layout/runtime.rs
@@ -596,6 +596,7 @@ animations:
 
   maximize:
     enabled true
+    # Visual-only maximize/unmaximize tween; field geometry stays unchanged.
     duration-ms 240
   end
 
@@ -945,7 +946,8 @@ mod tests {
             "  pins:\n    corner \"top-right\"\n    colour \"auto\"\n    background-colour \"auto\""
         ));
         assert!(rendered.contains("    size 1.0"));
-        assert!(rendered.contains("  maximize:\n    enabled true\n    duration-ms 240"));
+        assert!(rendered.contains("  maximize:\n    enabled true"));
+        assert!(rendered.contains("    duration-ms 240"));
         assert!(rendered.contains("  raise:\n    enabled true\n    duration-ms 140"));
         assert!(rendered.contains("  shadows:\n    window:"));
         assert!(rendered.contains("      colour \"#05030530\""));

--- a/crates/halley-config/src/layout/types.rs
+++ b/crates/halley-config/src/layout/types.rs
@@ -133,6 +133,7 @@ impl TimedAnimationConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WindowCloseAnimationStyle {
     Shrink,
+    Fade,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/crates/halley-config/src/layout/update.rs
+++ b/crates/halley-config/src/layout/update.rs
@@ -411,7 +411,8 @@ end
             .expect("config should update")
             .expect("config should change");
 
-        assert!(updated.contains("  maximize:\n    enabled true\n    duration-ms 240\n  end"));
+        assert!(updated.contains("  maximize:\n    enabled true"));
+        assert!(updated.contains("    duration-ms 240"));
         assert!(updated.contains("  raise:\n    enabled true\n    duration-ms 140"));
         assert!(updated.contains("smooth-resize:\n    enabled true\n    duration-ms 90"));
     }
@@ -520,7 +521,8 @@ end
 
         assert!(updated.contains("animation:\n  enabled true"));
         assert!(!updated.contains("\nanimations:\n"));
-        assert!(updated.contains("  maximize:\n    enabled true\n    duration-ms 240\n  end"));
+        assert!(updated.contains("  maximize:\n    enabled true"));
+        assert!(updated.contains("    duration-ms 240"));
     }
 
     #[test]

--- a/crates/halley-config/src/parse/primitives.rs
+++ b/crates/halley-config/src/parse/primitives.rs
@@ -484,6 +484,7 @@ pub(crate) fn pick_window_close_animation_style(
     };
     match raw.trim().trim_matches('"').to_ascii_lowercase().as_str() {
         "shrink" => WindowCloseAnimationStyle::Shrink,
+        "fade" => WindowCloseAnimationStyle::Fade,
         _ => default,
     }
 }

--- a/crates/halley-config/src/parse/sections/animations.rs
+++ b/crates/halley-config/src/parse/sections/animations.rs
@@ -275,4 +275,26 @@ end
         assert_eq!(out.animations.raise.scale, 1.025);
         assert_eq!(out.animations.raise.shadow_boost, 0.18);
     }
+
+    #[test]
+    fn window_close_style_accepts_fade() {
+        let cfg = RuneConfig::from_str(
+            r#"
+animations:
+  window-close:
+    style "fade"
+  end
+end
+"#,
+        )
+        .expect("animations config should parse");
+
+        let mut out = RuntimeTuning::default();
+        load_animations_section(&cfg, &mut out);
+
+        assert_eq!(
+            out.animations.window_close.style,
+            crate::layout::WindowCloseAnimationStyle::Fade
+        );
+    }
 }

--- a/crates/halley-config/src/parse/validate.rs
+++ b/crates/halley-config/src/parse/validate.rs
@@ -625,7 +625,7 @@ fn enum_allowed_values(path: &str) -> Option<&'static [&'static str]> {
         "placement.reveal.pan-to-new" => {
             Some(&["never", "if-needed", "if_needed", "always", "true", "false"])
         }
-        "animations.window-close.style" => Some(&["shrink"]),
+        "animations.window-close.style" => Some(&["shrink", "fade"]),
         path if viewport_output_path(path)
             .is_some_and(|rest| rest == "vrr" || rest == "variable-refresh-rate") =>
         {

--- a/crates/halley-wl/src/backend/tty/drm.rs
+++ b/crates/halley-wl/src/backend/tty/drm.rs
@@ -2055,6 +2055,11 @@ fn fullscreen_direct_scanout_candidate(
     if hover_node.is_some() || preview_hover_node.is_some() {
         return Some(blocked("hover UI is active"));
     }
+    if !active_surface_frontmost_on_monitor(st, node_id, output_name) {
+        return Some(blocked(
+            "fullscreen candidate is covered by a higher stacked window",
+        ));
+    }
     if st.should_draw_focus_ring_preview(Instant::now()) {
         return Some(blocked("focus preview is active"));
     }
@@ -2084,6 +2089,38 @@ fn fullscreen_direct_scanout_candidate(
         surface,
         surface_loc: (-bbox.loc.x, -bbox.loc.y),
     }))
+}
+
+fn active_surface_frontmost_on_monitor(
+    st: &Halley,
+    node_id: halley_core::field::NodeId,
+    output_name: &str,
+) -> bool {
+    let target_rank = st.overlap_policy_stack_rank(node_id);
+    st.model.field.node_ids_all().into_iter().all(|other_id| {
+        if other_id == node_id {
+            return true;
+        }
+        let Some(other) = st.model.field.node(other_id) else {
+            return true;
+        };
+        if other.kind != halley_core::field::NodeKind::Surface
+            || other.state != halley_core::field::NodeState::Active
+            || !st.model.field.is_visible(other_id)
+        {
+            return true;
+        }
+        if !st
+            .model
+            .monitor_state
+            .node_monitor
+            .get(&other_id)
+            .is_some_and(|monitor| monitor == output_name)
+        {
+            return true;
+        }
+        st.overlap_policy_stack_rank(other_id) <= target_rank
+    })
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -298,13 +298,17 @@ fn start_restore_maximize_session(
         (session.node_snapshots.clone(), session.camera)
     };
 
-    let _ = now;
     if state == crate::compositor::workspace::state::MaximizeSessionState::Restoring {
         crate::compositor::workspace::state::set_monitor_camera_target_snapshot(
             st, monitor, camera,
         );
     }
     for (node_id, snapshot) in &node_snapshots {
+        let from =
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                st, *node_id, now,
+            )
+            .unwrap_or_else(|| maximize_target_for_monitor(st, monitor));
         if let Some(node) = st.model.field.node_mut(*node_id) {
             node.pos = snapshot.pos;
             node.intrinsic_size = snapshot.size;
@@ -317,8 +321,24 @@ fn start_restore_maximize_session(
             snapshot.size.y.round() as i32,
         );
         st.set_last_active_size_now(*node_id, snapshot.size);
+        if st.runtime.tuning.maximize_animation_enabled() {
+            st.model.workspace_state.maximize_animation.insert(
+                *node_id,
+                crate::compositor::workspace::state::MaximizeAnimation {
+                    monitor: monitor.to_string(),
+                    from_pos: from.0,
+                    to_pos: snapshot.pos,
+                    from_size: from.1,
+                    to_size: snapshot.size,
+                    start_ms: st.now_ms(now),
+                    duration_ms: st.runtime.tuning.maximize_animation_duration_ms(),
+                },
+            );
+        }
     }
-    st.model.workspace_state.maximize_sessions.remove(monitor);
+    if !st.runtime.tuning.maximize_animation_enabled() {
+        st.model.workspace_state.maximize_sessions.remove(monitor);
+    }
     st.request_maintenance();
     true
 }
@@ -336,12 +356,39 @@ fn start_active_maximize_session(
     crate::compositor::workspace::state::reset_monitor_zoom_for_maximize(st, monitor);
 
     let _ = node_snapshots;
-    let (_, target_size) = maximize_target_for_monitor(st, monitor);
+    let (target_pos, target_size) = maximize_target_for_monitor(st, monitor);
+    let from =
+        crate::compositor::workspace::state::maximize_animation_visual_for_node_on_monitor_at(
+            st, target_id, monitor, now,
+        )
+        .or_else(|| {
+            st.model.field.node(target_id).map(|node| {
+                (
+                    node.pos,
+                    current_window_size_for_node(st, target_id).unwrap_or(node.intrinsic_size),
+                )
+            })
+        })
+        .unwrap_or((target_pos, target_size));
     st.request_toplevel_resize(
         target_id,
         target_size.x.round() as i32,
         target_size.y.round() as i32,
     );
+    if st.runtime.tuning.maximize_animation_enabled() {
+        st.model.workspace_state.maximize_animation.insert(
+            target_id,
+            crate::compositor::workspace::state::MaximizeAnimation {
+                monitor: monitor.to_string(),
+                from_pos: from.0,
+                to_pos: target_pos,
+                from_size: from.1,
+                to_size: target_size,
+                start_ms: st.now_ms(now),
+                duration_ms: st.runtime.tuning.maximize_animation_duration_ms(),
+            },
+        );
+    }
     st.set_recent_top_node(target_id, now + std::time::Duration::from_millis(1200));
     st.request_maintenance();
     true
@@ -366,15 +413,6 @@ fn start_maximize_session(st: &mut Halley, id: NodeId, monitor: &str, now: Insta
                     )
                 }
                 crate::compositor::workspace::state::MaximizeSessionState::Restoring => {
-                    if let Some(session) =
-                        st.model.workspace_state.maximize_sessions.get_mut(monitor)
-                    {
-                        session.state =
-                            crate::compositor::workspace::state::MaximizeSessionState::Active;
-                    }
-                    start_active_maximize_session(st, id, monitor, &existing.node_snapshots, now)
-                }
-                crate::compositor::workspace::state::MaximizeSessionState::SpawnRestoring => {
                     if let Some(session) =
                         st.model.workspace_state.maximize_sessions.get_mut(monitor)
                     {
@@ -890,7 +928,9 @@ mod tests {
     #[test]
     fn maximize_toggle_saves_restore_geometry_and_centers_target() {
         let dh = Display::<Halley>::new().expect("display").handle();
-        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.maximize.enabled = false;
+        let mut st = Halley::new_for_test(&dh, tuning);
         let id = st.model.field.spawn_surface(
             "app",
             halley_core::field::Vec2 { x: 120.0, y: 140.0 },
@@ -936,6 +976,55 @@ mod tests {
             ),
             Some((target_pos, target_size))
         );
+    }
+
+    #[test]
+    fn maximize_animation_is_visual_only_and_preserves_field_geometry() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.maximize.enabled = true;
+        tuning.animations.maximize.duration_ms = 240;
+        let mut st = Halley::new_for_test(&dh, tuning);
+        let now = Instant::now();
+        let id = st.model.field.spawn_surface(
+            "app",
+            halley_core::field::Vec2 { x: 120.0, y: 140.0 },
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 },
+        );
+        st.assign_node_to_monitor(id, "monitor_a");
+
+        assert!(toggle_node_maximize_state(&mut st, id, now, "monitor_a"));
+
+        let node = st.model.field.node(id).expect("node");
+        assert_eq!(node.pos, halley_core::field::Vec2 { x: 120.0, y: 140.0 });
+        assert_eq!(
+            node.intrinsic_size,
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 }
+        );
+        assert!(
+            st.model
+                .workspace_state
+                .maximize_animation
+                .contains_key(&id)
+        );
+        assert_eq!(
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                &st, id, now
+            ),
+            Some((node.pos, node.intrinsic_size))
+        );
+
+        crate::compositor::workspace::state::tick_maximize_animation(
+            &mut st,
+            now + std::time::Duration::from_millis(260),
+        );
+        let node = st.model.field.node(id).expect("node");
+        assert_eq!(node.pos, halley_core::field::Vec2 { x: 120.0, y: 140.0 });
+        assert_eq!(
+            node.intrinsic_size,
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 }
+        );
+        assert!(st.model.workspace_state.maximize_animation.is_empty());
     }
 
     #[test]
@@ -1178,7 +1267,9 @@ mod tests {
     #[test]
     fn unmaximize_restores_camera_via_smooth_target() {
         let dh = Display::<Halley>::new().expect("display").handle();
-        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.maximize.enabled = false;
+        let mut st = Halley::new_for_test(&dh, tuning);
         st.model.zoom_ref_size = halley_core::field::Vec2 { x: 500.0, y: 375.0 };
         st.model.camera_target_view_size = st.model.zoom_ref_size;
         st.model.viewport.center = halley_core::field::Vec2 { x: 430.0, y: 280.0 };

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -1447,6 +1447,58 @@ mod tests {
     }
 
     #[test]
+    fn pending_manual_collapse_slides_from_original_active_position() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.window_close.enabled = false;
+        let mut st = Halley::new_for_test(&dh, tuning);
+        let monitor = st.model.monitor_state.current_monitor.clone();
+        let blocker = st.model.field.spawn_surface(
+            "blocker",
+            halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            halley_core::field::Vec2 { x: 420.0, y: 280.0 },
+        );
+        let target = st.model.field.spawn_surface(
+            "target",
+            halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            halley_core::field::Vec2 { x: 320.0, y: 220.0 },
+        );
+        st.assign_node_to_monitor(blocker, monitor.as_str());
+        st.assign_node_to_monitor(target, monitor.as_str());
+        let origin = st.model.field.node(target).expect("target").pos;
+        let now = Instant::now();
+
+        assert!(toggle_node_state(&mut st, target, now, monitor.as_str()));
+        assert!(
+            st.model
+                .workspace_state
+                .pending_manual_collapses
+                .contains_key(&target)
+        );
+
+        crate::compositor::workspace::state::process_pending_manual_collapses_for_monitor(
+            &mut st,
+            monitor.as_str(),
+            now + std::time::Duration::from_millis(140),
+        );
+
+        let resolved = st.model.field.node(target).expect("target").pos;
+        assert_ne!(resolved, origin);
+        let slide = st
+            .ui
+            .render_state
+            .landmark_slide_animations
+            .get(&target)
+            .expect("landmark slide animation");
+        assert_eq!(slide.from, origin);
+        assert_eq!(slide.to, resolved);
+        assert_eq!(
+            st.model.field.node(target).expect("target").state,
+            halley_core::field::NodeState::Node
+        );
+    }
+
+    #[test]
     fn reopening_collapsed_maximized_window_reenters_maximize() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut tuning = single_monitor_tuning();

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -133,6 +133,7 @@ pub(crate) fn focus_or_reveal_surface_node(
         halley_core::field::NodeState::Node => promote_node_level(st, node_id, now),
         halley_core::field::NodeState::Active | halley_core::field::NodeState::Drifting => {
             st.set_interaction_focus(Some(node_id), 30_000, now);
+            let _ = st.raise_overlap_policy_node(node_id);
             let is_pending_tiled = st
                 .model
                 .spawn_state
@@ -255,73 +256,6 @@ fn current_window_size_for_node(st: &Halley, id: NodeId) -> Option<halley_core::
         .or_else(|| st.model.field.node(id).map(|node| node.intrinsic_size))
 }
 
-fn maximize_viewport_rect_for_monitor(st: &Halley, monitor: &str) -> halley_core::field::Rect {
-    let viewport = field_viewport_for_monitor(st, monitor);
-    let half = halley_core::field::Vec2 {
-        x: viewport.size.x * 0.5,
-        y: viewport.size.y * 0.5,
-    };
-    halley_core::field::Rect {
-        min: halley_core::field::Vec2 {
-            x: viewport.center.x - half.x,
-            y: viewport.center.y - half.y,
-        },
-        max: halley_core::field::Vec2 {
-            x: viewport.center.x + half.x,
-            y: viewport.center.y + half.y,
-        },
-    }
-}
-
-fn node_intersects_maximize_monitor_viewport(st: &Halley, id: NodeId, monitor: &str) -> bool {
-    let Some(node) = st.model.field.node(id) else {
-        return false;
-    };
-    let ext = st.collision_extents_for_node(node);
-    halley_core::field::Rect {
-        min: halley_core::field::Vec2 {
-            x: node.pos.x - ext.left,
-            y: node.pos.y - ext.top,
-        },
-        max: halley_core::field::Vec2 {
-            x: node.pos.x + ext.right,
-            y: node.pos.y + ext.bottom,
-        },
-    }
-    .intersects(maximize_viewport_rect_for_monitor(st, monitor))
-}
-
-fn maximize_displaced_target(
-    pos: halley_core::field::Vec2,
-    ordinal: usize,
-    viewport_center: halley_core::field::Vec2,
-    viewport_size: halley_core::field::Vec2,
-) -> halley_core::field::Vec2 {
-    let mut dir = halley_core::field::Vec2 {
-        x: pos.x - viewport_center.x,
-        y: pos.y - viewport_center.y,
-    };
-    let len = dir.x.hypot(dir.y);
-    if len < 1.0 {
-        let dirs = [
-            halley_core::field::Vec2 { x: 1.0, y: 0.0 },
-            halley_core::field::Vec2 { x: -1.0, y: 0.0 },
-            halley_core::field::Vec2 { x: 0.0, y: -1.0 },
-            halley_core::field::Vec2 { x: 0.0, y: 1.0 },
-        ];
-        dir = dirs[ordinal % dirs.len()];
-    } else {
-        dir.x /= len;
-        dir.y /= len;
-    }
-
-    let radius = viewport_size.x.hypot(viewport_size.y) * 0.85 + 320.0;
-    halley_core::field::Vec2 {
-        x: viewport_center.x + dir.x * radius,
-        y: viewport_center.y + dir.y * radius,
-    }
-}
-
 fn maximize_snapshot_for_node(
     st: &Halley,
     id: NodeId,
@@ -350,72 +284,6 @@ fn maximize_target_for_monitor(
     )
 }
 
-fn apply_maximize_geometry_now(
-    st: &mut Halley,
-    id: NodeId,
-    target_pos: halley_core::field::Vec2,
-    target_size: halley_core::field::Vec2,
-) -> bool {
-    if let Some(node) = st.model.field.node_mut(id) {
-        node.pos = target_pos;
-        node.intrinsic_size = target_size;
-    } else {
-        return false;
-    }
-    let _ = st.model.field.sync_active_footprint_to_intrinsic(id);
-    st.request_toplevel_resize(
-        id,
-        target_size.x.round() as i32,
-        target_size.y.round() as i32,
-    );
-    st.set_last_active_size_now(id, target_size);
-    true
-}
-
-fn begin_maximize_animation(
-    st: &mut Halley,
-    monitor: &str,
-    id: NodeId,
-    from_pos: halley_core::field::Vec2,
-    from_size: halley_core::field::Vec2,
-    to_pos: halley_core::field::Vec2,
-    to_size: halley_core::field::Vec2,
-    now: Instant,
-) -> bool {
-    let _ = st.model.field.set_pinned(id, false);
-    if !st.runtime.tuning.maximize_animation_enabled() {
-        return apply_maximize_geometry_now(st, id, to_pos, to_size);
-    }
-
-    st.model.workspace_state.maximize_animation.insert(
-        id,
-        crate::compositor::workspace::state::MaximizeAnimation {
-            monitor: monitor.to_string(),
-            from_pos,
-            to_pos,
-            from_size,
-            to_size,
-            start_ms: st.now_ms(now),
-            duration_ms: st.runtime.tuning.maximize_animation_duration_ms(),
-        },
-    );
-    st.request_maintenance();
-    true
-}
-
-fn set_session_nodes_pinned(
-    st: &mut Halley,
-    snapshots: &std::collections::HashMap<
-        NodeId,
-        crate::compositor::workspace::state::MaximizeNodeSnapshot,
-    >,
-    pinned: bool,
-) {
-    for &node_id in snapshots.keys() {
-        let _ = st.model.field.set_pinned(node_id, pinned);
-    }
-}
-
 fn start_restore_maximize_session(
     st: &mut Halley,
     monitor: &str,
@@ -430,61 +298,29 @@ fn start_restore_maximize_session(
         (session.node_snapshots.clone(), session.camera)
     };
 
+    let _ = now;
     if state == crate::compositor::workspace::state::MaximizeSessionState::Restoring {
         crate::compositor::workspace::state::set_monitor_camera_target_snapshot(
             st, monitor, camera,
         );
     }
-    if !st.runtime.tuning.maximize_animation_enabled() {
-        for (node_id, snapshot) in &node_snapshots {
-            let _ = st.model.field.set_pinned(*node_id, false);
-            let _ = apply_maximize_geometry_now(st, *node_id, snapshot.pos, snapshot.size);
-            let _ = st.model.field.set_pinned(*node_id, snapshot.pinned);
-        }
-        st.model.workspace_state.maximize_sessions.remove(monitor);
-        st.resolve_overlap_now();
-        return true;
-    }
-
     for (node_id, snapshot) in &node_snapshots {
-        let Some(node) = st.model.field.node(*node_id) else {
-            continue;
-        };
-        let from_pos = node.pos;
-        let from_intrinsic_size = node.intrinsic_size;
-        let from_size = current_window_size_for_node(st, *node_id).unwrap_or(from_intrinsic_size);
-        let _ = begin_maximize_animation(
-            st,
-            monitor,
+        if let Some(node) = st.model.field.node_mut(*node_id) {
+            node.pos = snapshot.pos;
+            node.intrinsic_size = snapshot.size;
+        }
+        let _ = st.model.field.sync_active_footprint_to_intrinsic(*node_id);
+        let _ = st.model.field.set_pinned(*node_id, snapshot.pinned);
+        st.request_toplevel_resize(
             *node_id,
-            from_pos,
-            from_size,
-            snapshot.pos,
-            snapshot.size,
-            now,
+            snapshot.size.x.round() as i32,
+            snapshot.size.y.round() as i32,
         );
+        st.set_last_active_size_now(*node_id, snapshot.size);
     }
+    st.model.workspace_state.maximize_sessions.remove(monitor);
+    st.request_maintenance();
     true
-}
-
-pub(crate) fn restore_maximize_session_for_spawn(
-    st: &mut Halley,
-    monitor: &str,
-    now: Instant,
-) -> bool {
-    let Some(target_id) =
-        crate::compositor::workspace::state::maximize_session_target_for_monitor(st, monitor)
-    else {
-        return false;
-    };
-    st.set_recent_top_node(target_id, now + std::time::Duration::from_millis(1200));
-    st.set_interaction_focus(Some(target_id), 30_000, now);
-    start_restore_maximize_session(
-        st,
-        monitor,
-        now,
-        crate::compositor::workspace::state::MaximizeSessionState::SpawnRestoring,
-    )
 }
 
 fn start_active_maximize_session(
@@ -499,84 +335,15 @@ fn start_active_maximize_session(
 ) -> bool {
     crate::compositor::workspace::state::reset_monitor_zoom_for_maximize(st, monitor);
 
-    let viewport = field_viewport_for_monitor(st, monitor);
-    let (target_pos, target_size) = maximize_target_for_monitor(st, monitor);
-    let mut bystanders = node_snapshots
-        .keys()
-        .copied()
-        .filter(|node_id| *node_id != target_id)
-        .collect::<Vec<_>>();
-    bystanders.sort_by_key(|node_id| node_id.as_u64());
-
-    if !st.runtime.tuning.maximize_animation_enabled() {
-        let _ = apply_maximize_geometry_now(st, target_id, target_pos, target_size);
-        for (ordinal, other_id) in bystanders.iter().enumerate() {
-            if let Some(snapshot) = node_snapshots.get(other_id).copied() {
-                let _ = apply_maximize_geometry_now(
-                    st,
-                    *other_id,
-                    maximize_displaced_target(
-                        snapshot.pos,
-                        ordinal,
-                        viewport.center,
-                        viewport.size,
-                    ),
-                    snapshot.size,
-                );
-            }
-        }
-        set_session_nodes_pinned(st, node_snapshots, true);
-        st.resolve_overlap_now();
-        st.request_maintenance();
-        return true;
-    }
-
-    let target_from = st
-        .model
-        .field
-        .node(target_id)
-        .map(|node| {
-            (
-                node.pos,
-                current_window_size_for_node(st, target_id).unwrap_or(node.intrinsic_size),
-            )
-        })
-        .unwrap_or((target_pos, target_size));
-    let _ = begin_maximize_animation(
-        st,
-        monitor,
+    let _ = node_snapshots;
+    let (_, target_size) = maximize_target_for_monitor(st, monitor);
+    st.request_toplevel_resize(
         target_id,
-        target_from.0,
-        target_from.1,
-        target_pos,
-        target_size,
-        now,
+        target_size.x.round() as i32,
+        target_size.y.round() as i32,
     );
-    for (ordinal, other_id) in bystanders.iter().enumerate() {
-        if let Some(snapshot) = node_snapshots.get(other_id).copied() {
-            let from = st
-                .model
-                .field
-                .node(*other_id)
-                .map(|node| {
-                    (
-                        node.pos,
-                        current_window_size_for_node(st, *other_id).unwrap_or(node.intrinsic_size),
-                    )
-                })
-                .unwrap_or((snapshot.pos, snapshot.size));
-            let _ = begin_maximize_animation(
-                st,
-                monitor,
-                *other_id,
-                from.0,
-                from.1,
-                maximize_displaced_target(snapshot.pos, ordinal, viewport.center, viewport.size),
-                snapshot.size,
-                now,
-            );
-        }
-    }
+    st.set_recent_top_node(target_id, now + std::time::Duration::from_millis(1200));
+    st.request_maintenance();
     true
 }
 
@@ -629,34 +396,6 @@ fn start_maximize_session(st: &mut Halley, id: NodeId, monitor: &str, now: Insta
 
     let mut node_snapshots = std::collections::HashMap::new();
     node_snapshots.insert(id, target_snapshot);
-
-    let mut bystanders = st
-        .model
-        .field
-        .node_ids_all()
-        .into_iter()
-        .filter(|other_id| *other_id != id)
-        .filter_map(|other_id| {
-            let node = st.model.field.node(other_id)?;
-            (node.kind == halley_core::field::NodeKind::Surface
-                && st.model.field.is_visible(other_id)
-                && !st.node_user_pinned(other_id)
-                && st
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&other_id)
-                    .is_some_and(|node_monitor| node_monitor == monitor)
-                && node_intersects_maximize_monitor_viewport(st, other_id, monitor))
-            .then_some(other_id)
-        })
-        .collect::<Vec<_>>();
-    bystanders.sort_by_key(|node_id| node_id.as_u64());
-    for other_id in &bystanders {
-        if let Some(snapshot) = maximize_snapshot_for_node(st, *other_id) {
-            node_snapshots.insert(*other_id, snapshot);
-        }
-    }
 
     st.model.workspace_state.maximize_sessions.insert(
         monitor.to_string(),
@@ -796,12 +535,6 @@ pub(crate) fn move_latest_node_direction(st: &mut Halley, direction: NodeMoveDir
 }
 
 pub(crate) fn step_window_trail(st: &mut Halley, direction: TrailDirection) -> bool {
-    if crate::compositor::workspace::state::maximize_session_active_on_monitor(
-        st,
-        st.focused_monitor(),
-    ) {
-        return false;
-    }
     st.navigate_window_trail(direction, Instant::now())
 }
 
@@ -1114,11 +847,13 @@ mod tests {
             "monitor_a"
         ));
 
-        let (target_pos, target_size) = maximize_target_for_monitor(&st, "monitor_a");
         let node = st.model.field.node(id).expect("node");
         assert_eq!(node.state, halley_core::field::NodeState::Active);
-        assert_eq!(node.pos, target_pos);
-        assert_eq!(node.intrinsic_size, target_size);
+        assert_eq!(node.pos, halley_core::field::Vec2 { x: 120.0, y: 140.0 });
+        assert_eq!(
+            node.intrinsic_size,
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 }
+        );
         assert!(
             !st.model
                 .workspace_state
@@ -1181,13 +916,6 @@ mod tests {
             .get(&id)
             .copied()
             .expect("restore snapshot");
-        let anim = st
-            .model
-            .workspace_state
-            .maximize_animation
-            .get(&id)
-            .cloned()
-            .expect("maximize animation");
         let (target_pos, target_size) = maximize_target_for_monitor(&st, "monitor_a");
 
         assert_eq!(session.target_id, id);
@@ -1196,12 +924,22 @@ mod tests {
             restore.size,
             halley_core::field::Vec2 { x: 320.0, y: 240.0 }
         );
-        assert_eq!(anim.to_pos, target_pos);
-        assert_eq!(anim.to_size, target_size);
+        assert!(st.model.workspace_state.maximize_animation.is_empty());
+        assert_eq!(st.model.field.node(id).expect("node").pos, restore.pos);
+        assert_eq!(
+            st.model.field.node(id).expect("node").intrinsic_size,
+            restore.size
+        );
+        assert_eq!(
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
+                &st, id
+            ),
+            Some((target_pos, target_size))
+        );
     }
 
     #[test]
-    fn maximize_session_tracks_bystanders_and_camera_snapshot() {
+    fn maximize_session_tracks_target_only_and_leaves_bystanders() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
         st.model.zoom_ref_size = halley_core::field::Vec2 { x: 500.0, y: 375.0 };
@@ -1235,12 +973,6 @@ mod tests {
             .maximize_sessions
             .get("monitor_a")
             .expect("maximize session");
-        let bystander_snapshot = session
-            .node_snapshots
-            .get(&bystander)
-            .copied()
-            .expect("bystander snapshot");
-
         assert_eq!(
             session.camera.center,
             halley_core::field::Vec2 { x: 430.0, y: 280.0 }
@@ -1249,12 +981,26 @@ mod tests {
             session.camera.view_size,
             halley_core::field::Vec2 { x: 500.0, y: 375.0 }
         );
+        assert!(session.node_snapshots.contains_key(&target));
+        assert!(!session.node_snapshots.contains_key(&bystander));
         assert_eq!(
-            bystander_snapshot.pos,
+            st.model.field.node(target).expect("target").pos,
+            halley_core::field::Vec2 { x: 120.0, y: 140.0 }
+        );
+        assert_eq!(
+            st.model.field.node(target).expect("target").intrinsic_size,
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 }
+        );
+        assert_eq!(
+            st.model.field.node(bystander).expect("bystander").pos,
             halley_core::field::Vec2 { x: 460.0, y: 260.0 }
         );
         assert_eq!(
-            bystander_snapshot.size,
+            st.model
+                .field
+                .node(bystander)
+                .expect("bystander")
+                .intrinsic_size,
             halley_core::field::Vec2 { x: 240.0, y: 180.0 }
         );
         assert_eq!(
@@ -1266,7 +1012,7 @@ mod tests {
     }
 
     #[test]
-    fn unmaximize_restores_bystanders_and_camera_snapshot() {
+    fn unmaximize_restores_target_and_leaves_bystanders() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut tuning = single_monitor_tuning();
         tuning.animations.maximize.enabled = false;
@@ -1339,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn moving_external_active_window_to_maximized_monitor_unmaximizes() {
+    fn moving_external_active_window_to_maximized_monitor_keeps_maximize() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut st = Halley::new_for_test(&dh, two_monitor_tuning());
 
@@ -1378,7 +1124,7 @@ mod tests {
         st.assign_node_to_monitor(moved, "right");
 
         assert!(
-            !st.model
+            st.model
                 .workspace_state
                 .maximize_sessions
                 .contains_key("right")
@@ -1467,14 +1213,10 @@ mod tests {
             halley_core::field::Vec2 { x: 430.0, y: 280.0 }
         );
         assert!(
-            st.model
+            !st.model
                 .workspace_state
                 .maximize_sessions
-                .get("monitor_a")
-                .is_some_and(|session| {
-                    session.state
-                        == crate::compositor::workspace::state::MaximizeSessionState::Restoring
-                })
+                .contains_key("monitor_a")
         );
     }
 
@@ -1666,11 +1408,11 @@ mod tests {
                 .maximize_sessions
                 .contains_key(monitor.as_str())
         );
-        let (target_pos, target_size) = maximize_target_for_monitor(&st, monitor.as_str());
-        assert_eq!(st.model.field.node(target).expect("target").pos, target_pos);
-        assert_eq!(
-            st.model.field.node(target).expect("target").intrinsic_size,
-            target_size
+        assert!(
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
+                &st, target
+            )
+            .is_some()
         );
     }
 

--- a/crates/halley-wl/src/compositor/focus/cycle.rs
+++ b/crates/halley-wl/src/compositor/focus/cycle.rs
@@ -283,12 +283,6 @@ impl<T: DerefMut<Target = Halley>> FocusCycleController<T> {
             self.apply_wayland_focus_state(None);
             return true;
         };
-        let target_monitor = self.monitor_for_node_or_current(target);
-        let origin_fullscreen = session.origin_focus.and_then(|node_id| {
-            self.is_fullscreen_active(node_id)
-                .then_some((node_id, self.monitor_for_node_or_current(node_id)))
-        });
-
         if Some(target) == session.origin_focus {
             if let Some(immersive) = session.immersive_origin.as_ref()
                 && immersive.node_id == target
@@ -301,19 +295,9 @@ impl<T: DerefMut<Target = Halley>> FocusCycleController<T> {
                 );
             }
             self.apply_wayland_focus_state(Some(target));
+            let _ = self.raise_overlap_policy_node(target);
             crate::compositor::interaction::pointer::center_pointer_on_node(self, target, now);
             return true;
-        }
-
-        if let Some(immersive) = session.immersive_origin.as_ref()
-            && self.is_fullscreen_active(immersive.node_id)
-            && immersive.monitor == target_monitor
-        {
-            self.suspend_xdg_fullscreen(immersive.node_id, now);
-        } else if let Some((origin_id, origin_monitor)) = origin_fullscreen
-            && origin_monitor == target_monitor
-        {
-            self.exit_xdg_fullscreen(origin_id, now);
         }
 
         let changed =
@@ -560,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn same_monitor_commit_exits_origin_fullscreen_for_normal_fullscreen() {
+    fn same_monitor_commit_keeps_origin_fullscreen_behind_target() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -590,12 +574,13 @@ mod tests {
         assert!(state.start_or_step_focus_cycle(FocusCycleBindingAction::Forward, now));
         assert!(state.commit_focus_cycle(now));
 
-        assert!(
-            !state
+        assert_eq!(
+            state
                 .model
                 .fullscreen_state
                 .fullscreen_active_node
-                .contains_key(current_monitor.as_str())
+                .get(current_monitor.as_str()),
+            Some(&fullscreen)
         );
         assert!(
             state
@@ -608,10 +593,13 @@ mod tests {
             state.model.focus_state.primary_interaction_focus,
             Some(other)
         );
+        assert!(
+            state.overlap_policy_stack_rank(other) > state.overlap_policy_stack_rank(fullscreen)
+        );
     }
 
     #[test]
-    fn same_monitor_commit_suspends_origin_fullscreen_for_immersive_session() {
+    fn same_monitor_commit_keeps_immersive_fullscreen_behind_target() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -659,24 +647,27 @@ mod tests {
         let now = Instant::now();
         assert!(state.commit_focus_cycle(now));
 
-        assert!(
-            !state
-                .model
-                .fullscreen_state
-                .fullscreen_active_node
-                .contains_key(current_monitor.as_str())
-        );
         assert_eq!(
             state
                 .model
                 .fullscreen_state
-                .fullscreen_suspended_node
+                .fullscreen_active_node
                 .get(current_monitor.as_str()),
             Some(&fullscreen)
+        );
+        assert!(
+            state
+                .model
+                .fullscreen_state
+                .fullscreen_suspended_node
+                .is_empty()
         );
         assert_eq!(
             state.model.focus_state.primary_interaction_focus,
             Some(other)
+        );
+        assert!(
+            state.overlap_policy_stack_rank(other) > state.overlap_policy_stack_rank(fullscreen)
         );
     }
 }

--- a/crates/halley-wl/src/compositor/focus/decay.rs
+++ b/crates/halley-wl/src/compositor/focus/decay.rs
@@ -116,7 +116,7 @@ impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
         if active_windows_allowed == 0 {
             return;
         }
-        if self.spawn_or_open_transition_active(now_ms) {
+        if self.spawn_placement_transition_active(now_ms) {
             return;
         }
         let companion = self.companion_surface_node(now_ms);
@@ -221,17 +221,16 @@ impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
                     let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
                     continue;
                 }
+                let now = Instant::now();
                 crate::compositor::workspace::state::start_active_to_node_close_animation(
-                    self,
-                    id,
-                    Instant::now(),
+                    self, id, now,
                 );
-                let _ = self.model.field.set_decay_level(id, DecayLevel::Cold);
+                let _ = crate::compositor::workspace::state::finish_auto_collapse(self, id, now);
             }
         }
     }
 
-    fn spawn_or_open_transition_active(&self, now_ms: u64) -> bool {
+    fn spawn_placement_transition_active(&self, now_ms: u64) -> bool {
         self.model.spawn_state.active_spawn_pan.is_some()
             || !self.model.spawn_state.pending_spawn_pan_queue.is_empty()
             || self.model.spawn_state.pending_pan_activate.is_some()
@@ -247,12 +246,6 @@ impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
                 .pending_tiled_insert_reveal_at_ms
                 .values()
                 .any(|&at_ms| at_ms > now_ms)
-            || self
-                .model
-                .workspace_state
-                .active_transitions
-                .values()
-                .any(|transition| transition.is_active(now_ms))
     }
 
     pub fn apply_single_surface_decay_policy(
@@ -332,12 +325,11 @@ impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
             .or_insert(now_ms);
 
         if now_ms.saturating_sub(outside_since_ms) >= delay_ms {
+            let now = Instant::now();
             crate::compositor::workspace::state::start_active_to_node_close_animation(
-                self,
-                id,
-                Instant::now(),
+                self, id, now,
             );
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Cold);
+            let _ = crate::compositor::workspace::state::finish_auto_collapse(self, id, now);
         } else {
             let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
         }
@@ -530,6 +522,77 @@ mod tests {
     }
 
     #[test]
+    fn active_window_limit_collapse_places_node_out_from_under_active_window() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.field_active_windows_allowed = 1;
+        tuning.animations.window_close.enabled = false;
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let monitor = state.model.monitor_state.current_monitor.clone();
+        let keeper = state.model.field.spawn_surface(
+            "keeper",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 420.0, y: 280.0 },
+        );
+        let target = state.model.field.spawn_surface(
+            "target",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 320.0, y: 220.0 },
+        );
+        for id in [keeper, target] {
+            state.assign_node_to_monitor(id, monitor.as_str());
+            let _ = state
+                .model
+                .field
+                .set_state(id, halley_core::field::NodeState::Active);
+        }
+        state
+            .model
+            .focus_state
+            .monitor_focus
+            .insert(monitor.clone(), keeper);
+        let origin = state.model.field.node(target).expect("target").pos;
+
+        state.enforce_single_primary_active_unit();
+
+        let resolved = state.model.field.node(target).expect("target").pos;
+        assert_eq!(
+            state
+                .model
+                .field
+                .node(keeper)
+                .map(|node| node.state.clone()),
+            Some(halley_core::field::NodeState::Active)
+        );
+        assert_eq!(
+            state
+                .model
+                .field
+                .node(target)
+                .map(|node| node.state.clone()),
+            Some(halley_core::field::NodeState::Node)
+        );
+        assert_ne!(resolved, origin);
+        assert!(
+            !state
+                .model
+                .workspace_state
+                .manual_collapsed_nodes
+                .contains(&target)
+        );
+        let slide = state
+            .ui
+            .render_state
+            .landmark_slide_animations
+            .get(&target)
+            .expect("landmark slide animation");
+        assert_eq!(slide.from, origin);
+        assert_eq!(slide.to, resolved);
+    }
+
+    #[test]
     fn active_window_limit_waits_during_open_transition() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.field_active_windows_allowed = 1;
@@ -556,13 +619,11 @@ mod tests {
                 .field
                 .set_state(id, halley_core::field::NodeState::Active);
         }
-        state.model.workspace_state.active_transitions.insert(
-            second,
-            crate::compositor::workspace::state::ActiveTransition {
-                started_at_ms: 0,
-                duration_ms: u64::MAX,
-            },
-        );
+        state
+            .model
+            .spawn_state
+            .pending_spawn_activate_at_ms
+            .insert(second, u64::MAX);
 
         state.enforce_single_primary_active_unit();
 
@@ -573,6 +634,58 @@ mod tests {
         assert_eq!(
             state.model.field.node(second).map(|n| n.state.clone()),
             Some(halley_core::field::NodeState::Active)
+        );
+    }
+
+    #[test]
+    fn active_window_limit_does_not_wait_for_visual_active_transition() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.field_active_windows_allowed = 1;
+        tuning.animations.window_close.enabled = false;
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let monitor = state.model.monitor_state.current_monitor.clone();
+        let keeper = state.model.field.spawn_surface(
+            "keeper",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 100.0 },
+        );
+        let target = state.model.field.spawn_surface(
+            "target",
+            Vec2 { x: 180.0, y: 0.0 },
+            Vec2 { x: 100.0, y: 100.0 },
+        );
+        for id in [keeper, target] {
+            state.assign_node_to_monitor(id, monitor.as_str());
+            let _ = state
+                .model
+                .field
+                .set_state(id, halley_core::field::NodeState::Active);
+        }
+        state
+            .model
+            .focus_state
+            .monitor_focus
+            .insert(monitor, keeper);
+        state.model.workspace_state.active_transitions.insert(
+            target,
+            crate::compositor::workspace::state::ActiveTransition {
+                started_at_ms: 0,
+                duration_ms: u64::MAX,
+            },
+        );
+
+        state.enforce_single_primary_active_unit();
+
+        assert_eq!(
+            state.model.field.node(keeper).map(|n| n.state.clone()),
+            Some(halley_core::field::NodeState::Active)
+        );
+        assert_eq!(
+            state.model.field.node(target).map(|n| n.state.clone()),
+            Some(halley_core::field::NodeState::Node)
         );
     }
 

--- a/crates/halley-wl/src/compositor/focus/trail.rs
+++ b/crates/halley-wl/src/compositor/focus/trail.rs
@@ -133,12 +133,6 @@ impl<T: DerefMut<Target = Halley>> FocusTrailController<T> {
         now: Instant,
     ) -> bool {
         let monitor = self.focused_monitor().to_string();
-        if crate::compositor::workspace::state::maximize_session_active_on_monitor(
-            self,
-            monitor.as_str(),
-        ) {
-            return false;
-        }
         if self
             .active_cluster_workspace_for_monitor(monitor.as_str())
             .is_some()
@@ -523,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn trail_navigation_is_disabled_while_maximized() {
+    fn trail_navigation_raises_windows_while_maximized() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -553,10 +547,11 @@ mod tests {
             )
         );
 
-        assert!(!state.navigate_window_trail(TrailDirection::Prev, now));
+        assert!(state.navigate_window_trail(TrailDirection::Prev, now));
         assert_eq!(
             state.model.focus_state.primary_interaction_focus,
-            Some(second)
+            Some(first)
         );
+        assert!(state.overlap_policy_stack_rank(first) > state.overlap_policy_stack_rank(second));
     }
 }

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -1,7 +1,6 @@
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
-use smithay::wayland::compositor::get_parent;
 use std::ops::{Deref, DerefMut};
 
 use super::*;
@@ -25,76 +24,10 @@ pub(crate) fn on_seat_focus_changed(
     focused: Option<&WlSurface>,
     now: Instant,
 ) {
-    let st = &mut ctx.st;
-    let focused_is_layer = focused.is_some_and(|surface| {
-        crate::compositor::monitor::layer_shell::is_layer_surface(st, surface)
-    });
-    if focused_is_layer {
-        return;
-    }
-
-    let focused_root = focused.map(surface_tree_root);
-    let focused_id = focused_root.as_ref().map(|wl| wl.id());
-    let focused_node_id = focused_id
-        .as_ref()
-        .and_then(|fid| st.model.surface_to_node.get(fid).copied());
-    let focused_monitor: Option<String> = focused_node_id.as_ref().and_then(|node_id| {
-        Some(
-            st.model
-                .monitor_state
-                .node_monitor
-                .get(node_id)
-                .cloned()
-                .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone()),
-        )
-    });
-
-    let to_suspend: Vec<NodeId> = st
-        .model
-        .fullscreen_state
-        .fullscreen_active_node
-        .iter()
-        .filter_map(|(monitor, &fullscreen_id)| {
-            let same_monitor = focused_monitor
-                .as_deref()
-                .is_some_and(|fm| fm == monitor.as_str());
-            if !same_monitor {
-                return None;
-            }
-            if focused_node_preserves_fullscreen_lock(st, focused_node_id, monitor.as_str()) {
-                return None;
-            }
-            let fullscreen_surface_id = st
-                .platform
-                .xdg_shell_state
-                .toplevel_surfaces()
-                .iter()
-                .find_map(|top| {
-                    (st.model
-                        .surface_to_node
-                        .get(&top.wl_surface().id())
-                        .copied()
-                        == Some(fullscreen_id))
-                    .then(|| top.wl_surface().id())
-                });
-            (fullscreen_surface_id.is_some() && fullscreen_surface_id != focused_id)
-                .then_some(fullscreen_id)
-        })
-        .collect();
-
-    for fullscreen_id in to_suspend {
-        st.soft_suspend_xdg_fullscreen(fullscreen_id, now);
-    }
+    let _ = (ctx, focused, now);
 }
 
-fn surface_tree_root(surface: &WlSurface) -> WlSurface {
-    let mut root = surface.clone();
-    while let Some(parent) = get_parent(&root) {
-        root = parent;
-    }
-    root
-}
-
+#[cfg(test)]
 fn focused_node_preserves_fullscreen_lock(
     st: &Halley,
     focused_node_id: Option<NodeId>,
@@ -294,6 +227,19 @@ mod tests {
         let now = Instant::now();
 
         state.enter_xdg_fullscreen(fullscreen, None, now);
+        assert_eq!(
+            state.model.field.node(fullscreen).expect("fullscreen").pos,
+            fullscreen_pos
+        );
+        assert_eq!(
+            state
+                .model
+                .field
+                .node(fullscreen)
+                .expect("fullscreen")
+                .intrinsic_size,
+            Vec2 { x: 320.0, y: 240.0 }
+        );
         state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
         let unchanged_bystander = state.model.field.node(bystander).expect("bystander");
         assert_eq!(unchanged_bystander.pos, bystander_pos);
@@ -600,8 +546,8 @@ mod tests {
             )
         );
         let maximized = state.model.field.node(target).expect("target").clone();
-        assert_ne!(maximized.pos, original_pos);
-        assert_ne!(maximized.intrinsic_size, original_size);
+        assert_eq!(maximized.pos, original_pos);
+        assert_eq!(maximized.intrinsic_size, original_size);
         assert!(
             crate::compositor::workspace::state::maximize_session_active_on_monitor(
                 &state,
@@ -630,7 +576,9 @@ mod tests {
                 "monitor_a"
             )
         );
-        assert!(restored.pinned);
+        assert_eq!(restored.pos, original_pos);
+        assert_eq!(restored.intrinsic_size, original_size);
+        assert!(!restored.pinned);
     }
 }
 
@@ -688,6 +636,27 @@ pub(crate) fn is_fullscreen_active(st: &Halley, node_id: NodeId) -> bool {
     fullscreen_monitor_for_node(st, node_id).is_some()
 }
 
+pub(crate) fn fullscreen_visual_for_node_on_current_monitor(
+    st: &Halley,
+    node_id: NodeId,
+) -> Option<(Vec2, Vec2)> {
+    let monitor = st.model.monitor_state.current_monitor.as_str();
+    (st.model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(monitor)
+        .copied()
+        == Some(node_id))
+    .then(|| {
+        st.model
+            .monitor_state
+            .monitors
+            .get(monitor)
+            .map(|space| (space.viewport.center, space.viewport.size))
+            .unwrap_or((st.model.viewport.center, st.model.viewport.size))
+    })
+}
+
 pub(crate) fn is_fullscreen_session_node(st: &Halley, node_id: NodeId) -> bool {
     st.model
         .fullscreen_state
@@ -703,9 +672,6 @@ pub(crate) fn is_fullscreen_session_node(st: &Halley, node_id: NodeId) -> bool {
 }
 
 impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
-    const FULLSCREEN_ENTER_MS: u64 = 220;
-    const FULLSCREEN_EXIT_MS: u64 = 320;
-
     fn fullscreen_monitor_name(&self, node_id: NodeId, output: Option<&WlOutput>) -> String {
         output
             .and_then(|requested_output| {
@@ -763,25 +729,6 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             .fullscreen_suspended_node
             .iter()
             .find_map(|(monitor, &id)| (id == node_id).then_some(monitor.as_str()))
-    }
-
-    fn queue_fullscreen_motion(
-        &mut self,
-        id: NodeId,
-        from: Vec2,
-        to: Vec2,
-        now_ms: u64,
-        duration_ms: u64,
-    ) {
-        self.model.fullscreen_state.fullscreen_motion.insert(
-            id,
-            crate::compositor::fullscreen::state::FullscreenMotion {
-                from,
-                to,
-                start_ms: now_ms,
-                duration_ms: duration_ms.max(1),
-            },
-        );
     }
 
     fn fullscreen_restore_entries_for_monitor(
@@ -891,7 +838,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
     fn exit_xdg_fullscreen_inner(
         &mut self,
         node_id: NodeId,
-        now: Instant,
+        _now: Instant,
         suspend: bool,
         preserve_client_fullscreen: bool,
     ) {
@@ -935,8 +882,6 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
                 .remove(&monitor_name);
         }
 
-        let now_ms = self.now_ms(now);
-
         self.clear_non_target_fullscreen_restore_entries(&monitor_name, node_id);
 
         if let Some(entry) = self
@@ -946,21 +891,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             .get(&node_id)
             .copied()
         {
-            let _ = self.model.field.set_pinned(node_id, false);
-            let from = self
-                .model
-                .field
-                .node(node_id)
-                .map(|n| n.pos)
-                .unwrap_or(entry.pos);
             self.restore_fullscreen_snapshot(node_id, entry);
-            self.queue_fullscreen_motion(
-                node_id,
-                from,
-                entry.pos,
-                now_ms,
-                Self::FULLSCREEN_EXIT_MS,
-            );
         }
 
         if preserve_client_fullscreen {
@@ -996,13 +927,16 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             .fullscreen_state
             .fullscreen_scale_anim
             .remove(&node_id);
+        if !suspend {
+            self.model
+                .fullscreen_state
+                .fullscreen_restore
+                .remove(&node_id);
+        }
         self.request_maintenance();
     }
 
-    pub(crate) fn suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        self.exit_xdg_fullscreen_inner(node_id, now, true, false);
-    }
-
+    #[cfg(test)]
     pub(crate) fn soft_suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
         self.exit_xdg_fullscreen_inner(node_id, now, true, true);
     }
@@ -1013,6 +947,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
         entry: crate::compositor::fullscreen::state::FullscreenSessionEntry,
     ) {
         if let Some(node) = self.model.field.node_mut(id) {
+            node.pos = entry.pos;
             node.intrinsic_size = entry.intrinsic_size;
         }
         let _ = self.model.field.sync_active_footprint_to_intrinsic(id);
@@ -1091,7 +1026,6 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             self.exit_xdg_fullscreen(existing, now);
         }
 
-        let now_ms = self.now_ms(now);
         let target_size = self.fullscreen_target_size_for(monitor_name.as_str());
         let (viewport_center, _) = self.fullscreen_monitor_view(monitor_name.as_str());
         self.clear_non_target_fullscreen_restore_entries(&monitor_name, node_id);
@@ -1151,33 +1085,6 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
                 pinned: saved_pinned,
             },
         );
-        if soft_resume {
-            let fullscreen_size = Vec2 {
-                x: target_size.0 as f32,
-                y: target_size.1 as f32,
-            };
-            if let Some(node) = self.model.field.node_mut(node_id) {
-                node.intrinsic_size = fullscreen_size;
-            }
-            let _ = self.model.field.sync_active_footprint_to_intrinsic(node_id);
-            self.set_last_active_size_now(node_id, fullscreen_size);
-        }
-        let _ = self.model.field.set_pinned(node_id, false);
-        self.queue_fullscreen_motion(
-            node_id,
-            node.pos,
-            viewport_center,
-            now_ms,
-            Self::FULLSCREEN_ENTER_MS,
-        );
-        self.model.fullscreen_state.fullscreen_scale_anim.insert(
-            node_id,
-            crate::compositor::fullscreen::state::FullscreenScaleAnim {
-                start_ms: now_ms,
-                duration_ms: Self::FULLSCREEN_ENTER_MS,
-            },
-        );
-
         if !soft_resume {
             self.request_toplevel_fullscreen_state(node_id, true, output, Some(target_size));
         }
@@ -1187,6 +1094,7 @@ impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
             .fullscreen_active_node
             .insert(monitor_name, node_id);
         self.set_interaction_focus(Some(node_id), 30_000, now);
+        let _ = self.raise_overlap_policy_node(node_id);
         self.request_maintenance();
     }
 

--- a/crates/halley-wl/src/compositor/monitor/state.rs
+++ b/crates/halley-wl/src/compositor/monitor/state.rs
@@ -404,6 +404,14 @@ pub(crate) fn node_visible_on_current_monitor(st: &Halley, id: NodeId) -> bool {
         .is_none_or(|monitor| monitor == &st.model.monitor_state.current_monitor)
 }
 
+pub(crate) fn node_assigned_to_current_monitor(st: &Halley, id: NodeId) -> bool {
+    st.model
+        .monitor_state
+        .node_monitor
+        .get(&id)
+        .is_some_and(|monitor| monitor == &st.model.monitor_state.current_monitor)
+}
+
 #[allow(dead_code)]
 pub(crate) fn assign_node_to_current_monitor(st: &mut Halley, id: NodeId) {
     let monitor = st.model.monitor_state.current_monitor.clone();
@@ -663,6 +671,28 @@ mod tests {
 
         assert_eq!(state.focused_monitor(), "right");
         assert_eq!(state.interaction_monitor(), "left");
+    }
+
+    #[test]
+    fn render_assignment_requires_explicit_current_monitor_owner() {
+        let tuning = two_monitor_tuning();
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let node_id = state.model.field.spawn_surface(
+            "straddling",
+            Vec2 { x: 790.0, y: 300.0 },
+            Vec2 { x: 240.0, y: 160.0 },
+        );
+
+        let _ = state.activate_monitor("left");
+        assert!(!node_assigned_to_current_monitor(&state, node_id));
+        state.assign_node_to_monitor(node_id, "left");
+        assert!(node_assigned_to_current_monitor(&state, node_id));
+
+        let _ = state.activate_monitor("right");
+        assert!(!node_assigned_to_current_monitor(&state, node_id));
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/overlap/read.rs
+++ b/crates/halley-wl/src/compositor/overlap/read.rs
@@ -127,6 +127,14 @@ impl<'a> OverlapReadContext<'a> {
         if self.spawn_state.pending_initial_reveal.contains(&id) {
             return false;
         }
+        if self
+            .workspace_state
+            .maximize_sessions
+            .values()
+            .any(|session| session.target_id == id)
+        {
+            return false;
+        }
         self.field.node(id).is_some_and(|n| {
             self.field.is_visible(id)
                 && matches!(

--- a/crates/halley-wl/src/compositor/overlap/system/mod.rs
+++ b/crates/halley-wl/src/compositor/overlap/system/mod.rs
@@ -44,7 +44,7 @@ fn physics_inv_mass(st: &Halley, id: NodeId, pinned: bool) -> f32 {
 
 #[inline]
 fn node_participates_in_overlap(st: &Halley, id: NodeId) -> bool {
-    overlap_read_context(st).node_participates_in_overlap(id)
+    !st.is_fullscreen_active(id) && overlap_read_context(st).node_participates_in_overlap(id)
 }
 
 pub(crate) fn non_overlap_gap_world(st: &Halley) -> f32 {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1358,10 +1358,7 @@ impl Halley {
             })
     }
 
-    pub(crate) fn suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        super::fullscreen::system::fullscreen_controller(self).suspend_xdg_fullscreen(node_id, now)
-    }
-
+    #[cfg(test)]
     pub(crate) fn soft_suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
         super::fullscreen::system::fullscreen_controller(self)
             .soft_suspend_xdg_fullscreen(node_id, now)

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -745,6 +745,10 @@ impl Halley {
         super::monitor::state::node_visible_on_current_monitor(self, id)
     }
 
+    pub(crate) fn node_assigned_to_current_monitor(&self, id: NodeId) -> bool {
+        super::monitor::state::node_assigned_to_current_monitor(self, id)
+    }
+
     #[allow(dead_code)]
     pub(crate) fn assign_node_to_current_monitor(&mut self, id: NodeId) {
         let monitor = self.model.monitor_state.current_monitor.clone();

--- a/crates/halley-wl/src/compositor/spawn/state.rs
+++ b/crates/halley-wl/src/compositor/spawn/state.rs
@@ -177,9 +177,7 @@ pub(crate) fn node_draws_above_fullscreen_on_monitor(
         .monitor_state
         .node_monitor
         .get(&node_id)
-        .map(String::as_str)
-        .unwrap_or(st.model.monitor_state.current_monitor.as_str())
-        == monitor
+        .is_some_and(|node_monitor| node_monitor == monitor)
 }
 
 pub(crate) fn monitor_has_visible_overlap_policy_window(st: &Halley, monitor: &str) -> bool {
@@ -376,6 +374,55 @@ mod tests {
 
         assert!(monitor_has_visible_overlap_policy_window(
             &st,
+            monitor.as_str()
+        ));
+    }
+
+    #[test]
+    fn overlap_policy_window_without_monitor_assignment_draws_above_no_outputs() {
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.cluster_default_layout = halley_config::ClusterDefaultLayout::Tiling;
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, tuning);
+
+        let monitor = st.model.monitor_state.current_monitor.clone();
+        let fullscreen = st.model.field.spawn_surface(
+            "fullscreen",
+            Vec2 { x: 400.0, y: 300.0 },
+            Vec2 { x: 800.0, y: 600.0 },
+        );
+        let overlap = st.model.field.spawn_surface(
+            "overlap",
+            Vec2 { x: 790.0, y: 300.0 },
+            Vec2 { x: 240.0, y: 180.0 },
+        );
+        st.assign_node_to_monitor(fullscreen, monitor.as_str());
+        st.model.monitor_state.node_monitor.remove(&overlap);
+        for id in [fullscreen, overlap] {
+            let _ = st
+                .model
+                .field
+                .set_state(id, halley_core::field::NodeState::Active);
+        }
+        st.model
+            .fullscreen_state
+            .fullscreen_active_node
+            .insert(monitor.clone(), fullscreen);
+        st.model.spawn_state.applied_window_rules.insert(
+            overlap,
+            AppliedInitialWindowRule {
+                overlap_policy: InitialWindowOverlapPolicy::All,
+                spawn_placement: InitialWindowSpawnPlacement::Adjacent,
+                cluster_participation: InitialWindowClusterParticipation::Float,
+                parent_node: None,
+                suppress_reveal_pan: true,
+                builtin_rule: None,
+            },
+        );
+
+        assert!(!node_draws_above_fullscreen_on_monitor(
+            &st,
+            overlap,
             monitor.as_str()
         ));
     }

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
@@ -831,7 +831,7 @@ mod tests {
     }
 
     #[test]
-    fn new_toplevel_on_fullscreen_monitor_exits_only_that_monitor_fullscreen() {
+    fn new_toplevel_on_fullscreen_monitor_keeps_fullscreen_active() {
         let mut tuning = halley_config::RuntimeTuning::default();
         tuning.tty_viewports = vec![
             halley_config::ViewportOutputConfig {
@@ -892,12 +892,13 @@ mod tests {
 
         exit_monitor_fullscreen_for_new_toplevel(&mut state, "left", Instant::now());
 
-        assert!(
-            !state
+        assert_eq!(
+            state
                 .model
                 .fullscreen_state
                 .fullscreen_active_node
-                .contains_key("left")
+                .get("left"),
+            Some(&fullscreen_left)
         );
         assert_eq!(
             state
@@ -1010,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    fn maximize_exit_for_new_toplevel_restores_focus_anchor() {
+    fn new_toplevel_does_not_exit_maximize() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -1037,25 +1038,16 @@ mod tests {
         exit_monitor_maximize_for_new_toplevel(&mut state, monitor.as_str(), Instant::now());
 
         assert!(
-            !state
+            state
                 .model
                 .workspace_state
                 .maximize_sessions
                 .contains_key(monitor.as_str())
         );
-        assert_eq!(
-            state.model.focus_state.primary_interaction_focus,
-            Some(target)
-        );
-        assert_eq!(state.current_spawn_focus(monitor.as_str()).0, Some(target));
-        assert_eq!(
-            state.current_spawn_focus(monitor.as_str()).1,
-            Vec2 { x: 100.0, y: 100.0 }
-        );
     }
 
     #[test]
-    fn maximize_exit_rule_matches_only_non_overlap_toplevels() {
+    fn maximize_exit_rule_never_exits_for_new_toplevels() {
         let normal_intent = InitialWindowIntent {
             app_id: None,
             title: None,
@@ -1079,7 +1071,7 @@ mod tests {
             ..normal_intent.clone()
         };
 
-        assert!(should_exit_monitor_maximize_for_new_toplevel(
+        assert!(!should_exit_monitor_maximize_for_new_toplevel(
             &normal_intent
         ));
         assert!(!should_exit_monitor_maximize_for_new_toplevel(

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
@@ -6,45 +6,17 @@ pub(super) fn exit_monitor_fullscreen_for_new_toplevel(
     monitor: &str,
     now: Instant,
 ) {
-    if let Some(existing) = st
-        .model
-        .fullscreen_state
-        .fullscreen_active_node
-        .get(monitor)
-        .copied()
-    {
-        st.exit_xdg_fullscreen(existing, now);
-    }
+    let _ = (st, monitor, now);
 }
 
 pub(super) fn exit_monitor_maximize_for_new_toplevel(st: &mut Halley, monitor: &str, now: Instant) {
-    let Some(target_id) =
-        crate::compositor::workspace::state::maximize_session_target_for_monitor(st, monitor)
-    else {
-        return;
-    };
-    let target_anchor = st
-        .model
-        .workspace_state
-        .maximize_sessions
-        .get(monitor)
-        .and_then(|session| session.node_snapshots.get(&target_id))
-        .copied();
-    if let Some(snapshot) = target_anchor {
-        st.spawn_monitor_state_mut(monitor).spawn_focus_override =
-            Some(crate::compositor::spawn::state::SpawnFocusOverride {
-                pos: snapshot.pos,
-                size: snapshot.size,
-            });
-    }
-    if crate::compositor::actions::window::restore_maximize_session_for_spawn(st, monitor, now) {
-        st.request_maintenance();
-    }
+    let _ = (st, monitor, now);
 }
 
 #[inline]
 pub(super) fn should_exit_monitor_maximize_for_new_toplevel(intent: &InitialWindowIntent) -> bool {
-    intent.effective_overlap_policy() == halley_config::InitialWindowOverlapPolicy::None
+    let _ = intent;
+    false
 }
 
 pub(super) fn exit_monitor_fullscreen_for_overlap_intent(
@@ -459,6 +431,22 @@ pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
             .window_geometry
             .insert(node_id, window_geometry);
         if is_active_cluster_workspace_member(st, node_id) {
+            return;
+        }
+        if crate::compositor::workspace::state::node_in_maximize_session(st, node_id) {
+            st.model
+                .workspace_state
+                .last_active_size
+                .insert(node_id, new_size);
+            st.request_maintenance();
+            return;
+        }
+        if st.is_fullscreen_active(node_id) {
+            st.model
+                .workspace_state
+                .last_active_size
+                .insert(node_id, new_size);
+            st.request_maintenance();
             return;
         }
         let size_changed = st.model.field.node(node_id).is_some_and(|node| {

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -196,7 +196,27 @@ pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) 
     if st.is_fullscreen_session_node(id) {
         return false;
     }
-    let _ = st.model.field.set_state(id, NodeState::Node);
+    finish_surface_collapse(st, id, now, pending.map(|pending| pending.origin_pos), true)
+}
+
+pub(crate) fn finish_auto_collapse(st: &mut Halley, id: NodeId, now: Instant) -> bool {
+    if st.is_fullscreen_session_node(id) {
+        return false;
+    }
+    finish_surface_collapse(st, id, now, None, false)
+}
+
+fn finish_surface_collapse(
+    st: &mut Halley,
+    id: NodeId,
+    now: Instant,
+    origin_pos: Option<Vec2>,
+    preserve_manual: bool,
+) -> bool {
+    let Some(current_pos) = st.model.field.node(id).map(|node| node.pos) else {
+        return false;
+    };
+
     let _ = st
         .model
         .field
@@ -205,26 +225,27 @@ pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) 
         .spawn_state
         .pending_spawn_activate_at_ms
         .remove(&id);
-    st.model.workspace_state.manual_collapsed_nodes.insert(id);
-    if let Some(current_pos) = st.model.field.node(id).map(|node| node.pos) {
-        let from = pending
-            .map(|pending| pending.origin_pos)
-            .unwrap_or(current_pos);
-        let _ = st.carry_surface_non_overlap(id, from, false);
-        if let Some(to) = st.model.field.node(id).map(|node| node.pos)
-            && ((from.x - to.x).abs() > 0.5 || (from.y - to.y).abs() > 0.5)
-        {
-            let slide_start = st
-                .ui
-                .render_state
-                .closing_window_animations
-                .get(&id)
-                .map(|anim| anim.started_at + Duration::from_millis(anim.duration_ms))
-                .unwrap_or(now);
-            st.ui
-                .render_state
-                .start_landmark_slide_animation_at(id, from, to, slide_start);
-        }
+    if preserve_manual {
+        st.model.workspace_state.manual_collapsed_nodes.insert(id);
+    } else {
+        st.model.workspace_state.manual_collapsed_nodes.remove(&id);
+    }
+
+    let from = origin_pos.unwrap_or(current_pos);
+    let _ = st.carry_surface_non_overlap(id, from, false);
+    if let Some(to) = st.model.field.node(id).map(|node| node.pos)
+        && ((from.x - to.x).abs() > 0.5 || (from.y - to.y).abs() > 0.5)
+    {
+        let slide_start = st
+            .ui
+            .render_state
+            .closing_window_animations
+            .get(&id)
+            .map(|anim| anim.started_at + Duration::from_millis(anim.duration_ms))
+            .unwrap_or(now);
+        st.ui
+            .render_state
+            .start_landmark_slide_animation_at(id, from, to, slide_start);
     }
 
     if st.model.focus_state.primary_interaction_focus == Some(id) {
@@ -233,6 +254,7 @@ pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) 
     if st.model.focus_state.pan_restore_active_focus == Some(id) {
         st.model.focus_state.pan_restore_active_focus = None;
     }
+    st.request_maintenance();
     true
 }
 

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -51,7 +51,6 @@ pub(crate) struct MaximizeCameraSnapshot {
 pub(crate) enum MaximizeSessionState {
     Active,
     Restoring,
-    SpawnRestoring,
 }
 
 #[derive(Clone, Debug)]
@@ -297,12 +296,7 @@ pub(crate) fn maximize_animation_active(st: &Halley) -> bool {
             .workspace_state
             .maximize_sessions
             .values()
-            .any(|session| {
-                matches!(
-                    session.state,
-                    MaximizeSessionState::Restoring | MaximizeSessionState::SpawnRestoring
-                )
-            })
+            .any(|session| matches!(session.state, MaximizeSessionState::Restoring))
 }
 
 pub(crate) fn maximize_session_active_on_monitor(st: &Halley, monitor: &str) -> bool {
@@ -329,11 +323,25 @@ pub(crate) fn maximize_session_monitor_for_node(st: &Halley, node_id: NodeId) ->
         .find_map(|(monitor, session)| (session.target_id == node_id).then(|| monitor.clone()))
 }
 
+#[cfg(test)]
 pub(crate) fn maximized_visual_for_node_on_current_monitor(
     st: &Halley,
     node_id: NodeId,
 ) -> Option<(Vec2, Vec2)> {
+    maximized_visual_for_node_on_current_monitor_at(st, node_id, Instant::now())
+}
+
+pub(crate) fn maximized_visual_for_node_on_current_monitor_at(
+    st: &Halley,
+    node_id: NodeId,
+    now: Instant,
+) -> Option<(Vec2, Vec2)> {
     let monitor = st.model.monitor_state.current_monitor.as_str();
+    if let Some(rect) = maximize_animation_visual_for_node_on_monitor_at(st, node_id, monitor, now)
+    {
+        return Some(rect);
+    }
+
     let session = st.model.workspace_state.maximize_sessions.get(monitor)?;
     if session.target_id != node_id || session.state != MaximizeSessionState::Active {
         return None;
@@ -352,6 +360,36 @@ pub(crate) fn maximized_visual_for_node_on_current_monitor(
             y: (viewport.size.y - inset * 2.0).max(72.0),
         },
     ))
+}
+
+pub(crate) fn maximize_animation_visual_for_node_on_monitor_at(
+    st: &Halley,
+    node_id: NodeId,
+    monitor: &str,
+    now: Instant,
+) -> Option<(Vec2, Vec2)> {
+    let anim = st.model.workspace_state.maximize_animation.get(&node_id)?;
+    (anim.monitor == monitor).then(|| maximize_animation_rect(st, anim, now))
+}
+
+fn maximize_animation_rect(st: &Halley, anim: &MaximizeAnimation, now: Instant) -> (Vec2, Vec2) {
+    let now_ms = st.now_ms(now);
+    let elapsed = now_ms.saturating_sub(anim.start_ms);
+    let t = (elapsed as f32 / anim.duration_ms.max(1) as f32).clamp(0.0, 1.0);
+    let e = if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
+    };
+    let pos = Vec2 {
+        x: anim.from_pos.x + (anim.to_pos.x - anim.from_pos.x) * e,
+        y: anim.from_pos.y + (anim.to_pos.y - anim.from_pos.y) * e,
+    };
+    let size = Vec2 {
+        x: (anim.from_size.x + (anim.to_size.x - anim.from_size.x) * e).max(96.0),
+        y: (anim.from_size.y + (anim.to_size.y - anim.from_size.y) * e).max(72.0),
+    };
+    (pos, size)
 }
 
 pub(crate) fn node_in_maximize_session(st: &Halley, node_id: NodeId) -> bool {
@@ -458,30 +496,6 @@ pub(crate) fn reset_monitor_zoom_for_maximize(st: &mut Halley, monitor: &str) {
     }
 }
 
-pub(crate) fn monitor_camera_matches_snapshot(
-    st: &Halley,
-    monitor: &str,
-    snapshot: MaximizeCameraSnapshot,
-) -> bool {
-    if st.model.monitor_state.current_monitor == monitor {
-        (st.model.viewport.center.x - snapshot.center.x).abs() < 0.15
-            && (st.model.viewport.center.y - snapshot.center.y).abs() < 0.15
-            && (st.model.zoom_ref_size.x - snapshot.view_size.x).abs() < 0.15
-            && (st.model.zoom_ref_size.y - snapshot.view_size.y).abs() < 0.15
-    } else {
-        st.model
-            .monitor_state
-            .monitors
-            .get(monitor)
-            .is_some_and(|space| {
-                (space.camera_target_center.x - snapshot.center.x).abs() < 0.15
-                    && (space.camera_target_center.y - snapshot.center.y).abs() < 0.15
-                    && (space.camera_target_view_size.x - snapshot.view_size.x).abs() < 0.15
-                    && (space.camera_target_view_size.y - snapshot.view_size.y).abs() < 0.15
-            })
-    }
-}
-
 pub(crate) fn abort_maximize_session_for_monitor(st: &mut Halley, monitor: &str) -> bool {
     let Some(session) = st.model.workspace_state.maximize_sessions.remove(monitor) else {
         return false;
@@ -549,29 +563,6 @@ pub(crate) fn tick_maximize_animation(st: &mut Halley, now: Instant) {
     for (id, anim) in animations {
         let elapsed = now_ms.saturating_sub(anim.start_ms);
         let t = (elapsed as f32 / anim.duration_ms.max(1) as f32).clamp(0.0, 1.0);
-        let e = if t < 0.5 {
-            4.0 * t * t * t
-        } else {
-            1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
-        };
-        let pos = Vec2 {
-            x: anim.from_pos.x + (anim.to_pos.x - anim.from_pos.x) * e,
-            y: anim.from_pos.y + (anim.to_pos.y - anim.from_pos.y) * e,
-        };
-        let size = Vec2 {
-            x: (anim.from_size.x + (anim.to_size.x - anim.from_size.x) * e).max(96.0),
-            y: (anim.from_size.y + (anim.to_size.y - anim.from_size.y) * e).max(72.0),
-        };
-
-        if let Some(node) = st.model.field.node_mut(id) {
-            node.pos = pos;
-        }
-        let _ = st.model.field.set_resize_footprint(id, Some(size));
-        st.request_toplevel_resize(id, size.x.round() as i32, size.y.round() as i32);
-        st.input
-            .interaction_state
-            .physics_velocity
-            .insert(id, Vec2 { x: 0.0, y: 0.0 });
 
         if t >= 1.0 {
             finished.push((id, anim));
@@ -581,54 +572,23 @@ pub(crate) fn tick_maximize_animation(st: &mut Halley, now: Instant) {
     let had_finished = !finished.is_empty();
     for (id, anim) in finished {
         st.model.workspace_state.maximize_animation.remove(&id);
-        if let Some(node) = st.model.field.node_mut(id) {
-            node.pos = anim.to_pos;
-            node.intrinsic_size = anim.to_size;
-        }
-        let _ = st.model.field.sync_active_footprint_to_intrinsic(id);
-        st.set_last_active_size_now(id, anim.to_size);
-
-        if let Some(session) = st
+        if st
             .model
             .workspace_state
             .maximize_sessions
             .get(anim.monitor.as_str())
-            && let Some(snapshot) = session.node_snapshots.get(&id).copied()
+            .is_some_and(|session| {
+                session.target_id == id && matches!(session.state, MaximizeSessionState::Restoring)
+            })
         {
-            let pinned = match session.state {
-                MaximizeSessionState::Active => true,
-                MaximizeSessionState::Restoring | MaximizeSessionState::SpawnRestoring => {
-                    snapshot.pinned
-                }
-            };
-            let _ = st.model.field.set_pinned(id, pinned);
+            st.model
+                .workspace_state
+                .maximize_sessions
+                .remove(anim.monitor.as_str());
         }
     }
 
-    let sessions_to_remove =
-        st.model
-            .workspace_state
-            .maximize_sessions
-            .iter()
-            .filter_map(|(monitor, session)| {
-                ((session.state == MaximizeSessionState::Restoring
-                    && session
-                        .node_snapshots
-                        .keys()
-                        .all(|id| !st.model.workspace_state.maximize_animation.contains_key(id))
-                    && monitor_camera_matches_snapshot(st, monitor, session.camera))
-                    || (session.state == MaximizeSessionState::SpawnRestoring
-                        && session.node_snapshots.keys().all(|id| {
-                            !st.model.workspace_state.maximize_animation.contains_key(id)
-                        })))
-                .then(|| monitor.clone())
-            })
-            .collect::<Vec<_>>();
-    for monitor in sessions_to_remove {
-        st.model.workspace_state.maximize_sessions.remove(&monitor);
-    }
-
-    if had_finished {
-        st.resolve_overlap_now();
+    if had_finished || !st.model.workspace_state.maximize_animation.is_empty() {
+        st.request_maintenance();
     }
 }

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -10,7 +10,7 @@ pub(crate) struct WorkspaceState {
     pub(crate) active_transitions: HashMap<NodeId, ActiveTransition>,
     pub(crate) primary_promote_cooldown_until_ms: HashMap<NodeId, u64>,
     pub(crate) manual_collapsed_nodes: HashSet<NodeId>,
-    pub(crate) pending_manual_collapses: HashMap<NodeId, u64>,
+    pub(crate) pending_manual_collapses: HashMap<NodeId, PendingManualCollapse>,
     pub(crate) pending_silent_close_until_ms: HashMap<NodeId, u64>,
     pub(crate) user_pinned_nodes: HashSet<NodeId>,
     pub(crate) maximize_sessions: HashMap<String, MaximizeSession>,
@@ -22,6 +22,12 @@ pub(crate) struct WorkspaceState {
 pub(crate) struct ActiveTransition {
     pub(crate) started_at_ms: u64,
     pub(crate) duration_ms: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingManualCollapse {
+    pub(crate) requested_at_ms: u64,
+    pub(crate) origin_pos: Vec2,
 }
 
 impl ActiveTransition {
@@ -164,16 +170,26 @@ pub(crate) fn queue_pending_manual_collapse(st: &mut Halley, id: NodeId, now: In
         return;
     }
     let now_ms = st.now_ms(now);
+    let origin_pos = st
+        .model
+        .field
+        .node(id)
+        .map(|node| node.pos)
+        .unwrap_or(Vec2 { x: 0.0, y: 0.0 });
     st.model
         .workspace_state
         .pending_manual_collapses
         .entry(id)
-        .or_insert(now_ms);
+        .or_insert(PendingManualCollapse {
+            requested_at_ms: now_ms,
+            origin_pos,
+        });
     st.request_maintenance();
 }
 
 pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) -> bool {
-    st.model
+    let pending = st
+        .model
         .workspace_state
         .pending_manual_collapses
         .remove(&id);
@@ -190,7 +206,10 @@ pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) 
         .pending_spawn_activate_at_ms
         .remove(&id);
     st.model.workspace_state.manual_collapsed_nodes.insert(id);
-    if let Some(from) = st.model.field.node(id).map(|node| node.pos) {
+    if let Some(current_pos) = st.model.field.node(id).map(|node| node.pos) {
+        let from = pending
+            .map(|pending| pending.origin_pos)
+            .unwrap_or(current_pos);
         let _ = st.carry_surface_non_overlap(id, from, false);
         if let Some(to) = st.model.field.node(id).map(|node| node.pos)
             && ((from.x - to.x).abs() > 0.5 || (from.y - to.y).abs() > 0.5)
@@ -232,11 +251,11 @@ pub(crate) fn process_pending_manual_collapses_for_monitor(
         .workspace_state
         .pending_manual_collapses
         .iter()
-        .map(|(&id, &requested_at_ms)| (id, requested_at_ms))
+        .map(|(&id, pending)| (id, *pending))
         .collect::<Vec<_>>();
 
     let mut needs_retry = false;
-    for (id, requested_at_ms) in pending {
+    for (id, pending) in pending {
         let Some(node) = st.model.field.node(id) else {
             st.model
                 .workspace_state
@@ -265,7 +284,7 @@ pub(crate) fn process_pending_manual_collapses_for_monitor(
         }
 
         if start_active_to_node_close_animation(st, id, now)
-            || now_ms.saturating_sub(requested_at_ms) >= PENDING_MANUAL_COLLAPSE_MAX_WAIT_MS
+            || now_ms.saturating_sub(pending.requested_at_ms) >= PENDING_MANUAL_COLLAPSE_MAX_WAIT_MS
         {
             let _ = finish_manual_collapse(st, id, now);
         } else {
@@ -297,6 +316,20 @@ pub(crate) fn maximize_animation_active(st: &Halley) -> bool {
             .maximize_sessions
             .values()
             .any(|session| matches!(session.state, MaximizeSessionState::Restoring))
+}
+
+pub(crate) fn maximize_animation_active_for_monitor(st: &Halley, monitor: &str) -> bool {
+    st.model
+        .workspace_state
+        .maximize_animation
+        .values()
+        .any(|anim| anim.monitor == monitor)
+        || st
+            .model
+            .workspace_state
+            .maximize_sessions
+            .get(monitor)
+            .is_some_and(|session| matches!(session.state, MaximizeSessionState::Restoring))
 }
 
 pub(crate) fn maximize_session_active_on_monitor(st: &Halley, monitor: &str) -> bool {

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use halley_core::field::{NodeId, NodeKind, NodeState, Vec2};
 
@@ -196,9 +196,16 @@ pub(crate) fn finish_manual_collapse(st: &mut Halley, id: NodeId, now: Instant) 
         if let Some(to) = st.model.field.node(id).map(|node| node.pos)
             && ((from.x - to.x).abs() > 0.5 || (from.y - to.y).abs() > 0.5)
         {
+            let slide_start = st
+                .ui
+                .render_state
+                .closing_window_animations
+                .get(&id)
+                .map(|anim| anim.started_at + Duration::from_millis(anim.duration_ms))
+                .unwrap_or(now);
             st.ui
                 .render_state
-                .start_landmark_slide_animation(id, from, to, now);
+                .start_landmark_slide_animation_at(id, from, to, slide_start);
         }
     }
 

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -321,6 +321,39 @@ pub(crate) fn maximize_session_target_for_monitor(st: &Halley, monitor: &str) ->
         .map(|session| session.target_id)
 }
 
+pub(crate) fn maximize_session_monitor_for_node(st: &Halley, node_id: NodeId) -> Option<String> {
+    st.model
+        .workspace_state
+        .maximize_sessions
+        .iter()
+        .find_map(|(monitor, session)| (session.target_id == node_id).then(|| monitor.clone()))
+}
+
+pub(crate) fn maximized_visual_for_node_on_current_monitor(
+    st: &Halley,
+    node_id: NodeId,
+) -> Option<(Vec2, Vec2)> {
+    let monitor = st.model.monitor_state.current_monitor.as_str();
+    let session = st.model.workspace_state.maximize_sessions.get(monitor)?;
+    if session.target_id != node_id || session.state != MaximizeSessionState::Active {
+        return None;
+    }
+    let viewport = if st.model.monitor_state.current_monitor == monitor {
+        st.model.viewport
+    } else {
+        st.model.monitor_state.monitors.get(monitor)?.viewport
+    };
+    let inset = st.non_overlap_gap_world().max(0.0)
+        + crate::window::active_window_frame_pad_px(&st.runtime.tuning) as f32;
+    Some((
+        viewport.center,
+        Vec2 {
+            x: (viewport.size.x - inset * 2.0).max(96.0),
+            y: (viewport.size.y - inset * 2.0).max(72.0),
+        },
+    ))
+}
+
 pub(crate) fn node_in_maximize_session(st: &Halley, node_id: NodeId) -> bool {
     st.model
         .workspace_state
@@ -456,7 +489,6 @@ pub(crate) fn abort_maximize_session_for_monitor(st: &mut Halley, monitor: &str)
 
     apply_monitor_camera_snapshot(st, monitor, session.camera);
 
-    let mut restored_any = false;
     for (id, snapshot) in session.node_snapshots {
         st.model.workspace_state.maximize_animation.remove(&id);
 
@@ -465,7 +497,6 @@ pub(crate) fn abort_maximize_session_for_monitor(st: &mut Halley, monitor: &str)
         };
         node.pos = snapshot.pos;
         node.intrinsic_size = snapshot.size;
-        restored_any = true;
         let _ = st.model.field.sync_active_footprint_to_intrinsic(id);
         let _ = st.model.field.set_pinned(id, snapshot.pinned);
         st.request_toplevel_resize(
@@ -474,10 +505,6 @@ pub(crate) fn abort_maximize_session_for_monitor(st: &mut Halley, monitor: &str)
             snapshot.size.y.round() as i32,
         );
         st.set_last_active_size_now(id, snapshot.size);
-    }
-
-    if restored_any {
-        st.resolve_overlap_now();
     }
     true
 }
@@ -504,23 +531,8 @@ pub(crate) fn abort_maximize_session_for_external_active_node_on_monitor(
     monitor: &str,
     entering_id: NodeId,
 ) -> bool {
-    let should_abort = {
-        let Some(session) = st.model.workspace_state.maximize_sessions.get(monitor) else {
-            return false;
-        };
-        if session.state != MaximizeSessionState::Active
-            || session.node_snapshots.contains_key(&entering_id)
-        {
-            return false;
-        }
-        st.model.field.node(entering_id).is_some_and(|node| {
-            node.kind == NodeKind::Surface
-                && node.state == NodeState::Active
-                && st.model.field.is_visible(entering_id)
-        })
-    };
-
-    should_abort && abort_maximize_session_for_monitor(st, monitor)
+    let _ = (st, monitor, entering_id);
+    false
 }
 
 pub(crate) fn tick_maximize_animation(st: &mut Halley, now: Instant) {

--- a/crates/halley-wl/src/frame_loop.rs
+++ b/crates/halley-wl/src/frame_loop.rs
@@ -39,7 +39,11 @@ pub(crate) struct TtyOutputAnimationRedrawState {
 }
 
 pub(crate) fn monitor_overlay_requires_full_repaint(st: &Halley, monitor: &str) -> bool {
-    if st.now_ms(std::time::Instant::now()) < st.runtime.screenshot_full_repaint_until_ms {
+    monitor_overlay_requires_full_repaint_at(st, monitor, st.now_ms(std::time::Instant::now()))
+}
+
+fn monitor_overlay_requires_full_repaint_at(st: &Halley, monitor: &str, now_ms: u64) -> bool {
+    if now_ms < st.runtime.screenshot_full_repaint_until_ms {
         return true;
     }
     st.cluster_mode_active_for_monitor(monitor)
@@ -53,9 +57,7 @@ pub(crate) fn monitor_overlay_requires_full_repaint(st: &Halley, monitor: &str) 
             .cluster_state
             .cluster_overflow_visible_until_ms
             .get(monitor)
-            .is_some_and(|visible_until_ms| {
-                *visible_until_ms > st.now_ms(std::time::Instant::now())
-            })
+            .is_some_and(|visible_until_ms| *visible_until_ms > now_ms)
         || st
             .model
             .cluster_state
@@ -69,7 +71,7 @@ pub(crate) fn monitor_overlay_requires_full_repaint(st: &Halley, monitor: &str) 
             .focus_state
             .focus_ring_preview_until_ms
             .get(monitor)
-            .is_some_and(|until_ms| *until_ms > st.now_ms(std::time::Instant::now()))
+            .is_some_and(|until_ms| *until_ms > now_ms)
         || st.input.interaction_state.focus_cycle_session.is_some()
         || st
             .model
@@ -147,7 +149,8 @@ pub(crate) fn tty_output_animation_redraw_state(
     );
     let fullscreen_motion_active = !st.model.fullscreen_state.fullscreen_motion.is_empty()
         || !st.model.fullscreen_state.fullscreen_scale_anim.is_empty();
-    let maximize_motion_active = crate::compositor::workspace::state::maximize_animation_active(st);
+    let maximize_motion_active =
+        crate::compositor::workspace::state::maximize_animation_active_for_monitor(st, monitor);
     let current_monitor = st.model.monitor_state.current_monitor.as_str();
     let viewport_pan_active = st
         .input
@@ -172,7 +175,7 @@ pub(crate) fn tty_output_animation_redraw_state(
             || (st.model.viewport.center.y - st.model.camera_target_center.y).abs() > 0.05
             || (st.model.zoom_ref_size.x - st.model.camera_target_view_size.x).abs() > 0.05
             || (st.model.zoom_ref_size.y - st.model.camera_target_view_size.y).abs() > 0.05);
-    let overlay_active = monitor_overlay_requires_full_repaint(st, monitor)
+    let overlay_active = monitor_overlay_requires_full_repaint_at(st, monitor, now_ms)
         || st
             .ui
             .render_state

--- a/crates/halley-wl/src/input/pointer/motion/drag.rs
+++ b/crates/halley-wl/src/input/pointer/motion/drag.rs
@@ -75,6 +75,14 @@ pub(crate) fn begin_drag(
     st.input.interaction_state.pending_core_click = None;
     st.input.interaction_state.pending_collapsed_node_press = None;
     st.input.interaction_state.pending_collapsed_node_click = None;
+    if let Some(monitor) =
+        crate::compositor::workspace::state::maximize_session_monitor_for_node(st, hit.node_id)
+    {
+        let _ = crate::compositor::workspace::state::abort_maximize_session_for_monitor(
+            st,
+            monitor.as_str(),
+        );
+    }
     let drag_monitor = st.monitor_for_node_or_current(hit.node_id);
     let edge_pan_eligible = drag_edge_pan_eligible(
         st,
@@ -494,6 +502,63 @@ mod tests {
 
         assert!(!node_is_pointer_draggable(&st, id));
     }
+
+    #[test]
+    fn finishing_active_drag_raises_dropped_window() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, halley_config::RuntimeTuning::default());
+        let existing = st.model.field.spawn_surface(
+            "existing",
+            halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            halley_core::field::Vec2 { x: 400.0, y: 260.0 },
+        );
+        let dragged = st.model.field.spawn_surface(
+            "dragged",
+            halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            halley_core::field::Vec2 { x: 400.0, y: 260.0 },
+        );
+        st.assign_node_to_current_monitor(existing);
+        st.assign_node_to_current_monitor(dragged);
+        let _ = st
+            .model
+            .field
+            .set_state(existing, halley_core::field::NodeState::Active);
+        let _ = st
+            .model
+            .field
+            .set_state(dragged, halley_core::field::NodeState::Active);
+        assert!(st.raise_overlap_policy_node(existing));
+        assert!(st.overlap_policy_stack_rank(existing) > st.overlap_policy_stack_rank(dragged));
+
+        let mut ps = PointerState::default();
+        st.input.interaction_state.active_drag = Some(ActiveDragState {
+            node_id: dragged,
+            allow_monitor_transfer: true,
+            edge_pan_eligible: false,
+            current_offset: halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            pointer_monitor: st.model.monitor_state.current_monitor.clone(),
+            pointer_workspace_size: (1600, 1200),
+            pointer_screen_local: (200.0, 120.0),
+            edge_pan_x: DragAxisMode::Free,
+            edge_pan_y: DragAxisMode::Free,
+            last_edge_pan_at: Instant::now(),
+        });
+
+        finish_pointer_drag(
+            &mut st,
+            &mut ps,
+            dragged,
+            true,
+            halley_core::field::Vec2 { x: 0.0, y: 0.0 },
+            Instant::now(),
+        );
+
+        assert!(st.overlap_policy_stack_rank(dragged) > st.overlap_policy_stack_rank(existing));
+        assert_eq!(
+            st.model.focus_state.primary_interaction_focus,
+            Some(dragged)
+        );
+    }
 }
 
 pub(crate) fn finish_pointer_drag(
@@ -541,6 +606,11 @@ pub(crate) fn finish_pointer_drag(
     }
     crate::compositor::carry::system::set_drag_authority_node(st, None);
     crate::compositor::carry::system::end_carry_state_tracking(st, node_id);
+    if started_active {
+        let _ = st.raise_overlap_policy_node(node_id);
+        st.set_recent_top_node(node_id, now + Duration::from_millis(1200));
+        st.set_interaction_focus(Some(node_id), 30_000, now);
+    }
     st.resolve_surface_overlap();
     ps.preview_block_until = Some(now + Duration::from_millis(360));
     ps.drag = None;

--- a/crates/halley-wl/src/input/pointer/resize/geometry.rs
+++ b/crates/halley-wl/src/input/pointer/resize/geometry.rs
@@ -91,8 +91,8 @@ pub(crate) fn active_node_screen_rect(
     }
 
     if let Some((center, size)) =
-        crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
-            st, node_id,
+        crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+            st, node_id, now,
         )
     {
         let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);
@@ -239,8 +239,8 @@ pub(crate) fn active_node_surface_transform_screen_details(
             let rh = (gh * visual_scale).round() as i32;
             (cx - (rw / 2), cy - (rh / 2), visual_scale)
         } else if let Some((center, visual_size)) =
-            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
-                st, node_id,
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                st, node_id, now,
             )
         {
             let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);

--- a/crates/halley-wl/src/input/pointer/resize/geometry.rs
+++ b/crates/halley-wl/src/input/pointer/resize/geometry.rs
@@ -73,6 +73,40 @@ pub(crate) fn active_node_screen_rect(
         ));
     }
 
+    if let Some((center, size)) =
+        crate::compositor::fullscreen::system::fullscreen_visual_for_node_on_current_monitor(
+            st, node_id,
+        )
+    {
+        let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);
+        let cam_scale = st.camera_render_scale();
+        let half_w = size.x * cam_scale * 0.5;
+        let half_h = size.y * cam_scale * 0.5;
+        return Some((
+            cx as f32 - half_w,
+            cy as f32 - half_h,
+            cx as f32 + half_w,
+            cy as f32 + half_h,
+        ));
+    }
+
+    if let Some((center, size)) =
+        crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
+            st, node_id,
+        )
+    {
+        let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);
+        let cam_scale = st.camera_render_scale();
+        let half_w = size.x * cam_scale * 0.5;
+        let half_h = size.y * cam_scale * 0.5;
+        return Some((
+            cx as f32 - half_w,
+            cy as f32 - half_h,
+            cx as f32 + half_w,
+            cy as f32 + half_h,
+        ));
+    }
+
     let xform = active_node_surface_transform_screen_details(st, w, h, node_id, now, None)?;
     let local_geo = active_node_visual_local_rect(st, node_id).or_else(|| {
         st.model.field.node(node_id).map(|n| {
@@ -150,63 +184,87 @@ pub(crate) fn active_node_surface_transform_screen_details(
         * fit_scale
         * cam_scale;
 
-    let (origin_x, origin_y, scale) =
-        if let Some(active_resize) = active_resize_geometry_screen(st, node_id, resize_preview) {
-            (
-                active_resize.surface_origin_x,
-                active_resize.surface_origin_y,
-                1.0f32,
+    let (origin_x, origin_y, scale) = if let Some(active_resize) =
+        active_resize_geometry_screen(st, node_id, resize_preview)
+    {
+        (
+            active_resize.surface_origin_x,
+            active_resize.surface_origin_y,
+            1.0f32,
+        )
+    } else {
+        let p = n.pos;
+        let (cx, cy) = world_to_screen(st, w, h, p.x, p.y);
+
+        let bbox_lx = st
+            .ui
+            .render_state
+            .cache
+            .bbox_loc
+            .get(&node_id)
+            .copied()
+            .unwrap_or((0.0, 0.0))
+            .0;
+        let bbox_ly = st
+            .ui
+            .render_state
+            .cache
+            .bbox_loc
+            .get(&node_id)
+            .copied()
+            .unwrap_or((0.0, 0.0))
+            .1;
+        let bbox_w = n.intrinsic_size.x.max(1.0);
+        let bbox_h = n.intrinsic_size.y.max(1.0);
+        let local_bbox = (bbox_lx, bbox_ly, bbox_w, bbox_h);
+        let (gx, gy, gw, gh) = st
+            .ui
+            .render_state
+            .cache
+            .window_geometry
+            .get(&node_id)
+            .copied()
+            .map(|(x, y, w, h)| (x, y, w.max(1.0), h.max(1.0)))
+            .unwrap_or(local_bbox);
+
+        let (rx, ry, scale) = if let Some((center, visual_size)) =
+            crate::compositor::fullscreen::system::fullscreen_visual_for_node_on_current_monitor(
+                st, node_id,
+            ) {
+            let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);
+            let scale_x = visual_size.x * cam_scale / gw.max(1.0);
+            let scale_y = visual_size.y * cam_scale / gh.max(1.0);
+            let visual_scale = scale_x.min(scale_y).max(0.001);
+            let rw = (gw * visual_scale).round() as i32;
+            let rh = (gh * visual_scale).round() as i32;
+            (cx - (rw / 2), cy - (rh / 2), visual_scale)
+        } else if let Some((center, visual_size)) =
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
+                st, node_id,
             )
+        {
+            let (cx, cy) = world_to_screen(st, w, h, center.x, center.y);
+            let scale_x = visual_size.x * cam_scale / gw.max(1.0);
+            let scale_y = visual_size.y * cam_scale / gh.max(1.0);
+            let visual_scale = scale_x.min(scale_y).max(0.001);
+            let rw = (gw * visual_scale).round() as i32;
+            let rh = (gh * visual_scale).round() as i32;
+            (cx - (rw / 2), cy - (rh / 2), visual_scale)
+        } else if st
+            .fullscreen_monitor_for_node(node_id)
+            .is_some_and(|monitor| monitor == st.model.monitor_state.current_monitor)
+        {
+            (0, 0, anim_scale)
         } else {
-            let p = n.pos;
-            let (cx, cy) = world_to_screen(st, w, h, p.x, p.y);
-
-            let bbox_lx = st
-                .ui
-                .render_state
-                .cache
-                .bbox_loc
-                .get(&node_id)
-                .copied()
-                .unwrap_or((0.0, 0.0))
-                .0;
-            let bbox_ly = st
-                .ui
-                .render_state
-                .cache
-                .bbox_loc
-                .get(&node_id)
-                .copied()
-                .unwrap_or((0.0, 0.0))
-                .1;
-            let bbox_w = n.intrinsic_size.x.max(1.0);
-            let bbox_h = n.intrinsic_size.y.max(1.0);
-            let local_bbox = (bbox_lx, bbox_ly, bbox_w, bbox_h);
-            let (gx, gy, gw, gh) = st
-                .ui
-                .render_state
-                .cache
-                .window_geometry
-                .get(&node_id)
-                .copied()
-                .map(|(x, y, w, h)| (x, y, w.max(1.0), h.max(1.0)))
-                .unwrap_or(local_bbox);
-
-            let (rx, ry) = if st
-                .fullscreen_monitor_for_node(node_id)
-                .is_some_and(|monitor| monitor == st.model.monitor_state.current_monitor)
-            {
-                (0, 0)
-            } else {
-                let rw = (gw * anim_scale).round() as i32;
-                let rh = (gh * anim_scale).round() as i32;
-                (cx - (rw / 2), cy - (rh / 2))
-            };
-            let origin_x = (rx as f32) - (gx * anim_scale).round();
-            let origin_y = (ry as f32) - (gy * anim_scale).round();
-
-            (origin_x, origin_y, anim_scale)
+            let rw = (gw * anim_scale).round() as i32;
+            let rh = (gh * anim_scale).round() as i32;
+            (cx - (rw / 2), cy - (rh / 2), anim_scale)
         };
+        let origin_x = (rx as f32) - (gx * scale).round();
+        let origin_y = (ry as f32) - (gy * scale).round();
+
+        (origin_x, origin_y, scale)
+    };
 
     Some(ActiveNodeSurfaceTransformScreen {
         origin_x,

--- a/crates/halley-wl/src/input/pointer/resize/interaction.rs
+++ b/crates/halley-wl/src/input/pointer/resize/interaction.rs
@@ -27,6 +27,14 @@ pub(crate) fn begin_resize(
     hit: HitNode,
     frame: ButtonFrame,
 ) {
+    if let Some(monitor) =
+        crate::compositor::workspace::state::maximize_session_monitor_for_node(st, hit.node_id)
+    {
+        let _ = crate::compositor::workspace::state::abort_maximize_session_for_monitor(
+            st,
+            monitor.as_str(),
+        );
+    }
     if !node_allows_interactive_resize(st, hit.node_id) {
         return;
     }

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -138,8 +138,13 @@ impl XdgShellHandler for Halley {
         let Some(node_id) = self.model.surface_to_node.get(&key).copied() else {
             return;
         };
-        if crate::compositor::workspace::state::node_in_maximize_session(self, node_id) {
-            return;
+        if let Some(monitor) =
+            crate::compositor::workspace::state::maximize_session_monitor_for_node(self, node_id)
+        {
+            let _ = crate::compositor::workspace::state::abort_maximize_session_for_monitor(
+                self,
+                monitor.as_str(),
+            );
         }
         let now = Instant::now();
         let focus_target = surface::stack_focus_target_for_node(self, node_id).unwrap_or(node_id);

--- a/crates/halley-wl/src/render/frame/draw.rs
+++ b/crates/halley-wl/src/render/frame/draw.rs
@@ -448,12 +448,14 @@ fn draw_closing_window_animations(
             continue;
         };
 
-        let scale = match style {
+        let eased = crate::animation::ease_in_out_cubic(animation.progress);
+        let (scale, alpha) = match style {
             halley_config::WindowCloseAnimationStyle::Shrink => {
-                (1.0 - crate::animation::ease_in_out_cubic(animation.progress)).clamp(0.0, 1.0)
+                ((1.0 - eased).clamp(0.0, 1.0), 1.0)
             }
+            halley_config::WindowCloseAnimationStyle::Fade => (1.0, (1.0 - eased).clamp(0.0, 1.0)),
         };
-        if scale <= 0.001 {
+        if scale <= 0.001 || alpha <= 0.001 {
             continue;
         }
 
@@ -477,6 +479,7 @@ fn draw_closing_window_animations(
                 tex.geo_w *= scale;
                 tex.geo_h *= scale;
                 tex.corner_radius *= scale;
+                tex.alpha *= alpha;
                 tex
             })
             .collect::<Vec<_>>();
@@ -511,7 +514,7 @@ fn draw_closing_window_animations(
                         inner_offset_y: border_rect.inner_offset_y * scale,
                         inner_w: (border_rect.inner_w * scale).max(1.0),
                         inner_h: (border_rect.inner_h * scale).max(1.0),
-                        alpha: border_rect.alpha,
+                        alpha: border_rect.alpha * alpha,
                         border_px: border_rect.border_px * scale,
                         corner_radius: border_rect.corner_radius * scale,
                         inner_corner_radius: border_rect.inner_corner_radius * scale,

--- a/crates/halley-wl/src/render/frame/scene.rs
+++ b/crates/halley-wl/src/render/frame/scene.rs
@@ -248,7 +248,7 @@ pub(super) fn collect_debug_frame_scene(
             let node = st.model.field.node(id)?;
             if !st.model.field.participates_in_field_view(id)
                 || !st.model.field.is_visible(id)
-                || !st.node_visible_on_current_monitor(id)
+                || !st.node_assigned_to_current_monitor(id)
             {
                 return None;
             }

--- a/crates/halley-wl/src/render/state/mod.rs
+++ b/crates/halley-wl/src/render/state/mod.rs
@@ -180,6 +180,16 @@ impl RenderState {
         to: Vec2,
         now: Instant,
     ) {
+        self.start_landmark_slide_animation_at(node_id, from, to, now);
+    }
+
+    pub(crate) fn start_landmark_slide_animation_at(
+        &mut self,
+        node_id: NodeId,
+        from: Vec2,
+        to: Vec2,
+        started_at: Instant,
+    ) {
         if (from.x - to.x).abs() <= 0.5 && (from.y - to.y).abs() <= 0.5 {
             return;
         }
@@ -188,7 +198,7 @@ impl RenderState {
             LandmarkSlideAnimationState {
                 from,
                 to,
-                started_at: now,
+                started_at,
             },
         );
     }

--- a/crates/halley-wl/src/spatial/hit_test.rs
+++ b/crates/halley-wl/src/spatial/hit_test.rs
@@ -24,7 +24,6 @@ struct ActiveHitOrderingView {
     stack_ranks: HashMap<NodeId, usize>,
     overlap_ranks: HashMap<NodeId, (u64, u64)>,
     draws_above_fullscreen: HashSet<NodeId>,
-    fullscreen_on_current_monitor: HashSet<NodeId>,
     persistent_top: HashSet<NodeId>,
 }
 
@@ -35,7 +34,6 @@ impl ActiveHitOrderingView {
         stack_visible_front_to_back: &[NodeId],
         hits: &[HitNode],
     ) -> Self {
-        let current_monitor = st.model.monitor_state.current_monitor.as_str();
         let stack_ranks = stack_visible_front_to_back
             .iter()
             .enumerate()
@@ -43,19 +41,12 @@ impl ActiveHitOrderingView {
             .collect();
         let mut overlap_ranks = HashMap::new();
         let mut draws_above_fullscreen = HashSet::new();
-        let mut fullscreen_on_current_monitor = HashSet::new();
         let mut persistent_top = HashSet::new();
         for hit in hits {
             let node_id = hit.node_id;
             overlap_ranks.insert(node_id, st.overlap_policy_stack_rank(node_id));
             if st.node_draws_above_fullscreen_on_current_monitor(node_id) {
                 draws_above_fullscreen.insert(node_id);
-            }
-            if st
-                .fullscreen_monitor_for_node(node_id)
-                .is_some_and(|monitor| monitor == current_monitor)
-            {
-                fullscreen_on_current_monitor.insert(node_id);
             }
             if is_persistent_rule_top(st, node_id) {
                 persistent_top.insert(node_id);
@@ -65,7 +56,6 @@ impl ActiveHitOrderingView {
             stack_ranks,
             overlap_ranks,
             draws_above_fullscreen,
-            fullscreen_on_current_monitor,
             persistent_top,
         }
     }
@@ -76,12 +66,6 @@ impl ActiveHitOrderingView {
             self.draws_above_fullscreen.contains(&a.node_id),
             self.draws_above_fullscreen.contains(&b.node_id),
         )
-        .then_with(|| {
-            compare_bool(
-                self.fullscreen_on_current_monitor.contains(&a.node_id),
-                self.fullscreen_on_current_monitor.contains(&b.node_id),
-            )
-        })
         .then_with(|| {
             compare_bool(
                 self.persistent_top.contains(&a.node_id),
@@ -405,6 +389,84 @@ mod tests {
             .expect("surface hit");
 
         assert_eq!(hit.node_id, raised);
+    }
+
+    #[test]
+    fn maximized_window_uses_normal_raise_order_for_hits() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+
+        let maximized = st.model.field.spawn_surface(
+            "maximized",
+            halley_core::field::Vec2 { x: 120.0, y: 140.0 },
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 },
+        );
+        let floating = st.model.field.spawn_surface(
+            "floating",
+            halley_core::field::Vec2 { x: 400.0, y: 300.0 },
+            halley_core::field::Vec2 { x: 220.0, y: 160.0 },
+        );
+        for node_id in [maximized, floating] {
+            st.assign_node_to_monitor(node_id, "monitor_a");
+            let _ = st
+                .model
+                .field
+                .set_state(node_id, halley_core::field::NodeState::Active);
+        }
+        assert!(
+            crate::compositor::actions::window::toggle_node_maximize_state(
+                &mut st,
+                maximized,
+                Instant::now(),
+                "monitor_a",
+            )
+        );
+
+        let hit = pick_hit_node_at(&st, 800, 600, 400.0, 300.0, Instant::now(), None)
+            .expect("surface hit");
+        assert_eq!(hit.node_id, floating);
+
+        assert!(st.raise_overlap_policy_node(maximized));
+        let hit = pick_hit_node_at(&st, 800, 600, 400.0, 300.0, Instant::now(), None)
+            .expect("surface hit");
+        assert_eq!(hit.node_id, maximized);
+    }
+
+    #[test]
+    fn fullscreen_window_uses_normal_raise_order_for_hits() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+
+        let fullscreen = st.model.field.spawn_surface(
+            "fullscreen",
+            halley_core::field::Vec2 { x: 120.0, y: 140.0 },
+            halley_core::field::Vec2 { x: 320.0, y: 240.0 },
+        );
+        let floating = st.model.field.spawn_surface(
+            "floating",
+            halley_core::field::Vec2 { x: 400.0, y: 300.0 },
+            halley_core::field::Vec2 { x: 220.0, y: 160.0 },
+        );
+        for node_id in [fullscreen, floating] {
+            st.assign_node_to_monitor(node_id, "monitor_a");
+            let _ = st
+                .model
+                .field
+                .set_state(node_id, halley_core::field::NodeState::Active);
+        }
+        st.model
+            .fullscreen_state
+            .fullscreen_active_node
+            .insert("monitor_a".to_string(), fullscreen);
+
+        let hit = pick_hit_node_at(&st, 800, 600, 400.0, 300.0, Instant::now(), None)
+            .expect("surface hit");
+        assert_eq!(hit.node_id, floating);
+
+        assert!(st.raise_overlap_policy_node(fullscreen));
+        let hit = pick_hit_node_at(&st, 800, 600, 400.0, 300.0, Instant::now(), None)
+            .expect("surface hit");
+        assert_eq!(hit.node_id, fullscreen);
     }
 
     #[test]

--- a/crates/halley-wl/src/spatial/hit_test.rs
+++ b/crates/halley-wl/src/spatial/hit_test.rs
@@ -394,7 +394,9 @@ mod tests {
     #[test]
     fn maximized_window_uses_normal_raise_order_for_hits() {
         let dh = Display::<Halley>::new().expect("display").handle();
-        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.maximize.enabled = false;
+        let mut st = Halley::new_for_test(&dh, tuning);
 
         let maximized = st.model.field.spawn_surface(
             "maximized",

--- a/crates/halley-wl/src/window/capture.rs
+++ b/crates/halley-wl/src/window/capture.rs
@@ -374,7 +374,7 @@ pub(crate) fn prewarm_visible_active_window_offscreen_caches(
         };
         if node.state != halley_core::field::NodeState::Active
             || !st.model.field.is_visible(node_id)
-            || !st.node_visible_on_current_monitor(node_id)
+            || !st.node_assigned_to_current_monitor(node_id)
             || node_requires_live_surface_render(st, node_id)
         {
             continue;

--- a/crates/halley-wl/src/window/geometry.rs
+++ b/crates/halley-wl/src/window/geometry.rs
@@ -21,6 +21,14 @@ pub(super) fn sync_node_size_from_surface(
         return bbox;
     }
 
+    if crate::compositor::workspace::state::node_in_maximize_session(st, node_id) {
+        return bbox;
+    }
+
+    if st.is_fullscreen_active(node_id) {
+        return bbox;
+    }
+
     if restoring_fullscreen {
         return bbox;
     }

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -319,9 +319,8 @@ pub(crate) fn collect_active_surfaces(
             .and_then(|plan| plan.poses.get(&node_id).copied());
         let stack_member_rendered = stack_render_set.contains(&node_id);
         if node.state != halley_core::field::NodeState::Active
-            || (!stack_member_rendered
-                && (!st.model.field.is_visible(node_id)
-                    || !st.node_visible_on_current_monitor(node_id)))
+            || !st.model.field.is_visible(node_id)
+            || !st.node_assigned_to_current_monitor(node_id)
         {
             continue;
         }

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -297,7 +297,13 @@ pub(crate) fn collect_active_surfaces(
             let wl = t.wl_surface().clone();
             let key = wl.id();
             let node_id = st.model.surface_to_node.get(&key).copied()?;
-            node_surface_map.insert(node_id, wl.clone());
+            let node = st.model.field.node(node_id)?;
+            if node.state != halley_core::field::NodeState::Active
+                || !st.model.field.is_visible(node_id)
+                || !st.node_assigned_to_current_monitor(node_id)
+            {
+                return None;
+            }
             Some((node_id, wl))
         })
         .collect();
@@ -314,6 +320,7 @@ pub(crate) fn collect_active_surfaces(
         let Some(node) = st.model.field.node(node_id) else {
             continue;
         };
+        node_surface_map.insert(node_id, wl.clone());
         let stack_transition_pose = stack_transition_plan
             .as_ref()
             .and_then(|plan| plan.poses.get(&node_id).copied());

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -211,17 +211,17 @@ pub(crate) fn collect_active_surfaces(
 ) {
     let active_elements: Vec<CroppedClippedSurfaceElement> = Vec::new();
     let mut resized_active_elements: Vec<CroppedClippedSurfaceElement> = Vec::new();
-    let mut fullscreen_active_elements: Vec<CroppedClippedSurfaceElement> = Vec::new();
+    let fullscreen_active_elements: Vec<CroppedClippedSurfaceElement> = Vec::new();
     let mut above_fullscreen_active_elements: Vec<CroppedClippedSurfaceElement> = Vec::new();
     let offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
     let mut resized_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
-    let mut fullscreen_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
+    let fullscreen_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
     let mut above_fullscreen_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
     let mut popup_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
-    let mut fullscreen_popup_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
+    let fullscreen_popup_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
     let mut above_fullscreen_popup_offscreen_textures: Vec<OffscreenNodeTexture> = Vec::new();
     let mut popup_elements: Vec<CroppedSurfaceElement> = Vec::new();
-    let mut fullscreen_popup_elements: Vec<CroppedSurfaceElement> = Vec::new();
+    let fullscreen_popup_elements: Vec<CroppedSurfaceElement> = Vec::new();
     let mut above_fullscreen_popup_elements: Vec<CroppedSurfaceElement> = Vec::new();
     let mut node_surface_map = HashMap::new();
     crate::animation::retain_live_cluster_tile_tracks(
@@ -331,6 +331,14 @@ pub(crate) fn collect_active_surfaces(
         let fullscreen_on_current_monitor = st
             .fullscreen_monitor_for_node(node_id)
             .is_some_and(|monitor| monitor == st.model.monitor_state.current_monitor);
+        let fullscreen_visual =
+            crate::compositor::fullscreen::system::fullscreen_visual_for_node_on_current_monitor(
+                st, node_id,
+            );
+        let maximized_visual =
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
+                st, node_id,
+            );
 
         let active_cluster_member = is_active_cluster_workspace_member(st, node_id);
         let dragging_this_node = st.input.interaction_state.drag_authority_node == Some(node_id);
@@ -397,9 +405,7 @@ pub(crate) fn collect_active_surfaces(
 
         // Fit scale for fullscreen windows that don't match the physical monitor resolution.
         let fit_scale = if fullscreen_on_current_monitor {
-            let sw = (output_clip.size.w as f32) / node_intrinsic.x.max(1.0);
-            let sh = (output_clip.size.h as f32) / node_intrinsic.y.max(1.0);
-            sw.min(sh).max(0.1) // aspect-correct fit
+            1.0
         } else if let Some(monitor) = st.fullscreen_monitor_for_node(node_id) {
             let (target_w, target_h) = st.fullscreen_target_size_for(monitor);
             let sw = (target_w as f32) / node_intrinsic.x.max(1.0);
@@ -420,11 +426,11 @@ pub(crate) fn collect_active_surfaces(
         } else {
             raise_anim.shadow_boost
         };
-        let render_scale = scale * cam_scale * fit_scale * raise_scale;
-
         let p = stack_transition_pose
             .map(|pose| pose.center)
             .or_else(|| tiling_tile_transition.map(|rect| rect.center))
+            .or_else(|| fullscreen_visual.map(|(center, _)| center))
+            .or_else(|| maximized_visual.map(|(center, _)| center))
             .unwrap_or(node_pos);
         let local_bbox = (
             bbox.loc.x as f32,
@@ -451,6 +457,18 @@ pub(crate) fn collect_active_surfaces(
         } else {
             frozen_tiling_geometry
                 .unwrap_or_else(|| window_geometry_for_node(st, node_id).unwrap_or(local_bbox))
+        };
+
+        let render_scale = if let Some((_, visual_size)) = fullscreen_visual {
+            let scale_x = visual_size.x * cam_scale / local_geo.2.max(1.0);
+            let scale_y = visual_size.y * cam_scale / local_geo.3.max(1.0);
+            scale_x.min(scale_y).max(0.001)
+        } else if let Some((_, visual_size)) = maximized_visual {
+            let scale_x = visual_size.x * cam_scale / local_geo.2.max(1.0);
+            let scale_y = visual_size.y * cam_scale / local_geo.3.max(1.0);
+            scale_x.min(scale_y).max(0.001)
+        } else {
+            scale * cam_scale * fit_scale * raise_scale
         };
 
         let (_cx, _cy, sx, sy, texture_rect, geometry_rect) =
@@ -828,8 +846,6 @@ pub(crate) fn collect_active_surfaces(
                             .extend(cropped);
                     } else if draw_above_fullscreen_this_node {
                         above_fullscreen_active_elements.extend(cropped);
-                    } else if fullscreen_on_current_monitor {
-                        fullscreen_active_elements.extend(cropped);
                     } else if draw_top_this_node {
                         resized_active_elements.extend(cropped);
                     } else {
@@ -972,8 +988,6 @@ pub(crate) fn collect_active_surfaces(
                                     .extend(cropped);
                             } else if draw_above_fullscreen_this_node {
                                 above_fullscreen_active_elements.extend(cropped);
-                            } else if fullscreen_on_current_monitor {
-                                fullscreen_active_elements.extend(cropped);
                             } else if draw_top_this_node {
                                 resized_active_elements.extend(cropped);
                             } else {
@@ -1214,8 +1228,6 @@ pub(crate) fn collect_active_surfaces(
                             .push(offscreen);
                     } else if draw_above_fullscreen_this_node {
                         above_fullscreen_offscreen_textures.push(offscreen);
-                    } else if fullscreen_on_current_monitor {
-                        fullscreen_offscreen_textures.push(offscreen);
                     } else if draw_top_this_node {
                         resized_offscreen_textures.push(offscreen);
                     } else {
@@ -1308,8 +1320,6 @@ pub(crate) fn collect_active_surfaces(
                     .extend(cropped);
             } else if draw_above_fullscreen_this_node {
                 above_fullscreen_active_elements.extend(cropped);
-            } else if fullscreen_on_current_monitor {
-                fullscreen_active_elements.extend(cropped);
             } else if draw_top_this_node {
                 resized_active_elements.extend(cropped);
             } else {
@@ -1380,8 +1390,6 @@ pub(crate) fn collect_active_surfaces(
                         };
                         if draw_above_fullscreen_this_node {
                             above_fullscreen_popup_offscreen_textures.push(offscreen_texture);
-                        } else if fullscreen_on_current_monitor {
-                            fullscreen_popup_offscreen_textures.push(offscreen_texture);
                         } else {
                             popup_offscreen_textures.push(offscreen_texture);
                         }
@@ -1421,8 +1429,6 @@ pub(crate) fn collect_active_surfaces(
 
         if draw_above_fullscreen_this_node {
             above_fullscreen_popup_elements.extend(popup_cropped);
-        } else if fullscreen_on_current_monitor {
-            fullscreen_popup_elements.extend(popup_cropped);
         } else {
             popup_elements.extend(popup_cropped);
         }

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -336,8 +336,8 @@ pub(crate) fn collect_active_surfaces(
                 st, node_id,
             );
         let maximized_visual =
-            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor(
-                st, node_id,
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                st, node_id, now,
             );
 
         let active_cluster_member = is_active_cluster_workspace_member(st, node_id);

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -264,6 +264,7 @@ animations:
 
   maximize:
     enabled true
+    # Visual-only maximize/unmaximize tween; field geometry stays unchanged.
     duration-ms 240
   end
 

--- a/examples/split-config/theme.rune
+++ b/examples/split-config/theme.rune
@@ -46,3 +46,23 @@ overlays:
   borders true
   border-source "primary"
 end
+
+animations:
+  enabled true
+
+  maximize:
+    enabled true
+    duration-ms 240
+  end
+
+  window-open:
+    enabled true
+    duration-ms 620
+  end
+
+  window-close:
+    enabled true
+    duration-ms 270
+    style "shrink"
+  end
+end


### PR DESCRIPTION
### Summary

Treat maximize and fullscreen as visual presentation states instead of placement/physics operations.

This keeps the field model stable while still allowing maximized/fullscreen windows to render and receive input as output-sized surfaces. Maximize/fullscreen no longer shove, pin, restore, or otherwise mutate unrelated windows, landmarks, cores, clusters, or pinned objects.

### Changes

* Preserve each target window’s field rect and restore size while maximized or fullscreen.
* Request client resize back to the saved restore size when leaving maximize/fullscreen.
* Stop maximize/fullscreen from moving or restoring bystander windows.
* Keep new, transferred, and overlapping windows from automatically unmaximizing or exiting fullscreen.
* Render and hit-test maximized/fullscreen windows using their output-sized visual rect while preserving normal field geography for placement/overlap logic.
* Allow normal windows to stack above maximized/fullscreen windows.
* Let click, trail navigation, and focus cycle raise maximized/fullscreen windows again through normal stack ordering.
* Raise active windows when finishing drag/drop so cross-monitor drops land above destination windows.
* Prevent focus changes and focus cycling from suspending or exiting fullscreen.
* Block direct scanout when a fullscreen candidate is covered by a higher-stacked active window.
* Add fade close animation.
* Animate maximize visually.
* Restrict rendering to the window’s assigned monitor.
* Preserve collapse slide origin.
* Resolve automatic collapse immediately.
* Document the maximize/fullscreen presentation behavior in `CHANGELOG.md`.

### Verification

* `cargo test -p halley-wl fullscreen -- --test-threads=1`
* `cargo test -p halley-wl maximize -- --test-threads=1`
* Focused focus-cycle, trail, hit-order, and drag/drop tests
* `cargo build`
* `git diff --check`
