### PR TITLE
fix(wl): smooth trail maximize and close animations

### DIFF
--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -556,6 +556,17 @@ pub(crate) fn toggle_node_maximize_state(
         return false;
     }
 
+    // If a trail/camera pan is in flight, let it finish first and run the maximize afterwards so
+    // the two animations stay sequential (pan, then maximize) instead of snapping simultaneously.
+    if st.input.interaction_state.viewport_pan_anim.is_some() {
+        st.input.interaction_state.pending_maximize =
+            Some(crate::compositor::interaction::state::PendingMaximize {
+                node_id: id,
+                focused_monitor: focused_monitor.to_string(),
+            });
+        return true;
+    }
+
     let maximize_resume_monitor =
         crate::compositor::workspace::state::take_maximize_resume_for_node(st, id);
     let monitor = maximize_resume_monitor.unwrap_or_else(|| {
@@ -573,6 +584,18 @@ pub(crate) fn toggle_node_maximize_state(
 
     st.set_interaction_focus(Some(id), 30_000, now);
     start_maximize_session(st, id, monitor.as_str(), now)
+}
+
+/// Run a maximize that was deferred while a trail/camera pan was animating. Once the pan has
+/// cleared, re-enter `toggle_node_maximize_state` so the camera is already settled on the target.
+pub(crate) fn tick_pending_maximize(st: &mut Halley, now: Instant) {
+    if st.input.interaction_state.viewport_pan_anim.is_some() {
+        return;
+    }
+    let Some(pending) = st.input.interaction_state.pending_maximize.take() else {
+        return;
+    };
+    let _ = toggle_node_maximize_state(st, pending.node_id, now, pending.focused_monitor.as_str());
 }
 
 fn uncollapse_surface_node_for_action(

--- a/crates/halley-wl/src/compositor/focus/trail.rs
+++ b/crates/halley-wl/src/compositor/focus/trail.rs
@@ -662,4 +662,68 @@ mod tests {
         );
         assert!(state.input.interaction_state.viewport_pan_anim.is_some());
     }
+
+    #[test]
+    fn maximize_during_trail_pan_defers_until_pan_completes() {
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, halley_config::RuntimeTuning::default());
+        let now = Instant::now();
+
+        let near = state.model.field.spawn_surface(
+            "near",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let far = state.model.field.spawn_surface(
+            "far",
+            Vec2 { x: 2_400.0, y: 0.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        state.assign_node_to_current_monitor(near);
+        state.assign_node_to_current_monitor(far);
+
+        // Trail history: focus far then near, with the camera parked on `near`.
+        state.set_interaction_focus(Some(far), 30_000, now);
+        state.set_interaction_focus(Some(near), 30_000, now);
+        state.model.viewport.center = Vec2 { x: 0.0, y: 0.0 };
+
+        // Trail back to `far` — starts a camera pan toward far.pos.
+        assert!(state.navigate_window_trail(TrailDirection::Prev, now));
+        assert_eq!(
+            state.model.focus_state.primary_interaction_focus,
+            Some(far)
+        );
+        assert!(state.input.interaction_state.viewport_pan_anim.is_some());
+
+        // Maximize mid-pan: it must be deferred, not applied, so the pan can play out first.
+        assert!(
+            crate::compositor::actions::window::toggle_node_maximize_state(
+                &mut state, far, now, "default",
+            )
+        );
+        assert!(state.input.interaction_state.viewport_pan_anim.is_some());
+        assert!(state.input.interaction_state.pending_maximize.is_some());
+        assert!(
+            !state
+                .model
+                .workspace_state
+                .maximize_sessions
+                .contains_key("default")
+        );
+
+        // Once the pan completes, the deferred maximize runs.
+        state.tick_viewport_pan_animation(state.now_ms(now) + 1_000);
+        assert!(state.input.interaction_state.viewport_pan_anim.is_none());
+        crate::compositor::actions::window::tick_pending_maximize(&mut state, now);
+        assert!(state.input.interaction_state.pending_maximize.is_none());
+        assert!(
+            state
+                .model
+                .workspace_state
+                .maximize_sessions
+                .contains_key("default")
+        );
+    }
 }

--- a/crates/halley-wl/src/compositor/interaction/state.rs
+++ b/crates/halley-wl/src/compositor/interaction/state.rs
@@ -70,6 +70,12 @@ pub(crate) struct ViewportPanAnim {
 }
 
 #[derive(Clone)]
+pub(crate) struct PendingMaximize {
+    pub(crate) node_id: NodeId,
+    pub(crate) focused_monitor: String,
+}
+
+#[derive(Clone)]
 pub(crate) struct ActiveDragState {
     pub(crate) node_id: NodeId,
     pub(crate) allow_monitor_transfer: bool,
@@ -245,6 +251,9 @@ pub(crate) struct InteractionState {
     pub(crate) smoothed_render_pos: HashMap<NodeId, Vec2>,
     pub(crate) viewport_pan_anim: Option<ViewportPanAnim>,
     pub(crate) pan_dominant_until_ms: u64,
+    /// Maximize requested mid-trail; deferred until `viewport_pan_anim` finishes so the pan
+    /// plays out first and the two animations stay sequential rather than simultaneous.
+    pub(crate) pending_maximize: Option<PendingMaximize>,
     pub(crate) active_drag: Option<ActiveDragState>,
     pub(crate) cluster_join_candidate: Option<ClusterJoinCandidate>,
     pub(crate) bloom_pull_preview: Option<BloomPullPreview>,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -384,6 +384,7 @@ impl Halley {
                     smoothed_render_pos: HashMap::new(),
                     viewport_pan_anim: None,
                     pan_dominant_until_ms: 0,
+                    pending_maximize: None,
                     active_drag: None,
                     cluster_join_candidate: None,
                     bloom_pull_preview: None,

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
@@ -327,7 +327,7 @@ pub(super) fn drop_surface_impl(st: &mut Halley, surface: &WlSurface) {
                     label,
                     state,
                 );
-            } else if let Some((border_rects, offscreen_textures)) =
+            } else if let Some((border_rects, offscreen_textures, start_scale, start_alpha)) =
                 crate::window::capture_closing_window_animation(st, monitor, id)
             {
                 st.ui.render_state.start_closing_window_animation(
@@ -338,6 +338,8 @@ pub(super) fn drop_surface_impl(st: &mut Halley, surface: &WlSurface) {
                     close_anim_style,
                     border_rects,
                     offscreen_textures,
+                    start_scale,
+                    start_alpha,
                 );
             }
         }

--- a/crates/halley-wl/src/compositor/workspace/state.rs
+++ b/crates/halley-wl/src/compositor/workspace/state.rs
@@ -147,7 +147,7 @@ pub(crate) fn start_active_to_node_close_animation(
     let style = st.runtime.tuning.window_close_style();
     // Close-to-node animation reuses the already-warmed offscreen cache. A first
     // collapse can race that cache; callers should queue a pending collapse then.
-    let Some((border_rects, offscreen_textures)) =
+    let Some((border_rects, offscreen_textures, start_scale, start_alpha)) =
         crate::window::capture_closing_window_animation(st, monitor.as_str(), id)
     else {
         return false;
@@ -161,6 +161,8 @@ pub(crate) fn start_active_to_node_close_animation(
         style,
         border_rects,
         offscreen_textures,
+        start_scale,
+        start_alpha,
     );
     st.ui.render_state.finish_window_animation_prewarm(id);
     st.ui

--- a/crates/halley-wl/src/frame_loop/mod.rs
+++ b/crates/halley-wl/src/frame_loop/mod.rs
@@ -125,6 +125,7 @@ pub(crate) fn tick_animator_frame(st: &mut Halley, now: Instant) {
 pub(crate) fn tick_frame_effects(st: &mut Halley, now: Instant) {
     let now_ms = st.now_ms(now);
     st.tick_viewport_pan_animation(now_ms);
+    crate::compositor::actions::window::tick_pending_maximize(st, now);
     let _ = st.process_pending_cluster_slot_transition_for_current_monitor(now);
     st.tick_pending_spawn_pan(now, now_ms);
     crate::compositor::workspace::state::tick_maximize_animation(st, now);
@@ -1075,6 +1076,8 @@ mod tests {
                 border_color: Color32F::new(1.0, 1.0, 1.0, 1.0),
             }],
             Vec::new(),
+            1.0,
+            1.0,
         );
 
         assert!(tty_output_animation_redraw_state(&state, "right", start).active);

--- a/crates/halley-wl/src/render/frame/draw.rs
+++ b/crates/halley-wl/src/render/frame/draw.rs
@@ -443,17 +443,23 @@ fn draw_closing_window_animations(
             style,
             border_rects,
             offscreen_textures,
+            start_scale,
+            start_alpha,
         } = &animation.kind
         else {
             continue;
         };
 
         let eased = crate::animation::ease_in_out_cubic(animation.progress);
+        // Fold in the window's live scale/alpha at close time so the tween continues seamlessly
+        // from the open animation instead of snapping to full size.
         let (scale, alpha) = match style {
             halley_config::WindowCloseAnimationStyle::Shrink => {
-                ((1.0 - eased).clamp(0.0, 1.0), 1.0)
+                (start_scale * (1.0 - eased).clamp(0.0, 1.0), *start_alpha)
             }
-            halley_config::WindowCloseAnimationStyle::Fade => (1.0, (1.0 - eased).clamp(0.0, 1.0)),
+            halley_config::WindowCloseAnimationStyle::Fade => {
+                (*start_scale, start_alpha * (1.0 - eased).clamp(0.0, 1.0))
+            }
         };
         if scale <= 0.001 || alpha <= 0.001 {
             continue;

--- a/crates/halley-wl/src/render/state/mod.rs
+++ b/crates/halley-wl/src/render/state/mod.rs
@@ -80,6 +80,8 @@ pub(crate) enum ClosingWindowAnimationKind {
         style: WindowCloseAnimationStyle,
         border_rects: Vec<ActiveBorderRect>,
         offscreen_textures: Vec<OffscreenNodeTexture>,
+        start_scale: f32,
+        start_alpha: f32,
     },
     Node {
         pos: Vec2,
@@ -325,6 +327,8 @@ impl RenderState {
         style: WindowCloseAnimationStyle,
         border_rects: Vec<ActiveBorderRect>,
         offscreen_textures: Vec<OffscreenNodeTexture>,
+        start_scale: f32,
+        start_alpha: f32,
     ) {
         if border_rects.is_empty() && offscreen_textures.is_empty() {
             return;
@@ -339,6 +343,8 @@ impl RenderState {
                     style,
                     border_rects,
                     offscreen_textures,
+                    start_scale,
+                    start_alpha,
                 },
             },
         );

--- a/crates/halley-wl/src/window/capture.rs
+++ b/crates/halley-wl/src/window/capture.rs
@@ -65,8 +65,30 @@ pub(crate) fn capture_closing_window_animation(
     st: &Halley,
     monitor: &str,
     node_id: NodeId,
-) -> Option<(Vec<ActiveBorderRect>, Vec<OffscreenNodeTexture>)> {
+) -> Option<(Vec<ActiveBorderRect>, Vec<OffscreenNodeTexture>, f32, f32)> {
     let node = st.model.field.node(node_id)?;
+    // The open grow-in is driven by the active-transition system (not the Animator). Capture the
+    // window's live render scale/alpha so the close tween continues from its current on-screen
+    // size instead of snapping to full size first. Mirrors window/layout.rs.
+    let now = Instant::now();
+    let anim = crate::frame_loop::anim_style_for(st, node_id, node.state.clone(), now);
+    let transition_alpha =
+        crate::compositor::workspace::state::active_transition_alpha(st, node_id, now);
+    let open_scale = crate::animation::active_surface_render_scale(
+        anim.scale,
+        st.active_zoom_lock_scale(),
+        node.intrinsic_size.x,
+        node.intrinsic_size.y,
+        transition_alpha,
+    );
+    let live_ramp = if transition_alpha > 0.0 {
+        crate::animation::ease_out_back((1.0 - transition_alpha).clamp(0.0, 1.0), 1.42)
+            .clamp(0.0, 1.08)
+    } else {
+        let live_t = ((anim.scale - 0.44) / (1.0 - 0.44)).clamp(0.0, 1.0);
+        crate::animation::ease_in_out_cubic(live_t).clamp(0.0, 1.0)
+    };
+    let open_alpha = (anim.alpha * live_ramp).clamp(0.0, 1.0);
     let cache = st
         .ui
         .render_state
@@ -98,10 +120,7 @@ pub(crate) fn capture_closing_window_animation(
     ));
     let maximized_visual =
         crate::compositor::workspace::state::maximized_visual_for_node_on_monitor_at(
-            st,
-            node_id,
-            monitor,
-            Instant::now(),
+            st, node_id, monitor, now,
         );
     let visual_pos = maximized_visual.map(|(pos, _)| pos).unwrap_or(node.pos);
     let (cx, cy) = world_to_screen_for_view(
@@ -220,7 +239,7 @@ pub(crate) fn capture_closing_window_animation(
         fullscreen_on_monitor,
     );
 
-    Some((border_rects, vec![offscreen]))
+    Some((border_rects, vec![offscreen], open_scale, open_alpha))
 }
 
 pub(crate) fn capture_window_to_png_via_renderer(
@@ -237,7 +256,7 @@ pub(crate) fn capture_window_to_png_via_renderer(
         ensure_window_texture_program(renderer, st);
         prewarm_visible_active_window_offscreen_caches(renderer, st, now);
 
-        let (mut border_rects, mut offscreen_textures) =
+        let (mut border_rects, mut offscreen_textures, _, _) =
             capture_closing_window_animation(st, monitor, node_id).ok_or_else(|| {
                 io::Error::other(format!(
                     "unable to prepare window capture for node {} on {monitor}",


### PR DESCRIPTION
Defer maximize requests made while a trail viewport pan is active, then run the maximize after the pan completes so the pan and maximize animations stay sequential instead of snapping together.

Capture the active window's live scale and alpha when starting close animations, then seed shrink/fade tweens from those values so windows that are still opening do not jump to full size or full opacity before closing.

Add coverage for maximize deferral during trail pans and update closing animation call sites to pass the captured starting scale and alpha.