### PR TITLE
chore(release): polish CLI help, changelog, and pre-v0.4 UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - TBD
 
 ### Added
+- Add `halley -h` / `halley --help` output documenting config selection and session startup options.
+- Add `halley -c` / `halley --config` support for selecting an explicit config file, with CLI config taking precedence over `HALLEY_WL_CONFIG`.
 - Add numeric `opacity` window-rule support using a `0.0` through `1.0` scale, applying matched opacity to window content, borders, shadows, popups, badges, close snapshots, and captures while blocking direct scanout for translucent windows.
 - Add optional `width` and `height` window-rule keys for fixed initial sizes on matched windows.
 - Add configurable fullscreen entry animation via `animations.fullscreen`, including bootstrap migration and example config coverage, so browser videos such as YouTube tween into fullscreen instead of snapping.
@@ -13,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - Add a `debug:` config section with `overlay-fps` and `show-ring-when-resizing` toggles, including a legible top-left FPS HUD and control over focus-ring config-change previews.
 
 ### Changed
+- Keep `halley-session` as the recommended public full-session launcher while documenting `halley --session` as a session-wrapper, packager, and service-file flag.
+- Resolve the effective Halley config path once at startup and reuse it for reload/watch behavior, with precedence of explicit config, `HALLEY_WL_CONFIG`, user config, system config, then generated user config/internal defaults.
 - Freeze Aperture work-area updates for the whole field maximize session — through both the enter and restore animations — after applying the initial reservation baseline, matching cluster workspace behavior and avoiding mid-animation `usable_viewport` re-basing (and the un-maximize top-strip pop) on lower-refresh displays. The deferred-flush maintenance pass now only runs when a pending monitor is actually unlocked, so a locked session no longer re-runs the work-area refresh or invalidates the Aperture mode cache every frame.
 - Resolve active-window render routing in `window::layout` with a `WindowRenderRoute` so surface collection appends shadows, borders, badges, surfaces, textures, and popups through a layout-provided route instead of repeating stack/top/fullscreen routing checks.
 - Add focused `RenderState` accessors for tile animation state, overlay toast lookup, view-state retention, and render tick telemetry to reduce direct bucket access from frame, layout, cluster, overlay, and camera code.
@@ -31,6 +35,9 @@ All notable changes to this project will be documented in this file.
 - Soften window shadows with a Gaussian/error-function falloff for a more natural shadow tail.
 
 ### Fixed
+- Avoid auto-creating `~/.config/halley/halley.rune` when `/etc/halley/halley.rune` exists, preventing system configs from being shadowed on first startup.
+- Treat empty or whitespace-only `HALLEY_WL_CONFIG` as unset.
+- Snap `halley-aperture` transitions into Minimal mode immediately so maximize work-area reservation and Aperture layer size stay in sync.
 - Recompute live window-rule opacity for already-open windows on config reload and title/app-id refreshes, without reapplying placement or cluster behavior.
 - Keep maximized windows visually maximized while closing by preserving the maximize session through `xdg_toplevel.close`, capturing close animations from maximized geometry, and cleaning up maximize state after the surface is dropped.
 - Skip close-restore panning while a maximize session is present on the monitor, avoiding unnecessary viewport movement when focus is restored during maximized flows.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ Install them to the standard system locations alongside the compositor binary:
     sudo install -Dm644 packaging/systemd-user/halley.service /usr/lib/systemd/user/halley.service
     sudo install -Dm644 packaging/systemd-user/halley-shutdown.target /usr/lib/systemd/user/halley-shutdown.target
 
-`halley-session` will start `halley.service` when a user systemd instance is available, which makes `graphical-session.target`, `xdg-desktop-autostart.target`, and related user-session units behave correctly under display managers like SDDM. If those units are not installed, the launcher falls back to executing `halley` directly.
+`halley-session` is the recommended public launcher for a full Halley desktop session. It will start `halley.service` when a user systemd instance is available, which makes `graphical-session.target`, `xdg-desktop-autostart.target`, and related user-session units behave correctly under display managers like SDDM. If those units are not installed, the launcher falls back to executing `halley` directly.
+
+The compositor also accepts `halley --session` for session wrappers, packagers, and service files. Normal users should prefer `halley-session`.
 
 After that, `Halley` should appear in Wayland-capable display managers.
 

--- a/crates/halley-wl/src/aperture/mod.rs
+++ b/crates/halley-wl/src/aperture/mod.rs
@@ -189,17 +189,6 @@ fn derive_aperture_mode(
         return ApertureMode::Hidden;
     }
 
-    if crate::compositor::workspace::state::maximize_session_active_on_monitor(st, monitor)
-        || (crate::compositor::clusters::system::active_cluster_workspace_for_monitor(st, monitor)
-            .is_some()
-            && matches!(
-                st.runtime.tuning.cluster_layout_kind(),
-                halley_core::cluster_layout::ClusterWorkspaceLayoutKind::Tiling
-            ))
-    {
-        return ApertureMode::Minimal;
-    }
-
     let render_state = &st.ui.render_state;
     let family = st.aperture_config().peek.clock.font_family.clone();
     let mut measure = |font_px: u32, text: &str| {
@@ -213,37 +202,95 @@ fn derive_aperture_mode(
     // for the candidate mode actually exists. Compute them at most once, lazily.
     let mut windows: Option<Vec<Rect>> = None;
 
-    let normal = st.aperture_snapshot_for_mode(
+    let minimal_intended =
+        crate::compositor::workspace::state::maximize_session_active_on_monitor(st, monitor)
+            || (crate::compositor::clusters::system::active_cluster_workspace_for_monitor(
+                st, monitor,
+            )
+            .is_some()
+                && matches!(
+                    st.runtime.tuning.cluster_layout_kind(),
+                    halley_core::cluster_layout::ClusterWorkspaceLayoutKind::Tiling
+                ));
+    if minimal_intended {
+        return unobstructed_aperture_mode(
+            st,
+            monitor,
+            ApertureMode::Minimal,
+            output_rect,
+            work_area_rect,
+            scale,
+            &mut measure,
+            &mut windows,
+        )
+        .unwrap_or(ApertureMode::Hidden);
+    }
+
+    if let Some(mode) = unobstructed_aperture_mode(
+        st,
+        monitor,
         ApertureMode::Normal,
         output_rect,
         work_area_rect,
         scale,
         &mut measure,
-    );
-    if let Some(snapshot) = &normal {
-        let windows = windows
-            .get_or_insert_with(|| active_window_rects_for_monitor(st, monitor, Instant::now()));
-        if !clock_obstructed(snapshot.bounds, windows) {
-            return ApertureMode::Normal;
-        }
+        &mut windows,
+    ) {
+        return mode;
     }
 
-    let collapsed = st.aperture_snapshot_for_mode(
+    if let Some(mode) = unobstructed_aperture_mode(
+        st,
+        monitor,
         ApertureMode::Collapsed,
         output_rect,
         work_area_rect,
         scale,
         &mut measure,
-    );
-    if let Some(snapshot) = &collapsed {
-        let windows = windows
-            .get_or_insert_with(|| active_window_rects_for_monitor(st, monitor, Instant::now()));
-        if !clock_obstructed(snapshot.bounds, windows) {
-            return ApertureMode::Collapsed;
-        }
+        &mut windows,
+    ) {
+        return mode;
     }
 
-    ApertureMode::Minimal
+    unobstructed_aperture_mode(
+        st,
+        monitor,
+        ApertureMode::Minimal,
+        output_rect,
+        work_area_rect,
+        scale,
+        &mut measure,
+        &mut windows,
+    )
+    .unwrap_or(ApertureMode::Hidden)
+}
+
+fn unobstructed_aperture_mode<F>(
+    st: &Halley,
+    monitor: &str,
+    mode: ApertureMode,
+    output_rect: Rect,
+    work_area_rect: Rect,
+    scale: f64,
+    measure: &mut F,
+    windows: &mut Option<Vec<Rect>>,
+) -> Option<ApertureMode>
+where
+    F: FnMut(u32, &str) -> Size,
+{
+    let snapshot =
+        st.aperture_snapshot_for_mode(mode, output_rect, work_area_rect, scale, measure)?;
+    let windows =
+        windows.get_or_insert_with(|| active_window_rects_for_monitor(st, monitor, Instant::now()));
+    unobstructed_aperture_mode_for_bounds(mode, snapshot.bounds, windows)
+}
+
+fn unobstructed_aperture_mode_for_bounds(
+    mode: ApertureMode,
+    bounds: Rect,
+    windows: &[Rect],
+) -> Option<ApertureMode> {
+    (!clock_obstructed(bounds, windows)).then_some(mode)
 }
 
 pub(crate) fn small_reservation_px_for_monitor(st: &Halley, monitor: &str) -> i32 {
@@ -349,6 +396,34 @@ mod tests {
             focus_ring: None,
         }];
         tuning
+    }
+
+    fn two_monitor_tuning() -> halley_config::RuntimeTuning {
+        let mut tuning = single_monitor_tuning();
+        tuning
+            .tty_viewports
+            .push(halley_config::ViewportOutputConfig {
+                connector: "monitor_b".to_string(),
+                enabled: true,
+                offset_x: 800,
+                offset_y: 0,
+                width: 800,
+                height: 600,
+                refresh_rate: None,
+                transform_degrees: 0,
+                vrr: halley_config::ViewportVrrMode::Off,
+                focus_ring: None,
+            });
+        tuning
+    }
+
+    fn test_output_rect() -> Rect {
+        Rect::new(0.0, 0.0, 800.0, 600.0)
+    }
+
+    fn derive_test_mode(st: &Halley, monitor: &str) -> ApertureMode {
+        let rect = test_output_rect();
+        derive_aperture_mode(st, monitor, rect, rect, 1.0)
     }
 
     fn usable_top_px(st: &Halley) -> i32 {
@@ -702,6 +777,98 @@ mod tests {
 
         assert_eq!(small_reservation_px_for_monitor(&st, MONITOR), 0);
         assert_eq!(usable_top_px(&st), 0);
+    }
+
+    #[test]
+    fn minimal_mode_hides_when_even_small_tab_is_obstructed() {
+        let clock = Rect::new(760.0, 0.0, 30.0, 16.0);
+        let blocker = Rect::new(0.0, 0.0, 800.0, 600.0);
+
+        assert_eq!(
+            unobstructed_aperture_mode_for_bounds(ApertureMode::Minimal, clock, &[blocker]),
+            None
+        );
+    }
+
+    #[test]
+    fn minimal_mode_survives_when_small_tab_is_unobstructed() {
+        let clock = Rect::new(760.0, 0.0, 30.0, 16.0);
+        let blocker = Rect::new(0.0, 64.0, 800.0, 536.0);
+
+        assert_eq!(
+            unobstructed_aperture_mode_for_bounds(ApertureMode::Minimal, clock, &[blocker]),
+            Some(ApertureMode::Minimal)
+        );
+    }
+
+    #[test]
+    fn aperture_hides_only_on_obstructed_monitor() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, two_monitor_tuning());
+
+        let blocker = st.model.field.spawn_surface(
+            "blocker",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 {
+                x: 2000.0,
+                y: 2000.0,
+            },
+        );
+        st.assign_node_to_monitor(blocker, MONITOR);
+
+        assert_eq!(derive_test_mode(&st, MONITOR), ApertureMode::Hidden);
+        assert_ne!(derive_test_mode(&st, "monitor_b"), ApertureMode::Hidden);
+    }
+
+    #[test]
+    fn maximized_mode_keeps_minimal_when_small_tab_is_unobstructed() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        set_aperture_tab_height(&mut st, 22);
+
+        let id = st.model.field.spawn_surface(
+            "maximized",
+            Vec2 { x: 100.0, y: 100.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        st.assign_node_to_monitor(id, MONITOR);
+        assert!(
+            crate::compositor::actions::window::toggle_node_maximize_state(
+                &mut st,
+                id,
+                Instant::now(),
+                MONITOR,
+            )
+        );
+
+        assert_eq!(derive_test_mode(&st, MONITOR), ApertureMode::Minimal);
+    }
+
+    #[test]
+    fn tiled_cluster_mode_keeps_minimal_when_small_tab_is_unobstructed() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+        set_aperture_tab_height(&mut st, 22);
+        let now = Instant::now();
+
+        let master = st.model.field.spawn_surface(
+            "master",
+            Vec2 { x: 100.0, y: 100.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let stack = st.model.field.spawn_surface(
+            "stack",
+            Vec2 { x: 500.0, y: 100.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        st.assign_node_to_monitor(master, MONITOR);
+        st.assign_node_to_monitor(stack, MONITOR);
+        let cid = st.create_cluster(vec![master, stack]).expect("cluster");
+        let core = st.collapse_cluster(cid).expect("core");
+        st.assign_node_to_monitor(core, MONITOR);
+        assert!(st.enter_cluster_workspace_by_core(core, MONITOR, now));
+
+        assert_eq!(derive_test_mode(&st, MONITOR), ApertureMode::Minimal);
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/focus/cycle.rs
+++ b/crates/halley-wl/src/compositor/focus/cycle.rs
@@ -312,9 +312,48 @@ impl<T: DerefMut<Target = Halley>> FocusCycleController<T> {
             let _ = self.raise_overlap_policy_node(target);
             changed
         } else {
-            crate::compositor::actions::window::focus_from_presentation_navigation(
-                self, target, now,
-            ) || crate::compositor::actions::window::focus_or_reveal_surface_node(self, target, now)
+            let target_monitor = self.monitor_for_node_or_current(target);
+            if crate::compositor::workspace::state::maximize_session_target_for_monitor(
+                self,
+                target_monitor.as_str(),
+            ) == Some(target)
+            {
+                let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
+                    self, target, now,
+                );
+                let _ = self.raise_overlap_policy_node(target);
+                changed
+            } else if self
+                .model
+                .fullscreen_state
+                .fullscreen_active_node
+                .get(target_monitor.as_str())
+                .copied()
+                .filter(|&fullscreen_id| fullscreen_id != target)
+                .is_some_and(|fullscreen_id| {
+                    !self
+                        .model
+                        .fullscreen_state
+                        .fullscreen_restore
+                        .contains_key(&fullscreen_id)
+                })
+                && self.model.field.node(target).is_some_and(|node| {
+                    node.state == halley_core::field::NodeState::Active
+                        && self.surface_is_fully_visible_on_monitor(target_monitor.as_str(), target)
+                })
+            {
+                let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
+                    self, target, now,
+                );
+                let _ = self.raise_overlap_policy_node(target);
+                changed
+            } else {
+                crate::compositor::actions::window::focus_from_presentation_navigation(
+                    self, target, now,
+                ) || crate::compositor::actions::window::focus_or_reveal_surface_node(
+                    self, target, now,
+                )
+            }
         };
         if changed {
             crate::compositor::interaction::pointer::center_pointer_on_node(self, target, now);
@@ -731,6 +770,58 @@ mod tests {
         );
         assert!(
             state.overlap_policy_stack_rank(visible) > state.overlap_policy_stack_rank(maximized)
+        );
+        assert!(state.input.interaction_state.viewport_pan_anim.is_none());
+    }
+
+    #[test]
+    fn commit_to_maximized_target_focuses_without_panning() {
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut tuning = halley_config::RuntimeTuning::default();
+        tuning.animations.maximize.enabled = false;
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let now = Instant::now();
+
+        let maximized = state.model.field.spawn_surface(
+            "maximized",
+            Vec2 { x: 0.0, y: 0.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let other = state.model.field.spawn_surface(
+            "other",
+            Vec2 { x: 2_400.0, y: 0.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        state.assign_node_to_current_monitor(maximized);
+        state.assign_node_to_current_monitor(other);
+        assert!(
+            crate::compositor::actions::window::toggle_node_maximize_state(
+                &mut state, maximized, now, "default",
+            )
+        );
+        state.set_interaction_focus(Some(other), 30_000, now);
+        state.input.interaction_state.viewport_pan_anim = None;
+        state.input.interaction_state.focus_cycle_session = Some(FocusCycleSession {
+            candidates: vec![other, maximized],
+            preview_index: 1,
+            origin_focus: Some(other),
+            immersive_origin: None,
+            immersive_lock_released: false,
+        });
+
+        assert!(state.commit_focus_cycle(now));
+        assert_eq!(
+            state.model.focus_state.primary_interaction_focus,
+            Some(maximized)
+        );
+        assert!(
+            state
+                .model
+                .workspace_state
+                .maximize_sessions
+                .contains_key("default")
         );
         assert!(state.input.interaction_state.viewport_pan_anim.is_none());
     }

--- a/crates/halley-wl/src/compositor/focus/trail.rs
+++ b/crates/halley-wl/src/compositor/focus/trail.rs
@@ -691,10 +691,7 @@ mod tests {
 
         // Trail back to `far` — starts a camera pan toward far.pos.
         assert!(state.navigate_window_trail(TrailDirection::Prev, now));
-        assert_eq!(
-            state.model.focus_state.primary_interaction_focus,
-            Some(far)
-        );
+        assert_eq!(state.model.focus_state.primary_interaction_focus, Some(far));
         assert!(state.input.interaction_state.viewport_pan_anim.is_some());
 
         // Maximize mid-pan: it must be deferred, not applied, so the pan can play out first.

--- a/crates/halley/src/main.rs
+++ b/crates/halley/src/main.rs
@@ -2,9 +2,14 @@ use std::ffi::OsString;
 
 fn main() {
     let args = match CliArgs::parse(std::env::args_os().skip(1)) {
-        Ok(args) => args,
+        Ok(ParseResult::Run(args)) => args,
+        Ok(ParseResult::Help) => {
+            print_help();
+            return;
+        }
         Err(err) => {
             eprintln!("halley: {err}");
+            eprintln!("Try 'halley --help' for usage.");
             std::process::exit(2);
         }
     };
@@ -31,11 +36,20 @@ struct CliArgs {
     config: Option<OsString>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum ParseResult {
+    Run(CliArgs),
+    Help,
+}
+
 impl CliArgs {
-    fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Self, String> {
+    fn parse(args: impl IntoIterator<Item = OsString>) -> Result<ParseResult, String> {
         let mut out = Self::default();
         let mut args = args.into_iter();
         while let Some(arg) = args.next() {
+            if arg == "--help" || arg == "-h" {
+                return Ok(ParseResult::Help);
+            }
             if arg == "--session" {
                 out.session = true;
                 continue;
@@ -64,8 +78,22 @@ impl CliArgs {
             return Err(format!("unknown argument {}", arg.to_string_lossy()));
         }
 
-        Ok(out)
+        Ok(ParseResult::Run(out))
     }
+}
+
+fn print_help() {
+    println!(
+        "Halley spatial Wayland compositor\n\
+\n\
+Usage: halley [OPTIONS]\n\
+\n\
+Options:\n\
+  -c, --config <PATH>  Use a specific config file\n\
+  -h, --help           Show this help\n\
+      --session        Run as a full desktop session; kept for session wrappers\n\
+                       and services. Normal users should launch halley-session."
+    );
 }
 
 #[cfg(test)]
@@ -80,20 +108,21 @@ mod tests {
     fn parses_long_config_with_space() {
         assert_eq!(
             CliArgs::parse(os(&["--config", "/tmp/halley.rune"])).unwrap(),
-            CliArgs {
+            ParseResult::Run(CliArgs {
                 session: false,
                 config: Some(OsString::from("/tmp/halley.rune")),
-            }
+            })
         );
     }
 
     #[test]
     fn parses_long_config_with_equals() {
         assert_eq!(
-            CliArgs::parse(os(&["--config=/tmp/halley.rune"]))
-                .unwrap()
-                .config,
-            Some(OsString::from("/tmp/halley.rune"))
+            CliArgs::parse(os(&["--config=/tmp/halley.rune"])).unwrap(),
+            ParseResult::Run(CliArgs {
+                session: false,
+                config: Some(OsString::from("/tmp/halley.rune")),
+            })
         );
     }
 
@@ -101,10 +130,21 @@ mod tests {
     fn parses_short_config_and_session() {
         assert_eq!(
             CliArgs::parse(os(&["--session", "-c", "/tmp/halley.rune"])).unwrap(),
-            CliArgs {
+            ParseResult::Run(CliArgs {
                 session: true,
                 config: Some(OsString::from("/tmp/halley.rune")),
-            }
+            })
         );
+    }
+
+    #[test]
+    fn parses_help_flags() {
+        assert_eq!(CliArgs::parse(os(&["--help"])).unwrap(), ParseResult::Help);
+        assert_eq!(CliArgs::parse(os(&["-h"])).unwrap(), ParseResult::Help);
+    }
+
+    #[test]
+    fn unknown_arg_errors() {
+        assert!(CliArgs::parse(os(&["session"])).is_err());
     }
 }


### PR DESCRIPTION
### Summary

This PR adds lightweight help output for the `halley` CLI, updates the unreleased changelog, and fixes two pre-v0.4 UX regressions around Aperture obstruction handling and focus-cycle behavior.

### Changes

#### CLI / session startup

* Add `-h` / `--help` handling to the lightweight `halley` CLI parser.
* Print usage covering config path selection and session startup.
* Keep `--session` accepted and visible, but describe it as a session-wrapper/service flag.
* Document `halley-session` as the recommended public launcher for full desktop sessions.
* Keep `halley --session` available for packagers and service files.

#### Docs

* Update the unreleased changelog with:

  * New `halley` help output.
  * Explicit config path support.
  * Stable config path precedence.
  * `halley-session` guidance.
  * Aperture Minimal obstruction fix.

#### Aperture

* Fix Minimal mode obstruction handling.
* Treat Minimal as the final obstruction-checked candidate instead of always returning it after Normal and Collapsed are blocked.
* Preserve explicitly intended Minimal mode for maximize and tiled cluster workspaces when unobstructed.
* Fall back to Hidden if the Minimal snapshot intersects an active obstruction on the same monitor.
* Keep obstruction handling per-monitor so one blocked output can hide Aperture without affecting unobstructed outputs.
* Add regression coverage for:

  * Minimal hiding when obstructed.
  * Minimal remaining visible when unobstructed.
  * Hiding only on the obstructed monitor.
  * Preserving Minimal for unobstructed maximize and tiled cluster modes.

#### Focus cycle / maximize

* Avoid starting viewport reveal/pan logic when focus-cycle commits back to the current maximize-session target.
* Focus and raise the maximized window directly because it is already presented on the monitor.
* Preserve existing presentation navigation behavior for offscreen/collapsed targets and XDG fullscreen sessions.
* Keep manually tracked same-monitor fullscreen behind a raised visible target.
* Add regression coverage for Alt-Tab/focus-cycle commit back to a maximized window without starting a viewport pan.

#### Cleanup

* Includes a rustfmt-only cleanup in a trail focus test assertion.

### Testing

* Added regression tests for Aperture Minimal obstruction behavior.
* Added regression test for focus-cycle commit back to a maximized window without triggering viewport pan.
* Existing tests continue to cover presentation navigation and fullscreen behavior.
