### PR TITLE
fix(config): make explicit config paths stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Defaults follow Halley's shipped fresh-config template.
 
 ## Configuration
 
-On first launch Halley bootstraps `~/.config/halley/halley.rune` for you from an internal fully documented template, inserting detected tty monitors into the `viewport` section. Normal config precedence is `~/.config/halley/halley.rune`, then `/etc/halley/halley.rune`, then bundled internal defaults.
+On first launch Halley bootstraps `~/.config/halley/halley.rune` for you from an internal fully documented template, inserting detected tty monitors into the `viewport` section. Normal config precedence is `--config`/`-c`, then `HALLEY_WL_CONFIG`, then `~/.config/halley/halley.rune`, then `/etc/halley/halley.rune`, then generated user config/internal defaults. Use `halley --config /path/to/halley.rune` or `halley -c /path/to/halley.rune` to force a specific file.
 
 Handled by `crates/halley-config`. Covers input settings like repeat/focus mode, keybinds, focus ring shape and size, decay threshold, max windows per Field, viewports, autostart programs and much **more**.
 

--- a/crates/halley-aperture/src/clock.rs
+++ b/crates/halley-aperture/src/clock.rs
@@ -389,6 +389,24 @@ mod tests {
     }
 
     #[test]
+    fn jump_to_minimal_mode_settles_immediately() {
+        let mut runtime = ApertureRuntime::new(ApertureConfig::default());
+        runtime.set_mode(ApertureMode::Collapsed);
+        runtime.update(Duration::from_millis(16), SystemTime::UNIX_EPOCH);
+
+        runtime.jump_to_mode(ApertureMode::Minimal);
+
+        let presentation = runtime.presentation();
+        let targets = mode_targets(runtime.config(), ApertureMode::Minimal);
+        assert_eq!(runtime.target_mode(), ApertureMode::Minimal);
+        assert!(!runtime.animation_active());
+        assert_eq!(presentation.alpha, targets.alpha);
+        assert_eq!(presentation.font_px, targets.font_px);
+        assert_eq!(presentation.edge_padding_px, targets.edge_padding_px);
+        assert_eq!(presentation.hidden_mix, targets.hidden_mix);
+    }
+
+    #[test]
     fn apply_config_updates_style_without_touching_mode() {
         let mut runtime = ApertureRuntime::new(ApertureConfig::default());
         runtime.set_mode(ApertureMode::Hidden);

--- a/crates/halley-aperture/src/standalone.rs
+++ b/crates/halley-aperture/src/standalone.rs
@@ -291,7 +291,11 @@ impl StandaloneAperture {
                 mode_for_output_in(&modes, fallback, placement, layer.output_name.as_deref())
                     .unwrap_or_else(|| layer.runtime.target_mode());
             if layer.runtime.target_mode() != mode {
-                layer.runtime.set_mode(mode);
+                if mode == ApertureMode::Minimal {
+                    layer.runtime.jump_to_mode(mode);
+                } else {
+                    layer.runtime.set_mode(mode);
+                }
                 layer.last_tick = now;
                 changed = true;
             }

--- a/crates/halley-config/src/layout/runtime.rs
+++ b/crates/halley-config/src/layout/runtime.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use halley_core::cluster_layout::ClusterWorkspaceLayoutKind;
@@ -19,6 +19,31 @@ use super::{
     PlacementConfig, ScreenshotConfig, ShapeStyle, ViewportOutputConfig, WindowCloseAnimationStyle,
     WindowRule,
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigPathSource {
+    Explicit,
+    User,
+    System,
+    GeneratedUser,
+}
+
+impl ConfigPathSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConfigPathSource::Explicit => "explicit",
+            ConfigPathSource::User => "user",
+            ConfigPathSource::System => "system",
+            ConfigPathSource::GeneratedUser => "generated user",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedConfigPath {
+    pub path: PathBuf,
+    pub source: ConfigPathSource,
+}
 
 #[derive(Clone, Debug)]
 pub struct RuntimeTuning {
@@ -109,6 +134,12 @@ impl RuntimeTuning {
 
     pub fn global_config_path() -> String {
         global_config_path().to_string_lossy().to_string()
+    }
+
+    pub fn explicit_config_path_from_env() -> Option<PathBuf> {
+        env::var("HALLEY_WL_CONFIG")
+            .ok()
+            .and_then(|path| explicit_config_path_from_value(path.as_str()))
     }
 
     pub fn internal_config_template() -> String {
@@ -264,22 +295,22 @@ impl RuntimeTuning {
     }
 
     pub fn config_path() -> String {
-        match env::var("HALLEY_WL_CONFIG") {
-            Ok(path) => absolutize_path(&path).to_string_lossy().to_string(),
-            Err(_) => {
-                let home = default_config_path();
-                if Path::new(&home).exists() {
-                    home.to_string_lossy().to_string()
-                } else {
-                    let global = global_config_path();
-                    if Path::new(&global).exists() {
-                        global.to_string_lossy().to_string()
-                    } else {
-                        home.to_string_lossy().to_string()
-                    }
-                }
-            }
-        }
+        Self::resolved_config_path()
+            .path
+            .to_string_lossy()
+            .to_string()
+    }
+
+    pub fn resolved_config_path() -> ResolvedConfigPath {
+        let user_path = default_config_path();
+        let system_path = global_config_path();
+        resolve_config_path_from_inputs(
+            env::var("HALLEY_WL_CONFIG").ok().as_deref(),
+            user_path.exists(),
+            system_path.exists(),
+            user_path,
+            system_path,
+        )
     }
 
     pub fn load() -> Self {
@@ -378,6 +409,45 @@ impl RuntimeTuning {
             self.zoom_smooth,
             self.zoom_smooth_rate,
         )
+    }
+}
+
+fn explicit_config_path_from_value(value: &str) -> Option<PathBuf> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| absolutize_path(trimmed))
+}
+
+pub(crate) fn resolve_config_path_from_inputs(
+    explicit: Option<&str>,
+    user_exists: bool,
+    system_exists: bool,
+    user_path: PathBuf,
+    system_path: PathBuf,
+) -> ResolvedConfigPath {
+    if let Some(path) = explicit.and_then(explicit_config_path_from_value) {
+        return ResolvedConfigPath {
+            path,
+            source: ConfigPathSource::Explicit,
+        };
+    }
+
+    if user_exists {
+        return ResolvedConfigPath {
+            path: user_path,
+            source: ConfigPathSource::User,
+        };
+    }
+
+    if system_exists {
+        return ResolvedConfigPath {
+            path: system_path,
+            source: ConfigPathSource::System,
+        };
+    }
+
+    ResolvedConfigPath {
+        path: user_path,
+        source: ConfigPathSource::GeneratedUser,
     }
 }
 
@@ -915,6 +985,78 @@ fn render_viewport_section(tty_viewports: &[ViewportOutputConfig]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn resolved(
+        explicit: Option<&str>,
+        user_exists: bool,
+        system_exists: bool,
+    ) -> ResolvedConfigPath {
+        resolve_config_path_from_inputs(
+            explicit,
+            user_exists,
+            system_exists,
+            PathBuf::from("/home/test/.config/halley/halley.rune"),
+            PathBuf::from("/etc/halley/halley.rune"),
+        )
+    }
+
+    #[test]
+    fn explicit_config_wins_over_env_home_and_system() {
+        let out = resolved(Some("/tmp/test-halley.rune"), true, true);
+
+        assert_eq!(out.source, ConfigPathSource::Explicit);
+        assert_eq!(out.path, PathBuf::from("/tmp/test-halley.rune"));
+    }
+
+    #[test]
+    fn non_empty_env_config_wins_over_home_and_system() {
+        let out = resolved(Some("/tmp/env-halley.rune"), true, true);
+
+        assert_eq!(out.source, ConfigPathSource::Explicit);
+        assert_eq!(out.path, PathBuf::from("/tmp/env-halley.rune"));
+    }
+
+    #[test]
+    fn empty_env_config_is_ignored() {
+        let out = resolved(Some("   "), true, true);
+
+        assert_eq!(out.source, ConfigPathSource::User);
+        assert_eq!(
+            out.path,
+            PathBuf::from("/home/test/.config/halley/halley.rune")
+        );
+    }
+
+    #[test]
+    fn home_config_wins_over_system_config() {
+        let out = resolved(None, true, true);
+
+        assert_eq!(out.source, ConfigPathSource::User);
+        assert_eq!(
+            out.path,
+            PathBuf::from("/home/test/.config/halley/halley.rune")
+        );
+    }
+
+    #[test]
+    fn system_config_is_used_when_home_config_is_missing() {
+        let out = resolved(None, false, true);
+
+        assert_eq!(out.source, ConfigPathSource::System);
+        assert_eq!(out.path, PathBuf::from("/etc/halley/halley.rune"));
+    }
+
+    #[test]
+    fn user_config_is_generation_target_when_no_config_exists() {
+        let out = resolved(None, false, false);
+
+        assert_eq!(out.source, ConfigPathSource::GeneratedUser);
+        assert_eq!(
+            out.path,
+            PathBuf::from("/home/test/.config/halley/halley.rune")
+        );
+    }
 
     #[test]
     fn total_window_border_footprint_includes_secondary_border_when_enabled() {

--- a/crates/halley-config/src/lib.rs
+++ b/crates/halley-config/src/lib.rs
@@ -11,17 +11,17 @@ pub use keybinds::{
 };
 pub use layout::{
     AnimationToggleConfig, AnimationsConfig, ClickCollapsedOutsideFocusMode, ClickCollapsedPanMode,
-    CloseRestorePanMode, ClusterBloomDirection, ClusterDefaultLayout, CursorConfig, DebugConfig,
-    DecorationBorderColor, DecorationsConfig, ExpandedPlacementConfig, ExpandedPlacementStrategy,
-    FindEmptyMode, FontConfig, InitialWindowClusterParticipation, InitialWindowOverlapPolicy,
-    InitialWindowSpawnPlacement, InputConfig, InputFocusMode, KeyboardConfig,
-    LandmarkPlacementConfig, LandmarkPlacementStrategy, NodeBackgroundColorMode,
+    CloseRestorePanMode, ClusterBloomDirection, ClusterDefaultLayout, ConfigPathSource,
+    CursorConfig, DebugConfig, DecorationBorderColor, DecorationsConfig, ExpandedPlacementConfig,
+    ExpandedPlacementStrategy, FindEmptyMode, FontConfig, InitialWindowClusterParticipation,
+    InitialWindowOverlapPolicy, InitialWindowSpawnPlacement, InputConfig, InputFocusMode,
+    KeyboardConfig, LandmarkPlacementConfig, LandmarkPlacementStrategy, NodeBackgroundColorMode,
     NodeBorderColorMode, NodeDisplayPolicy, NormalBlockerPolicy, OverlayBorderSource,
     OverlayColorMode, OverlayShape, OverlayStyleConfig, PanToNewMode, PinBadgeCorner,
     PinnedBlockerPolicy, PinsConfig, PlacementConfig, PlacementRevealConfig, PrimaryBorderConfig,
-    RaiseAnimationConfig, RuntimeTuning, ScreenshotConfig, SecondaryBorderConfig, ShadowColor,
-    ShadowLayerConfig, ShadowsConfig, ShapeStyle, TimedAnimationConfig, ViewportOutputConfig,
-    ViewportVrrMode, WindowCloseAnimationConfig, WindowCloseAnimationStyle, WindowRule,
-    WindowRulePattern,
+    RaiseAnimationConfig, ResolvedConfigPath, RuntimeTuning, ScreenshotConfig,
+    SecondaryBorderConfig, ShadowColor, ShadowLayerConfig, ShadowsConfig, ShapeStyle,
+    TimedAnimationConfig, ViewportOutputConfig, ViewportVrrMode, WindowCloseAnimationConfig,
+    WindowCloseAnimationStyle, WindowRule, WindowRulePattern,
 };
 pub use parse::{ConfigLoadDiagnostic, gather_dependencies_for_file};

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -1151,8 +1151,9 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             }
             eprintln!("halley-wl tty: logging initialized");
 
+            let resolved_config_path = RuntimeTuning::resolved_config_path();
             let (seat_name, drm_probe, libinput_backend, libinput_context, session_notifier) = {
-                let config_path = RuntimeTuning::config_path();
+                let config_path = resolved_config_path.path.to_string_lossy().to_string();
                 let tuning = RuntimeTuning::load_from_path(config_path.as_str());
                 let (tty_session, session_notifier) = LibSeatSession::new().map_err(|err| {
                     io::Error::other(format!("failed to initialize libseat session: {:?}", err))
@@ -1184,10 +1185,12 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             let mut display: Display<Halley> = Display::new()?;
             let dh = display.handle();
 
-            crate::bootstrap::ensure_default_user_config(Some(&bootstrap_tty_viewports(
-                drm_probe.outputs.as_slice(),
-            )));
-            let config_path = Rc::new(RuntimeTuning::config_path());
+            let resolved_config_path = crate::bootstrap::ensure_resolved_default_user_config(
+                resolved_config_path,
+                Some(&bootstrap_tty_viewports(drm_probe.outputs.as_slice())),
+            );
+            let config_source = resolved_config_path.source;
+            let config_path = Rc::new(resolved_config_path.path.to_string_lossy().to_string());
             let aperture_config_path = Rc::new(crate::aperture::default_aperture_config_path());
             let (tuning, startup_config_error) =
                 crate::bootstrap::load_startup_tuning(config_path.as_str());
@@ -1200,7 +1203,17 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                     config_path.as_str()
                 );
             }
-            info!("config path: {}", config_path.as_str());
+            info!(
+                "config: using {} {}",
+                config_source.as_str(),
+                config_path.as_str()
+            );
+            info!(
+                "keyboard config: layout={} variant={} options={}",
+                tuning.input.keyboard.layout,
+                tuning.input.keyboard.variant,
+                tuning.input.keyboard.options
+            );
             if !aperture_config_path.as_path().exists() {
                 warn!(
                     "aperture config file not found at {}; using built-in defaults",

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -251,8 +251,9 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let mut display: Display<Halley> = Display::new()?;
             let dh = display.handle();
 
-            crate::bootstrap::ensure_default_user_config(None);
-            let config_path = Rc::new(RuntimeTuning::config_path());
+            let resolved_config_path = crate::bootstrap::ensure_default_user_config(None);
+            let config_source = resolved_config_path.source;
+            let config_path = Rc::new(resolved_config_path.path.to_string_lossy().to_string());
             let aperture_config_path = Rc::new(crate::aperture::default_aperture_config_path());
             let (tuning, startup_config_error) =
                 crate::bootstrap::load_startup_tuning(config_path.as_str());
@@ -265,7 +266,17 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     config_path.as_str()
                 );
             }
-            info!("config path: {}", config_path.as_str());
+            info!(
+                "config: using {} {}",
+                config_source.as_str(),
+                config_path.as_str()
+            );
+            info!(
+                "keyboard config: layout={} variant={} options={}",
+                tuning.input.keyboard.layout,
+                tuning.input.keyboard.variant,
+                tuning.input.keyboard.options
+            );
             if !aperture_config_path.as_path().exists() {
                 warn!(
                     "aperture config file not found at {}; using built-in defaults",

--- a/crates/halley-wl/src/bootstrap/mod.rs
+++ b/crates/halley-wl/src/bootstrap/mod.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use halley_config::{ConfigLoadDiagnostic, RuntimeTuning, ViewportOutputConfig};
+use halley_config::{
+    ConfigLoadDiagnostic, ConfigPathSource, ResolvedConfigPath, RuntimeTuning, ViewportOutputConfig,
+};
 
 use eventline::{
     FileSetup, LogLevel, LogPolicy, RunHeader, Setup, debug, enable_console_color,
@@ -249,52 +251,84 @@ pub(crate) fn viewport_section_changed(prev: &RuntimeTuning, next: &RuntimeTunin
     normalized_tty_viewports(prev) != normalized_tty_viewports(next)
 }
 
-pub(crate) fn ensure_default_user_config(tty_viewports: Option<&[ViewportOutputConfig]>) {
-    if env::var("HALLEY_WL_CONFIG").is_ok() {
-        return;
-    }
+pub(crate) fn ensure_default_user_config(
+    tty_viewports: Option<&[ViewportOutputConfig]>,
+) -> ResolvedConfigPath {
+    let resolved = RuntimeTuning::resolved_config_path();
+    ensure_resolved_default_user_config(resolved, tty_viewports)
+}
 
-    let home_path = PathBuf::from(RuntimeTuning::default_home_config_path());
-    if home_path.exists() {
-        let raw = match fs::read_to_string(&home_path) {
-            Ok(raw) => raw,
-            Err(err) => {
+pub(crate) fn ensure_resolved_default_user_config(
+    resolved: ResolvedConfigPath,
+    tty_viewports: Option<&[ViewportOutputConfig]>,
+) -> ResolvedConfigPath {
+    match default_user_config_action(resolved.source) {
+        DefaultUserConfigAction::Skip => {}
+        DefaultUserConfigAction::BackfillUser => {
+            backfill_existing_user_config(resolved.path.as_path(), tty_viewports.unwrap_or(&[]));
+        }
+        DefaultUserConfigAction::CreateUser => {
+            create_default_user_config(resolved.path.as_path(), tty_viewports.unwrap_or(&[]));
+        }
+    }
+    resolved
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DefaultUserConfigAction {
+    Skip,
+    BackfillUser,
+    CreateUser,
+}
+
+fn default_user_config_action(source: ConfigPathSource) -> DefaultUserConfigAction {
+    match source {
+        ConfigPathSource::Explicit | ConfigPathSource::System => DefaultUserConfigAction::Skip,
+        ConfigPathSource::User => DefaultUserConfigAction::BackfillUser,
+        ConfigPathSource::GeneratedUser => DefaultUserConfigAction::CreateUser,
+    }
+}
+
+fn backfill_existing_user_config(home_path: &Path, tty_viewports: &[ViewportOutputConfig]) {
+    let raw = match fs::read_to_string(home_path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            warn!(
+                "bootstrap: failed to read existing config {}: {}",
+                home_path.display(),
+                err
+            );
+            return;
+        }
+    };
+
+    match RuntimeTuning::update_user_config_text(&raw, tty_viewports) {
+        Ok(Some(updated)) => {
+            if let Err(err) = fs::write(home_path, updated) {
                 warn!(
-                    "bootstrap: failed to read existing config {}: {}",
+                    "bootstrap: failed to update existing config {}: {}",
                     home_path.display(),
                     err
                 );
-                return;
-            }
-        };
-
-        match RuntimeTuning::update_user_config_text(&raw, tty_viewports.unwrap_or(&[])) {
-            Ok(Some(updated)) => {
-                if let Err(err) = fs::write(&home_path, updated) {
-                    warn!(
-                        "bootstrap: failed to update existing config {}: {}",
-                        home_path.display(),
-                        err
-                    );
-                } else {
-                    info!(
-                        "bootstrap: updated existing config {} with missing template entries",
-                        home_path.display()
-                    );
-                }
-            }
-            Ok(None) => {}
-            Err(err) => {
-                warn!(
-                    "bootstrap: skipped config update for {}: {}",
-                    home_path.display(),
-                    err
+            } else {
+                info!(
+                    "bootstrap: updated existing config {} with missing template entries",
+                    home_path.display()
                 );
             }
         }
-        return;
+        Ok(None) => {}
+        Err(err) => {
+            warn!(
+                "bootstrap: skipped config update for {}: {}",
+                home_path.display(),
+                err
+            );
+        }
     }
+}
 
+fn create_default_user_config(home_path: &Path, tty_viewports: &[ViewportOutputConfig]) {
     let Some(parent) = home_path.parent() else {
         warn!(
             "bootstrap: unable to determine config directory for {}",
@@ -311,8 +345,8 @@ pub(crate) fn ensure_default_user_config(tty_viewports: Option<&[ViewportOutputC
         return;
     }
 
-    let rendered = RuntimeTuning::render_fresh_config(tty_viewports.unwrap_or(&[]));
-    if let Err(err) = fs::write(&home_path, rendered) {
+    let rendered = RuntimeTuning::render_fresh_config(tty_viewports);
+    if let Err(err) = fs::write(home_path, rendered) {
         warn!(
             "bootstrap: failed to write {} from internal template: {}",
             home_path.display(),
@@ -325,6 +359,43 @@ pub(crate) fn ensure_default_user_config(tty_viewports: Option<&[ViewportOutputC
         "bootstrap: wrote {} using internal template",
         home_path.display()
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_config_does_not_create_or_backfill_home_config() {
+        assert_eq!(
+            default_user_config_action(ConfigPathSource::Explicit),
+            DefaultUserConfigAction::Skip
+        );
+    }
+
+    #[test]
+    fn system_config_does_not_create_home_config() {
+        assert_eq!(
+            default_user_config_action(ConfigPathSource::System),
+            DefaultUserConfigAction::Skip
+        );
+    }
+
+    #[test]
+    fn existing_user_config_is_backfilled() {
+        assert_eq!(
+            default_user_config_action(ConfigPathSource::User),
+            DefaultUserConfigAction::BackfillUser
+        );
+    }
+
+    #[test]
+    fn user_config_is_created_only_when_no_config_exists() {
+        assert_eq!(
+            default_user_config_action(ConfigPathSource::GeneratedUser),
+            DefaultUserConfigAction::CreateUser
+        );
+    }
 }
 
 pub fn run() -> Result<(), Box<dyn Error>> {

--- a/crates/halley/src/main.rs
+++ b/crates/halley/src/main.rs
@@ -1,6 +1,19 @@
+use std::ffi::OsString;
+
 fn main() {
-    let session = std::env::args_os().skip(1).any(|arg| arg == "--session");
-    let result = if session {
+    let args = match CliArgs::parse(std::env::args_os().skip(1)) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("halley: {err}");
+            std::process::exit(2);
+        }
+    };
+    if let Some(config) = args.config {
+        unsafe {
+            std::env::set_var("HALLEY_WL_CONFIG", config);
+        }
+    }
+    let result = if args.session {
         halley_wl::run_session()
     } else {
         halley_wl::run()
@@ -9,5 +22,89 @@ fn main() {
     if let Err(err) = result {
         eprintln!("halley-wl exited with error: {err}");
         std::process::exit(1);
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct CliArgs {
+    session: bool,
+    config: Option<OsString>,
+}
+
+impl CliArgs {
+    fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Self, String> {
+        let mut out = Self::default();
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            if arg == "--session" {
+                out.session = true;
+                continue;
+            }
+            if arg == "--config" || arg == "-c" {
+                let Some(path) = args.next() else {
+                    return Err(format!("{} requires a path", arg.to_string_lossy()));
+                };
+                if path.to_string_lossy().trim().is_empty() {
+                    return Err(format!(
+                        "{} requires a non-empty path",
+                        arg.to_string_lossy()
+                    ));
+                }
+                out.config = Some(path);
+                continue;
+            }
+            if let Some(path) = arg.to_string_lossy().strip_prefix("--config=") {
+                if path.trim().is_empty() {
+                    return Err("--config requires a non-empty path".to_string());
+                }
+                out.config = Some(OsString::from(path));
+                continue;
+            }
+
+            return Err(format!("unknown argument {}", arg.to_string_lossy()));
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn parses_long_config_with_space() {
+        assert_eq!(
+            CliArgs::parse(os(&["--config", "/tmp/halley.rune"])).unwrap(),
+            CliArgs {
+                session: false,
+                config: Some(OsString::from("/tmp/halley.rune")),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_long_config_with_equals() {
+        assert_eq!(
+            CliArgs::parse(os(&["--config=/tmp/halley.rune"]))
+                .unwrap()
+                .config,
+            Some(OsString::from("/tmp/halley.rune"))
+        );
+    }
+
+    #[test]
+    fn parses_short_config_and_session() {
+        assert_eq!(
+            CliArgs::parse(os(&["--session", "-c", "/tmp/halley.rune"])).unwrap(),
+            CliArgs {
+                session: true,
+                config: Some(OsString::from("/tmp/halley.rune")),
+            }
+        );
     }
 }


### PR DESCRIPTION
Add real config path selection for Halley startup.

This supports:\n- halley --config /path/to/halley.rune\n- halley --config=/path/to/halley.rune\n- halley -c /path/to/halley.rune\n- halley --session --config /path/to/halley.rune

Make explicit CLI config win over HALLEY_WL_CONFIG by setting HALLEY_WL_CONFIG before compositor startup. Treat empty or whitespace-only HALLEY_WL_CONFIG as unset.

Fix default config discovery so the effective startup precedence is:\n1. --config / -c\n2. HALLEY_WL_CONFIG\n3. ~/.config/halley/halley.rune\n4. /etc/halley/halley.rune\n5. generated user config / internal defaults

Avoid auto-creating ~/.config/halley/halley.rune when /etc/halley/halley.rune already exists, so a system config is not shadowed on first startup.

Resolve the effective config path once at startup and reuse that path for watch/reload behavior. This prevents switching from /etc to ~/.config mid-session if a user config appears later.

Add startup logs for the resolved config source/path and effective keyboard config to make layout/config reports easier to diagnose.

Also snap halley-aperture transitions into Minimal mode immediately to keep Aperture's layer size in sync with maximize work-area reservation.