### PR TITLE
Title: Make Lens search responsive, explicit, and cluster-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add `HALLEY_WL_PERF`-gated slow-frame and cluster-workspace entry timing logs for diagnosing render hitches without hot-path timestamp overhead when disabled.
 - Add a `debug:` config section with `overlay-fps` and `show-ring-when-resizing` toggles, including a legible top-left FPS HUD and control over focus-ring config-change previews.
 - Add Halley Lens, a standalone command palette for apps, nodes, clusters, actions, and config search, with slash modes, configurable UI, and cluster draft handoff support.
+- Add a Halley Lens `terminal` config key for launching `.desktop` apps that require a terminal.
 - Add first-class Gamescope integration through a top-level `gamescope:` config section, including global defaults, repeated per-game profiles, and per-game opt-outs, wired through `halleyctl gamescope run -- <command>` for use in Steam launch options.
 - Add automatic Gamescope resolution selection from the selected Halley viewport (`monitor` selector `focused`/`cursor`/`primary`/connector), so matching games launch with monitor-sized output and game dimensions by default.
 - Add clear diagnostics when Gamescope is enabled but the `gamescope` binary is unavailable, falling back to launching the game unwrapped instead of blocking it.
@@ -42,6 +43,8 @@ All notable changes to this project will be documented in this file.
 - Archive the experimental rail app and remove its public IPC surface ahead of Lens work.
 
 ### Fixed
+- Make Halley Lens startup and general search responsive by removing synchronous icon indexing, caching live IPC snapshots outside keystroke search, and precomputing app search text.
+- Restore broader Halley Lens icon coverage with background indexing, support live provider prefixes such as `action open` without badges, show all apps for an empty Apps search, keep cluster draft staging explicit to `cluster`/`/cluster` searches, and ellipsize overlong search text from the left so the latest input remains visible.
 - Avoid spatial-camera input remapping for Gamescope-managed pointer surfaces (config-gated via `gamescope.bypass-spatial-camera`) so the nested game receives a 1:1 pointer mapping while normal output and buffer scale handling are preserved.
 - Avoid auto-creating `~/.config/halley/halley.rune` when `/etc/halley/halley.rune` exists, preventing system configs from being shadowed on first startup.
 - Treat empty or whitespace-only `HALLEY_WL_CONFIG` as unset.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "halley"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "halley-wl",
 ]
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "halley-capit"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "image",
  "memmap2",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "halley-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "halley-api",
  "halley-config",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "halley-config"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "halley-core",
  "regex",
@@ -1167,11 +1167,11 @@ dependencies = [
 
 [[package]]
 name = "halley-core"
-version = "0.3.2"
+version = "0.4.0"
 
 [[package]]
 name = "halley-ipc"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "halley-api",
  "postcard",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "halley-wl"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "calloop 0.14.4",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 authors = ["Dustin Pilgrim <dustin.pilgrim1997@gmail.com>"]
 license = "GPL-3.0-only"
@@ -29,12 +29,12 @@ exclude = ["/.github", "/target", "/.idea", "/.vscode", "Cargo.lock"]
 chrono = { version = "0.4.44", default-features = false, features = ["clock", "std"] }
 halley-api = { path = "crates/halley-api", version = "0.1.0" }
 halley-aperture = { path = "crates/halley-aperture", version = "0.1.0" }
-halley-capit = { path = "crates/halley-capit", version = "0.3.2" }
-halley-config = { path = "crates/halley-config", version = "0.3.2" }
-halley-core = { path = "crates/halley-core", version = "0.3.2" }
-halley-ipc = { path = "crates/halley-ipc", version = "0.3.2" }
+halley-capit = { path = "crates/halley-capit", version = "0.4.0" }
+halley-config = { path = "crates/halley-config", version = "0.4.0" }
+halley-core = { path = "crates/halley-core", version = "0.4.0" }
+halley-ipc = { path = "crates/halley-ipc", version = "0.4.0" }
 halley-lens = { path = "crates/halley-lens", version = "0.1.0" }
-halley-wl = { path = "crates/halley-wl", version = "0.3.2", default-features = false }
+halley-wl = { path = "crates/halley-wl", version = "0.4.0", default-features = false }
 
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
 postcard = { version = "1.1.3", features = ["use-std"] }

--- a/crates/halley-api/src/lib.rs
+++ b/crates/halley-api/src/lib.rs
@@ -11,12 +11,12 @@ pub use protocol::{
 };
 pub use types::{
     ApertureMode, ApertureOutputStatus, ApertureStatusResponse, BearingsStatusResponse,
-    CaptureStatusResponse, ClusterDraftRequest, ClusterDraftSource, ClusterInfo, ClusterLayoutKind,
-    ClusterListResponse, ClusterOutputGroup, ClusterSummary, GamescopeTargetResponse,
-    LensResultKind, LensSearchResponse, LensSearchResult, LogicalOutputInfo, ModeInfo, NodeInfo,
-    NodeKind, NodeListResponse, NodeOutputGroup, NodeProtocolFamily, NodeRelationInfo, NodeRole,
-    NodeState, OutputInfo, OutputStatus, OutputsResponse, TrailEntryInfo, TrailListResponse,
-    VersionInfo,
+    CaptureStatusResponse, ClusterDraftAppLaunch, ClusterDraftRequest, ClusterDraftSource,
+    ClusterInfo, ClusterLayoutKind, ClusterListResponse, ClusterOutputGroup, ClusterSummary,
+    GamescopeTargetResponse, LensResultKind, LensSearchResponse, LensSearchResult,
+    LogicalOutputInfo, ModeInfo, NodeInfo, NodeKind, NodeListResponse, NodeOutputGroup,
+    NodeProtocolFamily, NodeRelationInfo, NodeRole, NodeState, OutputInfo, OutputStatus,
+    OutputsResponse, TrailEntryInfo, TrailListResponse, VersionInfo,
 };
 
 pub const HALLEY_API_VERSION: u32 = 1;

--- a/crates/halley-api/src/types.rs
+++ b/crates/halley-api/src/types.rs
@@ -60,9 +60,17 @@ pub enum ClusterDraftSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClusterDraftAppLaunch {
+    pub app_id: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ClusterDraftRequest {
     pub name_hint: Option<String>,
     pub app_ids: Vec<String>,
+    #[serde(default)]
+    pub app_launches: Vec<ClusterDraftAppLaunch>,
     pub running_node_ids: Vec<u64>,
     pub source: ClusterDraftSource,
 }

--- a/crates/halley-lens/README.md
+++ b/crates/halley-lens/README.md
@@ -14,39 +14,33 @@ You can also seed an initial query:
 halley-lens /cluster release
 ```
 
-## Slash Modes
+## Search Prefixes
 
-Lens searches everything by default. Slash tokens switch to a mode and become a removable badge in the search field.
+Lens searches everything by default. Prefixing the query with a provider name filters results without changing the search text into a badge.
 
 Supported modes:
 
 ```text
-/app /apps /a
-/cluster /clusters /c
-/node /nodes /n
-/action /actions
-/config
+app /app /apps /a
+cluster /cluster /clusters /c
+node /node /nodes /n
+action /actions
+config /config
 ```
 
 Example:
 
 ```text
-/cluster release
+cluster release
 ```
 
-becomes:
-
-```text
-[Clusters ×] release
-```
-
-Backspace with an empty query removes the badge and returns to general mode.
+searches clusters for `release` while leaving the full text visible in the search field.
 
 ## Cluster Drafts
 
-In cluster mode, `Space` stages or unstages apps and running nodes. This is side-effect-free.
+In `cluster`/`/cluster` searches, `Space` stages or unstages the selected app or running node. This is side-effect-free. Outside cluster searches, Space is normal search text.
 
-`Ctrl+Enter` or activating `Create cluster: <query>` materializes the draft:
+After at least one item is staged in cluster mode, `Ctrl+Enter` or activating `Create cluster: <query>` materializes the draft:
 
 ```text
 Cluster Draft: release · 3 selected
@@ -82,6 +76,7 @@ lens:
   icon-size 28
   icon-theme "auto"
   icon-search-depth 5
+  terminal "x-terminal-emulator -e"
   keyboard-interactivity "exclusive" # exclusive | on-demand
   close-on-focus-loss false
   close-on-click-away false
@@ -138,6 +133,8 @@ end
 
 `max-results` controls how many results Lens computes. `visible-results` controls how many rows are visible at once; keyboard selection scrolls through the full result set.
 
-App icons are read from `.desktop` `Icon=` entries and resolved from common XDG icon locations. Lens builds an icon index once at launch, then uses cached lookups while drawing. PNG, JPEG, and SVG icons are supported. Missing icons fall back to built-in glyphs.
+App icons are read from `.desktop` `Icon=` entries and resolved lazily from common XDG icon locations while drawing visible rows. Lens builds a broader icon index only after the first draw, then refreshes cached misses. PNG, JPEG, and SVG icons are supported. Missing icons fall back to built-in glyphs.
+
+`terminal` is prepended to `.desktop` apps with `Terminal=true`, so terminal apps such as `micro` or `nvim` open in the configured terminal.
 
 Mouse support includes hover selection, row click activation, and wheel navigation inside the Lens panel. Empty general search shows only the rounded search bar; typing or entering a slash mode expands a connected results body below it. Keyboard navigation supports held direction keys, Left/Right, PageUp/PageDown, Home/End, and Alt+1 through Alt+0 visible-row activation.

--- a/crates/halley-lens/src/config.rs
+++ b/crates/halley-lens/src/config.rs
@@ -14,6 +14,7 @@ pub struct LensConfig {
     pub icon_size: u32,
     pub icon_search_depth: usize,
     pub icon_theme: String,
+    pub terminal: String,
     pub keyboard_interactivity: String,
     pub close_on_focus_loss: bool,
     pub close_on_click_away: bool,
@@ -102,6 +103,7 @@ impl Default for LensConfig {
             icon_size: 28,
             icon_search_depth: 5,
             icon_theme: "auto".into(),
+            terminal: "x-terminal-emulator -e".into(),
             keyboard_interactivity: "exclusive".into(),
             close_on_focus_loss: false,
             close_on_click_away: false,
@@ -225,6 +227,7 @@ impl LensConfig {
             .get_or::<u32>("lens.icon-search-depth", out.icon_search_depth as u32)
             .clamp(1, 8) as usize;
         out.icon_theme = cfg.get_or("lens.icon-theme", out.icon_theme.clone());
+        out.terminal = cfg.get_or("lens.terminal", out.terminal.clone());
         out.keyboard_interactivity = cfg.get_or(
             "lens.keyboard-interactivity",
             out.keyboard_interactivity.clone(),
@@ -346,6 +349,9 @@ fn validate(config: &LensConfig) -> Result<(), String> {
     }
     if config.max_results == 0 {
         return Err("lens.max-results must be greater than zero".into());
+    }
+    if config.terminal.trim().is_empty() {
+        return Err("lens.terminal must not be empty".into());
     }
     if config.visible_results == 0 || config.visible_results > config.max_results {
         return Err("lens.visible-results must be between 1 and lens.max-results".into());

--- a/crates/halley-lens/src/main.rs
+++ b/crates/halley-lens/src/main.rs
@@ -4,10 +4,12 @@ mod model;
 mod providers;
 mod ui;
 
+use std::time::{Duration, Instant};
+
 use calloop::{EventLoop, LoopHandle};
 use calloop_wayland_source::WaylandSource;
 use config::{LensConfig, default_config_path};
-use mode::{LensMode, ModeInputState, parse_initial_mode};
+use mode::{LensMode, ModeInputState, effective_mode_query, parse_initial_mode};
 use model::{ClusterDraft, LensAction, LensResult, LensResultKind};
 use providers::{ProviderIndex, SearchContext, activate_result, materialize_cluster_draft};
 use smithay_client_toolkit::{
@@ -51,13 +53,22 @@ fn main() {
 }
 
 fn run() -> Result<(), String> {
+    let start = Instant::now();
     let config_path = default_config_path();
     let config = LensConfig::load(config_path.as_path())?;
+    perf_elapsed("config load", start);
     let initial_raw = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
     let (initial_mode, initial_query) = parse_initial_mode(initial_raw.as_str());
-    let font = FontRenderer::new(config.ui.font.as_str())?;
-    let index = ProviderIndex::load();
 
+    let start = Instant::now();
+    let font = FontRenderer::new(config.ui.font.as_str())?;
+    perf_elapsed("font load", start);
+
+    let start = Instant::now();
+    let index = ProviderIndex::load(&config);
+    perf_elapsed("desktop app index", start);
+
+    let start = Instant::now();
     let conn = Connection::connect_to_env().map_err(|err| format!("wayland connect: {err}"))?;
     let (globals, event_queue) =
         registry_queue_init(&conn).map_err(|err| format!("registry init: {err}"))?;
@@ -68,6 +79,8 @@ fn run() -> Result<(), String> {
     let layer_shell =
         LayerShell::bind(&globals, &qh).map_err(|err| format!("bind layer shell: {err}"))?;
     let shm = Shm::bind(&globals, &qh).map_err(|err| format!("bind shm: {err}"))?;
+    perf_elapsed("wayland init", start);
+
     let surface = compositor.create_surface(&qh);
     let layer =
         layer_shell.create_layer_surface(&qh, surface, Layer::Overlay, Some(NAMESPACE), None);
@@ -81,7 +94,10 @@ fn run() -> Result<(), String> {
     layer.commit();
     let pool = SlotPool::new((width * height * 4) as usize, &shm)
         .map_err(|err| format!("slot pool: {err}"))?;
+
+    let start = Instant::now();
     let icon_cache = IconCache::new(&config);
+    perf_elapsed("icon cache init", start);
 
     let mut event_loop: EventLoop<'static, LensApp> =
         EventLoop::try_new().map_err(|err| format!("event loop: {err}"))?;
@@ -105,6 +121,7 @@ fn run() -> Result<(), String> {
         keyboard_focused: false,
         had_keyboard_focus: false,
         configured: false,
+        prefetched_live: false,
         needs_redraw: false,
         width,
         height,
@@ -123,16 +140,32 @@ fn run() -> Result<(), String> {
         modifiers: Modifiers::default(),
         status: None,
     };
-    app.refresh_results();
+    if app.input.mode != LensMode::General || !app.input.query.trim().is_empty() {
+        app.refresh_results();
+    } else {
+        perf(format_args!("skip hidden empty-startup search"));
+    }
 
     while !app.exit {
-        if let Err(err) = event_loop.dispatch(None, &mut app) {
+        let timeout = app.background_poll_interval();
+        if let Err(err) = event_loop.dispatch(timeout, &mut app) {
             app.debug(format_args!("event dispatch error: {err}"));
             return Err(format!("event dispatch: {err}"));
         }
+        app.poll_background_jobs();
         app.flush_redraw();
     }
     Ok(())
+}
+
+fn perf(args: std::fmt::Arguments<'_>) {
+    if std::env::var_os("HALLEY_LENS_PERF").is_some() {
+        eprintln!("halley-lens perf: {args}");
+    }
+}
+
+fn perf_elapsed(label: &str, start: Instant) {
+    perf(format_args!("{label}: {:.2?}", start.elapsed()));
 }
 
 fn keyboard_interactivity(config: &LensConfig) -> KeyboardInteractivity {
@@ -199,6 +232,7 @@ struct LensApp {
     keyboard_focused: bool,
     had_keyboard_focus: bool,
     configured: bool,
+    prefetched_live: bool,
     needs_redraw: bool,
     width: u32,
     height: u32,
@@ -217,31 +251,66 @@ struct LensApp {
 
 impl LensApp {
     fn refresh_results(&mut self) {
-        if self.input.mode == LensMode::Clusters {
-            let hint = self.input.query.trim();
+        let start = Instant::now();
+        let (mode, query) = self.effective_search();
+        if mode == LensMode::Clusters {
+            let hint = query.trim();
             self.draft.name_hint = (!hint.is_empty()).then(|| hint.to_string());
         }
+        self.ensure_live_snapshot();
         let ctx = SearchContext {
-            mode: self.input.mode,
-            query: self.input.query.clone(),
+            mode,
+            query: query.clone(),
+            query_lower: query.trim().to_ascii_lowercase(),
             max_results: self.config.max_results,
+            draft_count: self.draft.count(),
         };
         self.results = self.index.search(&ctx);
         if self.selected >= self.results.len() {
             self.selected = self.results.len().saturating_sub(1);
         }
+        perf(format_args!(
+            "search mode={:?} query_len={} results={} elapsed={:.2?}",
+            mode,
+            query.len(),
+            self.results.len(),
+            start.elapsed()
+        ));
+    }
+
+    fn effective_search(&self) -> (LensMode, String) {
+        effective_mode_query(self.input.mode, self.input.query.as_str())
+    }
+
+    fn ensure_live_snapshot(&mut self) {
+        if !self.live_results_needed() || !self.index.needs_live_refresh() {
+            return;
+        }
+        let start = Instant::now();
+        self.index.start_live_refresh();
+        perf(format_args!(
+            "live ipc refresh started elapsed={:.2?}",
+            start.elapsed()
+        ));
+    }
+
+    fn live_results_needed(&self) -> bool {
+        let (mode, _) = self.effective_search();
+        matches!(mode, LensMode::Nodes | LensMode::Clusters)
     }
 
     fn draw(&mut self) -> Result<(), String> {
         if !self.configured {
             return Ok(());
         }
+        let start = Instant::now();
         let stride = self.width as i32 * 4;
         self.debug(format_args!(
             "draw size={}x{} stride={}",
             self.width, self.height, stride
         ));
         let scroll_offset = self.scroll_offset();
+        let (mode, _) = self.effective_search();
         let (buffer, canvas) = self
             .pool
             .create_buffer(
@@ -260,6 +329,7 @@ impl LensApp {
             View {
                 config: &self.config,
                 input: &self.input,
+                mode,
                 results: &self.results,
                 selected: self.selected,
                 scroll_offset,
@@ -274,6 +344,7 @@ impl LensApp {
             .attach_to(self.layer.wl_surface())
             .map_err(|err| format!("attach buffer: {err}"))?;
         self.layer.commit();
+        perf_elapsed("draw", start);
         Ok(())
     }
 
@@ -304,6 +375,59 @@ impl LensApp {
         }
         self.needs_redraw = false;
         self.redraw();
+        self.prefetch_live_after_first_draw();
+        self.index_icons_after_first_draw();
+    }
+
+    fn prefetch_live_after_first_draw(&mut self) {
+        if self.prefetched_live || !self.index.needs_live_refresh() {
+            return;
+        }
+        self.prefetched_live = true;
+        let start = Instant::now();
+        self.index.start_live_refresh();
+        perf(format_args!(
+            "live ipc prefetch started elapsed={:.2?}",
+            start.elapsed()
+        ));
+    }
+
+    fn index_icons_after_first_draw(&mut self) {
+        if self.icon_cache.needs_index() {
+            self.icon_cache.start_index();
+            perf(format_args!("icon index started"));
+        }
+        self.poll_icon_index();
+    }
+
+    fn poll_background_jobs(&mut self) {
+        self.poll_live_refresh();
+        self.poll_icon_index();
+    }
+
+    fn poll_live_refresh(&mut self) {
+        if let Some((nodes, clusters)) = self.index.finish_live_refresh_if_ready() {
+            perf(format_args!(
+                "live ipc prefetch ready nodes={} clusters={}",
+                nodes, clusters
+            ));
+            let (mode, query) = self.effective_search();
+            if matches!(
+                mode,
+                LensMode::General | LensMode::Nodes | LensMode::Clusters
+            ) && !query.trim().is_empty()
+            {
+                self.refresh_results();
+                self.mark_redraw();
+            }
+        }
+    }
+
+    fn poll_icon_index(&mut self) {
+        if let Some(count) = self.icon_cache.finish_index_if_ready() {
+            perf(format_args!("icon index entries={count} ready"));
+            self.mark_redraw();
+        }
     }
 
     fn desired_surface_height(&self) -> u32 {
@@ -352,6 +476,7 @@ impl LensApp {
         View {
             config: &self.config,
             input: &self.input,
+            mode: self.effective_search().0,
             results: &self.results,
             selected: self.selected,
             scroll_offset: self.scroll_offset(),
@@ -361,15 +486,13 @@ impl LensApp {
     }
 
     fn toggle_selected(&mut self) {
-        if self.input.mode != LensMode::Clusters {
-            return;
-        }
         let Some(result) = self.selected_result().cloned() else {
             return;
         };
         if matches!(result.kind, LensResultKind::App | LensResultKind::Node) {
             self.draft.toggle_result(&result);
             self.status = None;
+            self.refresh_results();
         }
     }
 
@@ -377,14 +500,14 @@ impl LensApp {
         let Some(result) = self.selected_result().cloned() else {
             return;
         };
-        if self.input.mode == LensMode::Clusters {
-            if matches!(result.action, LensAction::CreateCluster) {
-                self.materialize_draft();
-                return;
-            }
+        if matches!(result.action, LensAction::CreateCluster) {
+            self.materialize_draft();
+            return;
+        }
+        let (mode, _) = self.effective_search();
+        if mode == LensMode::Clusters {
             if matches!(result.kind, LensResultKind::App | LensResultKind::Node) {
-                self.draft.toggle_result(&result);
-                self.status = None;
+                self.toggle_selected();
                 return;
             }
         }
@@ -395,7 +518,16 @@ impl LensApp {
     }
 
     fn materialize_draft(&mut self) {
-        match materialize_cluster_draft(&self.index, &self.draft, self.input.query.as_str()) {
+        let (mode, query) = self.effective_search();
+        if mode != LensMode::Clusters {
+            self.status = Some("Use cluster search before finalizing a draft".into());
+            return;
+        }
+        if self.draft.count() == 0 {
+            self.status = Some("Select apps or nodes with Space before finalizing".into());
+            return;
+        }
+        match materialize_cluster_draft(&self.index, &self.draft, query.as_str()) {
             Ok(()) => self.exit("cluster-draft"),
             Err(err) => self.status = Some(err),
         }
@@ -412,13 +544,32 @@ impl LensApp {
         }
     }
 
+    fn background_poll_interval(&self) -> Option<Duration> {
+        self.has_background_jobs()
+            .then_some(Duration::from_millis(16))
+    }
+
+    fn has_background_jobs(&self) -> bool {
+        self.index.has_pending_live_refresh() || self.icon_cache.has_pending_index()
+    }
+
     fn handle_text(&mut self, text: &str) {
-        if text == " " && self.input.mode == LensMode::Clusters {
+        let (mode, query) = self.effective_search();
+        if text == " "
+            && mode == LensMode::Clusters
+            && !query.trim().is_empty()
+            && self.selected_is_stageable()
+        {
             self.toggle_selected();
             return;
         }
         self.input.insert_text(text);
         self.refresh_results();
+    }
+
+    fn selected_is_stageable(&self) -> bool {
+        self.selected_result()
+            .is_some_and(|result| matches!(result.kind, LensResultKind::App | LensResultKind::Node))
     }
 
     fn handle_key(&mut self, event: KeyEvent) {
@@ -442,7 +593,12 @@ impl LensApp {
             Keysym::Home => self.jump_to_edge(false),
             Keysym::End => self.jump_to_edge(true),
             Keysym::Tab => {
-                self.input.mode = LensMode::Actions;
+                if self.input.query.trim().is_empty() {
+                    self.input.query = "action ".into();
+                } else {
+                    self.input.query = format!("action {}", self.input.query.trim_start());
+                }
+                self.input.mode = LensMode::General;
                 self.refresh_results();
             }
             Keysym::BackSpace => {

--- a/crates/halley-lens/src/main.rs
+++ b/crates/halley-lens/src/main.rs
@@ -412,10 +412,8 @@ impl LensApp {
                 nodes, clusters
             ));
             let (mode, query) = self.effective_search();
-            if matches!(
-                mode,
-                LensMode::General | LensMode::Nodes | LensMode::Clusters
-            ) && !query.trim().is_empty()
+            if matches!(mode, LensMode::Nodes | LensMode::Clusters)
+                || (mode == LensMode::General && !query.trim().is_empty())
             {
                 self.refresh_results();
                 self.mark_redraw();

--- a/crates/halley-lens/src/mode.rs
+++ b/crates/halley-lens/src/mode.rs
@@ -135,6 +135,18 @@ mod tests {
     }
 
     #[test]
+    fn effective_query_detects_cluster_prefixes_with_empty_filter() {
+        assert_eq!(
+            effective_mode_query(LensMode::General, "cluster"),
+            (LensMode::Clusters, String::new())
+        );
+        assert_eq!(
+            effective_mode_query(LensMode::General, "clusters firefox"),
+            (LensMode::Clusters, "firefox".into())
+        );
+    }
+
+    #[test]
     fn unknown_slash_command_stays_general_text() {
         assert_eq!(
             parse_initial_mode("/wat test"),

--- a/crates/halley-lens/src/mode.rs
+++ b/crates/halley-lens/src/mode.rs
@@ -9,38 +9,35 @@ pub enum LensMode {
     Config,
 }
 
-impl LensMode {
-    pub fn label(self) -> Option<&'static str> {
-        match self {
-            Self::General => None,
-            Self::Apps => Some("Apps"),
-            Self::Clusters => Some("Clusters"),
-            Self::Nodes => Some("Nodes"),
-            Self::Actions => Some("Actions"),
-            Self::Config => Some("Config"),
-        }
-    }
-}
-
-pub fn mode_from_token(token: &str) -> Option<LensMode> {
+fn prefix_mode_from_token(token: &str) -> Option<LensMode> {
     match token.trim().to_ascii_lowercase().as_str() {
-        "/app" | "/apps" | "/a" => Some(LensMode::Apps),
-        "/cluster" | "/clusters" | "/c" => Some(LensMode::Clusters),
-        "/node" | "/nodes" | "/n" => Some(LensMode::Nodes),
-        "/action" | "/actions" => Some(LensMode::Actions),
-        "/config" => Some(LensMode::Config),
+        "app" | "apps" | "/app" | "/apps" | "/a" => Some(LensMode::Apps),
+        "cluster" | "clusters" | "/cluster" | "/clusters" | "/c" => Some(LensMode::Clusters),
+        "node" | "nodes" | "/node" | "/nodes" | "/n" => Some(LensMode::Nodes),
+        "action" | "actions" | "/action" | "/actions" => Some(LensMode::Actions),
+        "config" | "/config" => Some(LensMode::Config),
         _ => None,
     }
 }
 
 pub fn parse_initial_mode(raw: &str) -> (LensMode, String) {
-    let trimmed = raw.trim_start();
+    (LensMode::General, raw.trim().to_string())
+}
+
+pub fn effective_mode_query(mode: LensMode, query: &str) -> (LensMode, String) {
+    if mode != LensMode::General {
+        return (mode, query.trim().to_string());
+    }
+    let trimmed = query.trim_start();
     let Some((token, rest)) = trimmed.split_once(char::is_whitespace) else {
-        return (LensMode::General, raw.trim().to_string());
+        return match prefix_mode_from_token(trimmed) {
+            Some(mode) => (mode, String::new()),
+            None => (LensMode::General, query.trim().to_string()),
+        };
     };
-    match mode_from_token(token) {
+    match prefix_mode_from_token(token) {
         Some(mode) => (mode, rest.trim_start().to_string()),
-        None => (LensMode::General, raw.trim().to_string()),
+        None => (LensMode::General, query.trim().to_string()),
     }
 }
 
@@ -65,13 +62,6 @@ impl ModeInputState {
 
     pub fn insert_text(&mut self, text: &str) {
         self.query.push_str(text);
-        if self.query.starts_with('/')
-            && let Some((token, rest)) = self.query.split_once(char::is_whitespace)
-            && let Some(mode) = mode_from_token(token)
-        {
-            self.mode = mode;
-            self.query = rest.trim_start().to_string();
-        }
     }
 }
 
@@ -83,14 +73,18 @@ mod tests {
     fn parses_required_modes() {
         let cases = [
             ("release", LensMode::General, "release"),
-            ("/cluster release", LensMode::Clusters, "release"),
-            ("/clusters release", LensMode::Clusters, "release"),
-            ("/c release", LensMode::Clusters, "release"),
-            ("/node systemd", LensMode::Nodes, "systemd"),
-            ("/n systemd", LensMode::Nodes, "systemd"),
-            ("/app firefox", LensMode::Apps, "firefox"),
-            ("/a firefox", LensMode::Apps, "firefox"),
-            ("/config lens", LensMode::Config, "lens"),
+            ("/cluster release", LensMode::General, "/cluster release"),
+            ("/clusters release", LensMode::General, "/clusters release"),
+            ("/c release", LensMode::General, "/c release"),
+            ("/node systemd", LensMode::General, "/node systemd"),
+            ("/n systemd", LensMode::General, "/n systemd"),
+            ("/app firefox", LensMode::General, "/app firefox"),
+            ("/app", LensMode::General, "/app"),
+            ("/a firefox", LensMode::General, "/a firefox"),
+            ("/a", LensMode::General, "/a"),
+            ("/c", LensMode::General, "/c"),
+            ("/n", LensMode::General, "/n"),
+            ("/config lens", LensMode::General, "/config lens"),
         ];
         for (raw, mode, query) in cases {
             assert_eq!(parse_initial_mode(raw), (mode, query.to_string()));
@@ -125,8 +119,19 @@ mod tests {
             query: String::new(),
         };
         state.insert_text("/app firefox");
-        assert_eq!(state.mode, LensMode::Apps);
-        assert_eq!(state.query, "firefox");
+        assert_eq!(state.mode, LensMode::Nodes);
+        assert_eq!(state.query, "/app firefox");
+    }
+
+    #[test]
+    fn effective_query_detects_mode_prefixes() {
+        let mut state = ModeInputState::default();
+        state.insert_text("action open");
+        assert_eq!(state.mode, LensMode::General);
+        assert_eq!(
+            effective_mode_query(state.mode, state.query.as_str()),
+            (LensMode::Actions, "open".into())
+        );
     }
 
     #[test]

--- a/crates/halley-lens/src/providers.rs
+++ b/crates/halley-lens/src/providers.rs
@@ -6,8 +6,8 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread;
 
 use halley_api::{
-    ApiError, ClusterDraftRequest, ClusterDraftSource, ClusterRequest, ClusterTarget,
-    CompositorRequest, NodeKind, NodeRequest, NodeSelector, Request, Response,
+    ApiError, ClusterDraftAppLaunch, ClusterDraftRequest, ClusterDraftSource, ClusterRequest,
+    ClusterTarget, CompositorRequest, NodeKind, NodeRequest, NodeSelector, Request, Response,
 };
 
 use crate::config::{LensConfig, default_config_path};
@@ -49,7 +49,6 @@ struct CachedNode {
     id: u64,
     title: String,
     subtitle: String,
-    app_id: String,
     search_text: String,
     pinned: bool,
 }
@@ -141,7 +140,9 @@ impl ProviderIndex {
                 .then_with(|| a.section.cmp(&b.section))
                 .then_with(|| a.title.cmp(&b.title))
         });
-        let max_results = if ctx.mode == LensMode::Apps && ctx.query_lower.is_empty() {
+        let max_results = if matches!(ctx.mode, LensMode::Apps | LensMode::Clusters)
+            && ctx.query_lower.is_empty()
+        {
             usize::MAX
         } else {
             ctx.max_results
@@ -250,17 +251,17 @@ impl ProviderIndex {
         launch_exec(app.exec.as_str(), app.terminal, self.terminal.as_str())
     }
 
-    pub fn app_is_running(&self, app_id: &str, nodes: &[u64]) -> bool {
-        let _ = nodes;
-        if self.live_loaded {
-            return self
-                .nodes
-                .iter()
-                .any(|node| !node.app_id.is_empty() && app_id_matches(&node.app_id, app_id));
-        }
-        running_app_ids()
+    fn draft_app_launches(&self, app_ids: &[String]) -> Vec<ClusterDraftAppLaunch> {
+        app_ids
             .iter()
-            .any(|running| app_id_matches(running, app_id))
+            .filter_map(|app_id| {
+                let app = self.apps.iter().find(|app| app.id == *app_id)?;
+                Some(ClusterDraftAppLaunch {
+                    app_id: app.id.clone(),
+                    command: app_launch_command(app, self.terminal.as_str()),
+                })
+            })
+            .collect()
     }
 }
 
@@ -289,7 +290,6 @@ fn load_nodes() -> Vec<CachedNode> {
                 id: node.id,
                 title,
                 subtitle: format!("{app_label} on {output}"),
-                app_id,
                 search_text,
                 pinned: node.pinned,
             });
@@ -437,6 +437,7 @@ pub fn materialize_cluster_draft(
     let request = ClusterDraftRequest {
         name_hint: (!name_hint.is_empty()).then(|| name_hint.to_string()),
         app_ids: draft.app_ids.clone(),
+        app_launches: index.draft_app_launches(&draft.app_ids),
         running_node_ids: draft.running_node_ids.clone(),
         source: ClusterDraftSource::HalleyLens,
     };
@@ -446,14 +447,15 @@ pub fn materialize_cluster_draft(
             output: None,
         },
     )))?;
-    for app_id in &draft.app_ids {
-        if !index.app_is_running(app_id, &draft.running_node_ids)
-            && let Err(err) = index.launch_app(app_id)
-        {
-            eprintln!("halley-lens: failed to launch staged app {app_id}: {err}");
-        }
-    }
     Ok(())
+}
+
+fn app_launch_command(app: &DesktopApp, terminal_command: &str) -> String {
+    if app.terminal {
+        format!("{} {}", terminal_command.trim(), app.exec)
+    } else {
+        app.exec.clone()
+    }
 }
 
 fn expect_ok(response: Result<Response, halley_ipc::CodecError>) -> Result<(), String> {
@@ -655,21 +657,52 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-fn running_app_ids() -> Vec<String> {
-    let Ok(Response::NodeList(list)) =
-        halley_ipc::send_request(&Request::Node(NodeRequest::List { output: None }))
-    else {
-        return Vec::new();
-    };
-    list.outputs
-        .into_iter()
-        .flat_map(|group| group.nodes)
-        .filter_map(|node| node.app_id)
-        .collect()
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-fn app_id_matches(running: &str, staged: &str) -> bool {
-    let running = running.to_ascii_lowercase();
-    let staged = staged.to_ascii_lowercase();
-    running == staged || running.ends_with(&staged) || staged.ends_with(&running)
+    #[test]
+    fn cluster_mode_empty_query_keeps_all_stageable_results() {
+        let index = ProviderIndex {
+            apps: (0..5)
+                .map(|idx| DesktopApp {
+                    id: format!("app-{idx}"),
+                    name: format!("App {idx}"),
+                    comment: None,
+                    icon_name: None,
+                    exec: "true".into(),
+                    terminal: false,
+                    search_text: format!("app {idx}"),
+                })
+                .collect(),
+            nodes: (0..5)
+                .map(|idx| CachedNode {
+                    id: idx,
+                    title: format!("Node {idx}"),
+                    subtitle: "window on monitor".into(),
+                    search_text: format!("node {idx}"),
+                    pinned: false,
+                })
+                .collect(),
+            clusters: Vec::new(),
+            live_loaded: true,
+            live_rx: None,
+            terminal: String::new(),
+        };
+        let results = index.search(&SearchContext {
+            mode: LensMode::Clusters,
+            query: String::new(),
+            query_lower: String::new(),
+            max_results: 3,
+            draft_count: 0,
+        });
+
+        assert_eq!(results.len(), 10);
+        assert!(results.iter().any(|result| result.section == "Apps"));
+        assert!(
+            results
+                .iter()
+                .any(|result| result.section == "Running Nodes")
+        );
+    }
 }

--- a/crates/halley-lens/src/providers.rs
+++ b/crates/halley-lens/src/providers.rs
@@ -2,13 +2,15 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 use halley_api::{
     ApiError, ClusterDraftRequest, ClusterDraftSource, ClusterRequest, ClusterTarget,
     CompositorRequest, NodeKind, NodeRequest, NodeSelector, Request, Response,
 };
 
-use crate::config::default_config_path;
+use crate::config::{LensConfig, default_config_path};
 use crate::mode::LensMode;
 use crate::model::{ClusterDraft, LensAction, LensResult, LensResultKind, mode_allows};
 
@@ -16,12 +18,19 @@ use crate::model::{ClusterDraft, LensAction, LensResult, LensResultKind, mode_al
 pub struct SearchContext {
     pub mode: LensMode,
     pub query: String,
+    pub query_lower: String,
     pub max_results: usize,
+    pub draft_count: usize,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ProviderIndex {
     apps: Vec<DesktopApp>,
+    nodes: Vec<CachedNode>,
+    clusters: Vec<CachedCluster>,
+    live_loaded: bool,
+    live_rx: Option<Receiver<(Vec<CachedNode>, Vec<CachedCluster>)>>,
+    terminal: String,
 }
 
 #[derive(Clone, Debug)]
@@ -30,16 +39,70 @@ pub struct DesktopApp {
     pub name: String,
     pub comment: Option<String>,
     pub icon_name: Option<String>,
-    pub startup_wm_class: Option<String>,
     pub exec: String,
     pub terminal: bool,
+    search_text: String,
+}
+
+#[derive(Clone, Debug)]
+struct CachedNode {
+    id: u64,
+    title: String,
+    subtitle: String,
+    app_id: String,
+    search_text: String,
+    pinned: bool,
+}
+
+#[derive(Clone, Debug)]
+struct CachedCluster {
+    id: u64,
+    title: String,
+    subtitle: String,
+    search_text: String,
 }
 
 impl ProviderIndex {
-    pub fn load() -> Self {
+    pub fn load(config: &LensConfig) -> Self {
         Self {
             apps: load_desktop_apps(),
+            nodes: Vec::new(),
+            clusters: Vec::new(),
+            live_loaded: false,
+            live_rx: None,
+            terminal: config.terminal.trim().to_string(),
         }
+    }
+
+    pub fn needs_live_refresh(&self) -> bool {
+        !self.live_loaded && self.live_rx.is_none()
+    }
+
+    pub fn has_pending_live_refresh(&self) -> bool {
+        self.live_rx.is_some()
+    }
+
+    pub fn start_live_refresh(&mut self) {
+        if !self.needs_live_refresh() {
+            return;
+        }
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let _ = tx.send((load_nodes(), load_clusters()));
+        });
+        self.live_rx = Some(rx);
+    }
+
+    pub fn finish_live_refresh_if_ready(&mut self) -> Option<(usize, usize)> {
+        let rx = self.live_rx.as_ref()?;
+        let Ok((nodes, clusters)) = rx.try_recv() else {
+            return None;
+        };
+        self.nodes = nodes;
+        self.clusters = clusters;
+        self.live_loaded = true;
+        self.live_rx = None;
+        Some((self.nodes.len(), self.clusters.len()))
     }
 
     pub fn search(&self, ctx: &SearchContext) -> Vec<LensResult> {
@@ -54,10 +117,10 @@ impl ProviderIndex {
             ctx.mode,
             LensMode::General | LensMode::Nodes | LensMode::Clusters
         ) {
-            results.extend(search_nodes(ctx));
+            results.extend(self.search_nodes(ctx));
         }
         if matches!(ctx.mode, LensMode::General | LensMode::Clusters) {
-            results.extend(search_clusters(ctx));
+            results.extend(self.search_clusters(ctx));
         }
         if matches!(ctx.mode, LensMode::General | LensMode::Actions) {
             results.extend(search_actions(ctx));
@@ -66,7 +129,7 @@ impl ProviderIndex {
             results.extend(search_config(ctx));
         }
 
-        if ctx.mode == LensMode::Clusters {
+        if ctx.mode == LensMode::Clusters && ctx.draft_count > 0 {
             results.push(create_cluster_result(ctx.query.as_str()));
         }
 
@@ -78,8 +141,13 @@ impl ProviderIndex {
                 .then_with(|| a.section.cmp(&b.section))
                 .then_with(|| a.title.cmp(&b.title))
         });
-        if results.len() > ctx.max_results {
-            results.truncate(ctx.max_results);
+        let max_results = if ctx.mode == LensMode::Apps && ctx.query_lower.is_empty() {
+            usize::MAX
+        } else {
+            ctx.max_results
+        };
+        if results.len() > max_results {
+            results.truncate(max_results);
         }
         results
     }
@@ -88,14 +156,7 @@ impl ProviderIndex {
         self.apps
             .iter()
             .filter_map(|app| {
-                let haystack = format!(
-                    "{} {} {} {}",
-                    app.name,
-                    app.id,
-                    app.comment.as_deref().unwrap_or_default(),
-                    app.startup_wm_class.as_deref().unwrap_or_default()
-                );
-                let score = match_score(ctx.query.as_str(), haystack.as_str())?;
+                let score = match_score(ctx.query_lower.as_str(), app.search_text.as_str())?;
                 Some(LensResult {
                     section: if ctx.mode == LensMode::Clusters {
                         "Apps"
@@ -125,118 +186,142 @@ impl ProviderIndex {
             .collect()
     }
 
+    fn search_nodes(&self, ctx: &SearchContext) -> Vec<LensResult> {
+        self.nodes
+            .iter()
+            .filter_map(|node| {
+                let mut score = match_score(ctx.query_lower.as_str(), node.search_text.as_str())?;
+                if node.pinned {
+                    score += 1000.0;
+                }
+                Some(LensResult {
+                    section: if ctx.mode == LensMode::Clusters {
+                        "Running Nodes"
+                    } else {
+                        "Nodes"
+                    }
+                    .into(),
+                    title: node.title.clone(),
+                    subtitle: Some(node.subtitle.clone()),
+                    icon_name: None,
+                    kind: LensResultKind::Node,
+                    score,
+                    is_field_pinned: node.pinned,
+                    shortcut_hint: Some(
+                        if ctx.mode == LensMode::Clusters {
+                            "Space stage"
+                        } else {
+                            "Enter open"
+                        }
+                        .into(),
+                    ),
+                    action: LensAction::FocusNode { id: node.id },
+                })
+            })
+            .collect()
+    }
+
+    fn search_clusters(&self, ctx: &SearchContext) -> Vec<LensResult> {
+        self.clusters
+            .iter()
+            .filter_map(|cluster| {
+                let score = match_score(ctx.query_lower.as_str(), cluster.search_text.as_str())?;
+                Some(LensResult {
+                    section: "Existing Clusters".into(),
+                    title: cluster.title.clone(),
+                    subtitle: Some(cluster.subtitle.clone()),
+                    icon_name: None,
+                    kind: LensResultKind::Cluster,
+                    score: score + 20.0,
+                    is_field_pinned: false,
+                    shortcut_hint: Some("Enter open".into()),
+                    action: LensAction::OpenCluster { id: cluster.id },
+                })
+            })
+            .collect()
+    }
+
     pub fn launch_app(&self, app_id: &str) -> Result<(), String> {
         let app = self
             .apps
             .iter()
             .find(|app| app.id == app_id)
             .ok_or_else(|| format!("app `{app_id}` not found"))?;
-        launch_exec(app.exec.as_str(), app.terminal)
+        launch_exec(app.exec.as_str(), app.terminal, self.terminal.as_str())
     }
 
     pub fn app_is_running(&self, app_id: &str, nodes: &[u64]) -> bool {
         let _ = nodes;
+        if self.live_loaded {
+            return self
+                .nodes
+                .iter()
+                .any(|node| !node.app_id.is_empty() && app_id_matches(&node.app_id, app_id));
+        }
         running_app_ids()
             .iter()
             .any(|running| app_id_matches(running, app_id))
     }
 }
 
-fn search_nodes(ctx: &SearchContext) -> Vec<LensResult> {
+fn load_nodes() -> Vec<CachedNode> {
     let Ok(Response::NodeList(list)) =
         halley_ipc::send_request(&Request::Node(NodeRequest::List { output: None }))
     else {
         return Vec::new();
     };
-    let mut results = Vec::new();
+    let mut nodes = Vec::new();
     for group in list.outputs {
+        let output = group.output;
         for node in group.nodes {
             if node.kind != NodeKind::Surface || !node.visible {
                 continue;
             }
-            let haystack = format!(
-                "{} {} {}",
-                node.title,
-                node.app_id.as_deref().unwrap_or_default(),
-                group.output
-            );
-            let Some(mut score) = match_score(ctx.query.as_str(), haystack.as_str()) else {
-                continue;
+            let title = node.title;
+            let app_id = node.app_id.unwrap_or_default();
+            let app_label = if app_id.is_empty() {
+                "window"
+            } else {
+                app_id.as_str()
             };
-            if node.pinned {
-                score += 1000.0;
-            }
-            results.push(LensResult {
-                section: if ctx.mode == LensMode::Clusters {
-                    "Running Nodes"
-                } else {
-                    "Nodes"
-                }
-                .into(),
-                title: node.title,
-                subtitle: Some(format!(
-                    "{} on {}",
-                    node.app_id.unwrap_or_else(|| "window".into()),
-                    group.output
-                )),
-                icon_name: None,
-                kind: LensResultKind::Node,
-                score,
-                is_field_pinned: node.pinned,
-                shortcut_hint: Some(
-                    if ctx.mode == LensMode::Clusters {
-                        "Space stage"
-                    } else {
-                        "Enter open"
-                    }
-                    .into(),
-                ),
-                action: LensAction::FocusNode { id: node.id },
+            let search_text = format!("{title} {app_id} {output}").to_ascii_lowercase();
+            nodes.push(CachedNode {
+                id: node.id,
+                title,
+                subtitle: format!("{app_label} on {output}"),
+                app_id,
+                search_text,
+                pinned: node.pinned,
             });
         }
     }
-    results
+    nodes
 }
 
-fn search_clusters(ctx: &SearchContext) -> Vec<LensResult> {
+fn load_clusters() -> Vec<CachedCluster> {
     let Ok(Response::ClusterList(list)) =
         halley_ipc::send_request(&Request::Cluster(ClusterRequest::List { output: None }))
     else {
         return Vec::new();
     };
-    let mut results = Vec::new();
+    let mut clusters = Vec::new();
     for group in list.outputs {
+        let output = group.output;
         for cluster in group.clusters {
             let title = cluster
                 .name
-                .clone()
                 .unwrap_or_else(|| format!("Cluster {}", cluster.id));
-            let haystack = format!(
-                "{} {} {}",
+            let slot = cluster.slot.map(|s| s.to_string()).unwrap_or_default();
+            let search_text = format!("{title} {slot} {output}").to_ascii_lowercase();
+            clusters.push(CachedCluster {
+                id: cluster.id,
                 title,
-                cluster.slot.map(|s| s.to_string()).unwrap_or_default(),
-                group.output
-            );
-            let Some(score) = match_score(ctx.query.as_str(), haystack.as_str()) else {
-                continue;
-            };
-            results.push(LensResult {
-                section: "Existing Clusters".into(),
-                title,
-                subtitle: Some(format!(
-                    "{} members on {}",
-                    cluster.member_count, group.output
-                )),
-                icon_name: None,
-                kind: LensResultKind::Cluster,
-                score: score + 20.0,
-                is_field_pinned: false,
-                shortcut_hint: Some("Enter open".into()),
-                action: LensAction::OpenCluster { id: cluster.id },
+                subtitle: format!("{} members on {}", cluster.member_count, output),
+                search_text,
             });
         }
     }
-    results
+    clusters
 }
 
 fn create_cluster_result(query: &str) -> LensResult {
@@ -251,7 +336,7 @@ fn create_cluster_result(query: &str) -> LensResult {
         subtitle: Some("Open Cluster Finalize popup".into()),
         icon_name: None,
         kind: LensResultKind::CreateCluster,
-        score: 900.0,
+        score: 0.0,
         is_field_pinned: false,
         shortcut_hint: Some("Ctrl+Enter".into()),
         action: LensAction::CreateCluster,
@@ -278,7 +363,11 @@ fn search_actions(ctx: &SearchContext) -> Vec<LensResult> {
     actions
         .into_iter()
         .filter_map(|(_id, title, subtitle, action)| {
-            match_score(ctx.query.as_str(), title).map(|score| LensResult {
+            match_score(
+                ctx.query_lower.as_str(),
+                title.to_ascii_lowercase().as_str(),
+            )
+            .map(|score| LensResult {
                 section: "Actions".into(),
                 title: title.into(),
                 subtitle: Some(subtitle.into()),
@@ -295,7 +384,7 @@ fn search_actions(ctx: &SearchContext) -> Vec<LensResult> {
 
 fn search_config(ctx: &SearchContext) -> Vec<LensResult> {
     let path = default_config_path();
-    match_score(ctx.query.as_str(), "lens config").map_or_else(Vec::new, |score| {
+    match_score(ctx.query_lower.as_str(), "lens config").map_or_else(Vec::new, |score| {
         vec![LensResult {
             section: "Config".into(),
             title: "Lens config".into(),
@@ -330,9 +419,11 @@ pub fn activate_result(index: &ProviderIndex, result: &LensResult) -> Result<(),
         LensAction::ReloadConfig => expect_ok(halley_ipc::send_request(&Request::Compositor(
             CompositorRequest::Reload,
         ))),
-        LensAction::OpenPath { path } => {
-            launch_exec(format!("xdg-open {}", shell_quote(path)).as_str(), false)
-        }
+        LensAction::OpenPath { path } => launch_exec(
+            format!("xdg-open {}", shell_quote(path)).as_str(),
+            false,
+            index.terminal.as_str(),
+        ),
         LensAction::CreateCluster => Ok(()),
     }
 }
@@ -384,19 +475,17 @@ fn format_api_error(err: &ApiError) -> String {
     }
 }
 
-fn match_score(query: &str, haystack: &str) -> Option<f64> {
-    let query = query.trim().to_ascii_lowercase();
-    if query.is_empty() {
+fn match_score(query_lower: &str, haystack_lower: &str) -> Option<f64> {
+    if query_lower.is_empty() {
         return Some(1.0);
     }
-    let haystack = haystack.to_ascii_lowercase();
-    if haystack == query {
+    if haystack_lower == query_lower {
         return Some(300.0);
     }
-    if haystack.contains(&query) {
-        return Some(200.0 - haystack.find(&query).unwrap_or(0) as f64);
+    if haystack_lower.contains(query_lower) {
+        return Some(200.0 - haystack_lower.find(query_lower).unwrap_or(0) as f64);
     }
-    fuzzy_match(query.as_str(), haystack.as_str()).map(|score| 100.0 + score)
+    fuzzy_match(query_lower, haystack_lower).map(|score| 100.0 + score)
 }
 
 fn fuzzy_match(query: &str, haystack: &str) -> Option<f64> {
@@ -478,17 +567,27 @@ fn parse_desktop_app(path: &Path) -> Option<DesktopApp> {
         return None;
     }
     let id = path.file_stem()?.to_string_lossy().into_owned();
+    let name = name?;
+    let exec = exec?;
+    let search_text = format!(
+        "{} {} {} {}",
+        name,
+        id,
+        comment.as_deref().unwrap_or_default(),
+        startup_wm_class.as_deref().unwrap_or_default()
+    )
+    .to_ascii_lowercase();
     let icon_name = icon_name
         .or_else(|| startup_wm_class.clone())
         .or_else(|| Some(id.clone()));
     Some(DesktopApp {
         id,
-        name: name?,
+        name,
         comment,
         icon_name,
-        startup_wm_class,
-        exec: exec?,
+        exec,
         terminal,
+        search_text,
     })
 }
 
@@ -535,9 +634,9 @@ fn unescape(value: &str) -> String {
         .replace("\\\\", "\\")
 }
 
-fn launch_exec(command: &str, terminal: bool) -> Result<(), String> {
+fn launch_exec(command: &str, terminal: bool, terminal_command: &str) -> Result<(), String> {
     let command = if terminal {
-        format!("x-terminal-emulator -e {command}")
+        format!("{} {command}", terminal_command.trim())
     } else {
         command.to_string()
     };

--- a/crates/halley-lens/src/ui.rs
+++ b/crates/halley-lens/src/ui.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 use fontdb::{Database, Family, Query, Stretch, Style, Weight};
 use image::{RgbaImage, imageops};
@@ -9,7 +11,7 @@ use rusttype::{Font, PositionedGlyph, Scale, point};
 
 use crate::config::LensConfig;
 use crate::mode::{LensMode, ModeInputState};
-use crate::model::{ClusterDraft, LensResult, LensResultKind};
+use crate::model::{ClusterDraft, LensResult};
 
 #[derive(Clone, Copy)]
 pub struct Color(pub f32, pub f32, pub f32, pub f32);
@@ -26,6 +28,7 @@ pub struct Rect {
 pub struct View<'a> {
     pub config: &'a LensConfig,
     pub input: &'a ModeInputState,
+    pub mode: LensMode,
     pub results: &'a [LensResult],
     pub selected: usize,
     pub scroll_offset: usize,
@@ -46,7 +49,7 @@ pub fn surface_height(view: View<'_>) -> i32 {
     }
 
     height += ui.dropdown_gap + ui.dropdown_padding * 2;
-    if view.input.mode == LensMode::Clusters && view.draft.count() > 0 {
+    if view.mode == LensMode::Clusters && view.draft.count() > 0 {
         height += ui.draft_height + ui.row_gap;
     }
 
@@ -67,6 +70,7 @@ pub fn surface_height(view: View<'_>) -> i32 {
     if rows > 0 {
         height += section_budget + rows * ui.row_height + (rows - 1).max(0) * ui.row_gap;
     }
+    height += list_bottom_padding(view.config);
     if ui.footer_height > 0 {
         height += ui.row_gap + ui.footer_height;
     }
@@ -76,7 +80,11 @@ pub fn surface_height(view: View<'_>) -> i32 {
 fn dropdown_visible(view: View<'_>) -> bool {
     !view.input.query.trim().is_empty()
         || view.input.mode != LensMode::General
-        || (view.input.mode == LensMode::Clusters && view.draft.count() > 0)
+        || (view.mode == LensMode::Clusters && view.draft.count() > 0)
+}
+
+fn list_bottom_padding(config: &LensConfig) -> i32 {
+    config.ui.row_gap.max(8)
 }
 
 fn visible_section_count(view: View<'_>) -> usize {
@@ -123,7 +131,7 @@ pub fn result_index_at(view: View<'_>, width: u32, height: u32, sx: f64, sy: f64
         return None;
     }
     let mut y = panel.y + ui.search_height + ui.dropdown_gap + ui.dropdown_padding;
-    if view.input.mode == LensMode::Clusters && view.draft.count() > 0 {
+    if view.mode == LensMode::Clusters && view.draft.count() > 0 {
         y += ui.draft_height + ui.row_gap;
     }
     let mut last_section = "";
@@ -186,6 +194,9 @@ impl FontRenderer {
     }
 
     fn measure(&self, text: &str, px: u32) -> (i32, i32) {
+        if text.is_empty() {
+            return (0, px as i32);
+        }
         let scale = Scale::uniform(px as f32);
         let v = self.font.v_metrics(scale);
         let glyphs: Vec<_> = self
@@ -196,6 +207,66 @@ impl FontRenderer {
             return (px as i32, px as i32);
         };
         ((bounds.2 - bounds.0).max(1), (bounds.3 - bounds.1).max(1))
+    }
+
+    fn fit_text(&self, text: &str, px: u32, max_width: i32) -> String {
+        if max_width <= 0 || text.is_empty() {
+            return String::new();
+        }
+        if self.measure(text, px).0 <= max_width {
+            return text.to_string();
+        }
+        let ellipsis = "...";
+        let ellipsis_width = self.measure(ellipsis, px).0;
+        if ellipsis_width > max_width {
+            return String::new();
+        }
+
+        let mut fitted = String::new();
+        for ch in text.chars() {
+            fitted.push(ch);
+            let candidate = format!("{}{}", fitted.trim_end(), ellipsis);
+            if self.measure(candidate.as_str(), px).0 > max_width {
+                fitted.pop();
+                break;
+            }
+        }
+
+        if fitted.is_empty() {
+            ellipsis.to_string()
+        } else {
+            format!("{}{}", fitted.trim_end(), ellipsis)
+        }
+    }
+
+    fn fit_text_tail(&self, text: &str, px: u32, max_width: i32) -> String {
+        if max_width <= 0 || text.is_empty() {
+            return String::new();
+        }
+        if self.measure(text, px).0 <= max_width {
+            return text.to_string();
+        }
+        let ellipsis = "...";
+        let ellipsis_width = self.measure(ellipsis, px).0;
+        if ellipsis_width > max_width {
+            return String::new();
+        }
+
+        let mut fitted = String::new();
+        for ch in text.chars().rev() {
+            fitted.insert(0, ch);
+            let candidate = format!("{ellipsis}{fitted}");
+            if self.measure(candidate.as_str(), px).0 > max_width {
+                fitted.remove(0);
+                break;
+            }
+        }
+
+        if fitted.is_empty() {
+            ellipsis.to_string()
+        } else {
+            format!("{ellipsis}{fitted}")
+        }
     }
 
     fn draw(
@@ -237,13 +308,73 @@ impl FontRenderer {
             });
         }
     }
+
+    /// Constant line height (ascent + |descent|) for the font at `px`, independent of the
+    /// glyphs in any particular string. Use for vertical centering so text does not jump as
+    /// ascenders/descenders (e.g. `y`, `g`) come and go.
+    fn v_line_height(&self, px: u32) -> i32 {
+        let scale = Scale::uniform(px as f32);
+        let v = self.font.v_metrics(scale);
+        (v.ascent - v.descent).ceil().max(1.0) as i32
+    }
+
+    /// Draw `text` with a stable baseline: `top_y` is the top of the line box (the ascent line),
+    /// so vertical glyph positions depend only on the font metrics, never on which characters are
+    /// present. The leftmost ink is aligned to `x`. Use for live-edited single-line text.
+    #[allow(clippy::too_many_arguments)]
+    fn draw_line(
+        &self,
+        canvas: &mut [u8],
+        width: u32,
+        height: u32,
+        x: i32,
+        top_y: i32,
+        text: &str,
+        px: u32,
+        color: Color,
+    ) {
+        let scale = Scale::uniform(px as f32);
+        let v = self.font.v_metrics(scale);
+        let glyphs: Vec<_> = self
+            .font
+            .layout(text, scale, point(0.0, v.ascent))
+            .collect();
+        let x_min = glyphs
+            .iter()
+            .filter_map(|g| g.pixel_bounding_box())
+            .map(|bb| bb.min.x)
+            .min()
+            .unwrap_or(0);
+        for glyph in glyphs {
+            let Some(bb) = glyph.pixel_bounding_box() else {
+                continue;
+            };
+            glyph.draw(|gx, gy, coverage| {
+                let px = x + bb.min.x - x_min + gx as i32;
+                let py = top_y + bb.min.y + gy as i32;
+                if px < 0 || py < 0 || px >= width as i32 || py >= height as i32 {
+                    return;
+                }
+                let offset = ((py as u32 * width + px as u32) * 4) as usize;
+                blend(
+                    canvas,
+                    offset,
+                    Color(color.0, color.1, color.2, color.3 * coverage),
+                );
+            });
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct IconCache {
     entries: HashMap<String, Option<IconRaster>>,
     index: HashMap<String, IconIndexEntry>,
+    roots: Vec<PathBuf>,
     target_size: u32,
+    search_depth: usize,
+    indexed: bool,
+    index_rx: Option<Receiver<HashMap<String, IconIndexEntry>>>,
 }
 
 struct IconRaster {
@@ -262,9 +393,55 @@ impl IconCache {
     pub fn new(config: &LensConfig) -> Self {
         Self {
             entries: HashMap::new(),
-            index: build_icon_index(config),
+            index: HashMap::new(),
+            roots: if config.icons {
+                icon_roots(config)
+            } else {
+                Vec::new()
+            },
             target_size: config.icon_size.max(1),
+            search_depth: config.icon_search_depth,
+            indexed: !config.icons,
+            index_rx: None,
         }
+    }
+
+    pub fn needs_index(&self) -> bool {
+        !self.indexed && self.index_rx.is_none()
+    }
+
+    pub fn has_pending_index(&self) -> bool {
+        self.index_rx.is_some()
+    }
+
+    pub fn start_index(&mut self) {
+        if !self.needs_index() {
+            return;
+        }
+        let roots = self.roots.clone();
+        let search_depth = self.search_depth;
+        let target_size = self.target_size;
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let _ = tx.send(build_icon_index(
+                roots.as_slice(),
+                search_depth,
+                target_size,
+            ));
+        });
+        self.index_rx = Some(rx);
+    }
+
+    pub fn finish_index_if_ready(&mut self) -> Option<usize> {
+        let rx = self.index_rx.as_ref()?;
+        let Ok(index) = rx.try_recv() else {
+            return None;
+        };
+        self.index = index;
+        self.indexed = true;
+        self.index_rx = None;
+        self.entries.retain(|_, raster| raster.is_some());
+        Some(self.index.len())
     }
 
     fn load(&mut self, name: &str) -> Option<&IconRaster> {
@@ -291,11 +468,20 @@ impl IconCache {
         if let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) {
             push_icon_candidate(&mut candidates, stem.to_string());
         }
-        candidates.into_iter().find_map(|candidate| {
-            self.index
-                .get(&candidate.to_ascii_lowercase())
-                .map(|entry| entry.path.clone())
-        })
+        if self.indexed {
+            candidates.iter().find_map(|candidate| {
+                self.index
+                    .get(&candidate.to_ascii_lowercase())
+                    .map(|entry| entry.path.clone())
+            })
+        } else {
+            find_direct_icon(
+                self.roots.as_slice(),
+                candidates.as_slice(),
+                self.target_size,
+                self.search_depth,
+            )
+        }
     }
 }
 
@@ -386,7 +572,7 @@ pub fn draw_palette(
 
     let mut y = dropdown_y + ui.dropdown_padding;
 
-    if view.input.mode == LensMode::Clusters && view.draft.count() > 0 {
+    if view.mode == LensMode::Clusters && view.draft.count() > 0 {
         draw_draft_summary(canvas, width, height, font, view, panel, y);
         y += ui.draft_height + ui.row_gap;
     }
@@ -405,7 +591,6 @@ struct Palette {
     subtext: Color,
     hint: Color,
     accent: Color,
-    badge: Color,
     danger: Color,
 }
 
@@ -424,7 +609,6 @@ impl Palette {
             subtext: parse_color(&config.colors.subtext, Color(0.62, 0.66, 0.76, 0.95)),
             hint: parse_color(&config.colors.hint, Color(0.52, 0.58, 0.70, 0.9)),
             accent: parse_color(&config.colors.accent, Color(0.62, 0.74, 1.0, 1.0)),
-            badge: parse_color(&config.colors.badge, Color(0.20, 0.28, 0.46, 0.95)),
             danger: parse_color(&config.colors.danger, Color(0.92, 0.62, 0.56, 0.95)),
         }
     }
@@ -461,53 +645,29 @@ fn draw_search_box(
         corners,
         colors.search,
     );
-    let mut text_x = panel.x + pad;
-    if let Some(label) = input.mode.label() {
-        let badge = format!("{label} ×");
-        let (bw, bh) = font.measure(&badge, ui.badge_font_size);
-        let badge_h = (bh + 12).min(ui.search_height - 12).max(28);
-        let badge_y = y + (ui.search_height - badge_h) / 2;
-        fill_rounded_rect(
-            canvas,
-            width,
-            height,
-            panel.x + pad,
-            badge_y,
-            bw + 22,
-            badge_h,
-            config.rounding.badge,
-            colors.badge,
-        );
-        font.draw(
-            canvas,
-            width,
-            height,
-            panel.x + pad + 11,
-            badge_y + (badge_h - bh) / 2,
-            &badge,
-            ui.badge_font_size,
-            colors.text,
-        );
-        text_x = panel.x + pad + bw + 32;
-    }
+    let text_x = panel.x + pad;
+    let _ = input.mode;
+    let text_right = panel.x + panel.w - pad;
+    let text_width = (text_right - text_x).max(0);
     let placeholder = if input.query.is_empty() {
-        config.placeholder.as_str()
+        font.fit_text(config.placeholder.as_str(), ui.search_font_size, text_width)
     } else {
-        input.query.as_str()
+        font.fit_text_tail(input.query.as_str(), ui.search_font_size, text_width)
     };
     let color = if input.query.is_empty() {
         colors.hint
     } else {
         colors.text
     };
-    let (_, th) = font.measure(placeholder, ui.search_font_size);
-    font.draw(
+    let line_h = font.v_line_height(ui.search_font_size);
+    let top_y = y + (ui.search_height - line_h) / 2;
+    font.draw_line(
         canvas,
         width,
         height,
         text_x,
-        y + (ui.search_height - th) / 2,
-        placeholder,
+        top_y,
+        placeholder.as_str(),
         ui.search_font_size,
         color,
     );
@@ -643,7 +803,7 @@ fn draw_result_row(
         );
     }
 
-    if view.input.mode == LensMode::Clusters && view.draft.contains_result(result) {
+    if view.mode == LensMode::Clusters && view.draft.contains_result(result) {
         let (_, check_h) = font.measure("✓", ui.hint_font_size + 3);
         font.draw(
             canvas,
@@ -660,53 +820,19 @@ fn draw_result_row(
     let icon_size = view.config.icon_size as i32;
     let icon_x = panel.x + pad + 28;
     let icon_y = y + (ui.row_height - icon_size) / 2;
-    draw_result_icon(
-        canvas,
-        width,
-        height,
-        font,
-        icon_cache,
-        view.config,
-        result,
-        icon_x,
-        icon_y,
-    );
-
-    let text_x = icon_x + icon_size + 16;
-    let (_, title_h) = font.measure(result.title.as_str(), ui.title_font_size);
-    let subtitle_h = result
-        .subtitle
-        .as_ref()
-        .map(|subtitle| font.measure(subtitle, ui.subtitle_font_size).1)
-        .unwrap_or(0);
-    let text_block_h = if subtitle_h > 0 {
-        title_h + 7 + subtitle_h
-    } else {
-        title_h
-    };
-    let title_y = y + (ui.row_height - text_block_h) / 2;
-    font.draw(
-        canvas,
-        width,
-        height,
-        text_x,
-        title_y,
-        result.title.as_str(),
-        ui.title_font_size,
-        colors.text,
-    );
-    if let Some(subtitle) = &result.subtitle {
-        font.draw(
+    if view.config.icons {
+        draw_result_icon(
             canvas,
             width,
             height,
-            text_x,
-            title_y + title_h + 7,
-            subtitle.as_str(),
-            ui.subtitle_font_size,
-            colors.subtext,
+            icon_cache,
+            view.config,
+            result,
+            icon_x,
+            icon_y,
         );
     }
+
     let visible_index = index.saturating_sub(view.scroll_offset);
     let alt_hint = (view.config.alt_number_jump && visible_index < 10).then(|| {
         if visible_index == 9 {
@@ -716,13 +842,67 @@ fn draw_result_row(
         }
     });
     let hint = alt_hint.as_deref().or(result.shortcut_hint.as_deref());
-    if let Some(hint) = hint {
-        let (hint_w, hint_h) = font.measure(hint, ui.hint_font_size);
+    let hint_metrics = hint.map(|hint| (hint, font.measure(hint, ui.hint_font_size)));
+    let hint_x = hint_metrics
+        .map(|(_, (hint_w, _))| panel.x + panel.w - pad - 14 - hint_w)
+        .unwrap_or(panel.x + panel.w - pad - 14);
+
+    let text_x = if view.config.icons {
+        icon_x + icon_size + 16
+    } else {
+        icon_x
+    };
+    let text_right = hint_metrics
+        .map(|_| hint_x - 18)
+        .unwrap_or(panel.x + panel.w - pad - 14);
+    let text_width = (text_right - text_x).max(0);
+    let title = font.fit_text(result.title.as_str(), ui.title_font_size, text_width);
+    let subtitle = result
+        .subtitle
+        .as_ref()
+        .map(|subtitle| font.fit_text(subtitle.as_str(), ui.subtitle_font_size, text_width));
+    let (_, title_h) = font.measure(title.as_str(), ui.title_font_size);
+    let subtitle_h = subtitle
+        .as_deref()
+        .filter(|subtitle| !subtitle.is_empty())
+        .map(|subtitle| font.measure(subtitle, ui.subtitle_font_size).1)
+        .unwrap_or(0);
+    let text_block_h = if subtitle_h > 0 {
+        title_h + 7 + subtitle_h
+    } else {
+        title_h
+    };
+    let title_y = y + (ui.row_height - text_block_h) / 2;
+    if !title.is_empty() {
         font.draw(
             canvas,
             width,
             height,
-            panel.x + panel.w - pad - 14 - hint_w,
+            text_x,
+            title_y,
+            title.as_str(),
+            ui.title_font_size,
+            colors.text,
+        );
+    }
+    if let Some(subtitle) = subtitle.as_deref().filter(|subtitle| !subtitle.is_empty()) {
+        font.draw(
+            canvas,
+            width,
+            height,
+            text_x,
+            title_y + title_h + 7,
+            subtitle,
+            ui.subtitle_font_size,
+            colors.subtext,
+        );
+    }
+    if let Some((hint, (_, hint_h))) = hint_metrics {
+        font.draw(
+            canvas,
+            width,
+            height,
+            hint_x,
             y + (ui.row_height - hint_h) / 2,
             hint,
             ui.hint_font_size,
@@ -736,48 +916,21 @@ fn draw_result_icon(
     canvas: &mut [u8],
     width: u32,
     height: u32,
-    font: &FontRenderer,
     icon_cache: &mut IconCache,
     config: &LensConfig,
     result: &LensResult,
     x: i32,
     y: i32,
 ) {
-    let colors = Palette::from_config(config);
+    // Only render a resolvable raster icon; results without an icon render nothing (no
+    // placeholder glyph).
     let size = config.icon_size as i32;
     if config.icons
         && let Some(name) = result.icon_name.as_deref()
         && let Some(raster) = icon_cache.load(name)
     {
         draw_raster(canvas, width, height, raster, x, y, size, size);
-        return;
     }
-
-    let glyph = match result.kind {
-        LensResultKind::App => "▣",
-        LensResultKind::Cluster | LensResultKind::CreateCluster => "◈",
-        LensResultKind::Node => {
-            if result.is_field_pinned {
-                "⌖"
-            } else {
-                "●"
-            }
-        }
-        LensResultKind::Action => "⚙",
-        LensResultKind::Config => "◇",
-    };
-    let font_size = (config.icon_size + 2).clamp(16, 48);
-    let (gw, gh) = font.measure(glyph, font_size);
-    font.draw(
-        canvas,
-        width,
-        height,
-        x + (size - gw) / 2,
-        y + (size - gh) / 2,
-        glyph,
-        font_size,
-        colors.accent,
-    );
 }
 
 fn draw_footer(
@@ -806,10 +959,10 @@ fn draw_footer(
             colors.danger,
         );
     }
-    let create_hint = if view.draft.app_ids.is_empty() {
+    let create_hint = if view.draft.count() == 0 {
         "Ctrl+Enter Create"
     } else {
-        "Ctrl+Enter Launch apps & finalize draft"
+        "Ctrl+Enter Finalize draft"
     };
     let footer = format!("Enter Open    Space Select    Tab Actions    {create_hint}    Esc Close");
     let (_, footer_h) = font.measure(&footer, ui.hint_font_size);
@@ -892,55 +1045,48 @@ fn fill_rounded_rect_corners(
     let y0 = y.max(0);
     let x1 = (x + w).min(width as i32);
     let y1 = (y + h).min(height as i32);
-    let r = radius.min(w / 2).min(h / 2).max(0);
-    let r2 = r * r;
+    let r = radius.min(w / 2).min(h / 2).max(0) as f32;
+    // Arc centres for each rounded corner (in pixel space).
+    let left_c = x as f32 + r;
+    let right_c = (x + w) as f32 - r;
+    let top_c = y as f32 + r;
+    let bottom_c = (y + h) as f32 - r;
     let (top_left, top_right, bottom_right, bottom_left) = corners;
     for py in y0..y1 {
         for px in x0..x1 {
-            let left_corner = px < x + r;
-            let right_corner = px >= x + w - r;
-            let top_corner = py < y + r;
-            let bottom_corner = py >= y + h - r;
-            let rounded = if left_corner && top_corner {
-                top_left
-            } else if right_corner && top_corner {
-                top_right
-            } else if right_corner && bottom_corner {
-                bottom_right
-            } else if left_corner && bottom_corner {
-                bottom_left
+            // Sample at the pixel centre for sub-pixel coverage.
+            let cx = px as f32 + 0.5;
+            let cy = py as f32 + 0.5;
+            let left = cx < left_c;
+            let right = cx > right_c;
+            let top = cy < top_c;
+            let bottom = cy > bottom_c;
+            let (arc, rounded) = if left && top {
+                ((left_c, top_c), top_left)
+            } else if right && top {
+                ((right_c, top_c), top_right)
+            } else if right && bottom {
+                ((right_c, bottom_c), bottom_right)
+            } else if left && bottom {
+                ((left_c, bottom_c), bottom_left)
             } else {
-                false
+                ((0.0, 0.0), false)
             };
-            if !rounded {
-                blend(
-                    canvas,
-                    ((py as u32 * width + px as u32) * 4) as usize,
-                    color,
-                );
+            // Straight interior, or a square (non-rounded) corner: full coverage.
+            let coverage = if !rounded {
+                1.0
+            } else {
+                let dist = ((cx - arc.0).powi(2) + (cy - arc.1).powi(2)).sqrt();
+                (r + 0.5 - dist).clamp(0.0, 1.0)
+            };
+            if coverage <= 0.0 {
                 continue;
             }
-            let dx = if left_corner {
-                x + r - px
-            } else if right_corner {
-                px - (x + w - r - 1)
-            } else {
-                0
-            };
-            let dy = if top_corner {
-                y + r - py
-            } else if bottom_corner {
-                py - (y + h - r - 1)
-            } else {
-                0
-            };
-            if dx > 0 && dy > 0 && dx * dx + dy * dy > r2 {
-                continue;
-            }
-            blend(
+            blend_coverage(
                 canvas,
                 ((py as u32 * width + px as u32) * 4) as usize,
                 color,
+                coverage,
             );
         }
     }
@@ -979,6 +1125,12 @@ fn draw_raster(
             );
         }
     }
+}
+
+/// Source-over blend with the source alpha scaled by `coverage` (0..1) for anti-aliased edges.
+fn blend_coverage(canvas: &mut [u8], offset: usize, color: Color, coverage: f32) {
+    let Color(r, g, b, a) = color;
+    blend(canvas, offset, Color(r, g, b, a * coverage.clamp(0.0, 1.0)));
 }
 
 fn blend(canvas: &mut [u8], offset: usize, color: Color) {
@@ -1061,11 +1213,15 @@ fn themed_icon_root(root: PathBuf, config: &LensConfig) -> Option<PathBuf> {
     themed.is_dir().then_some(themed)
 }
 
-fn build_icon_index(config: &LensConfig) -> HashMap<String, IconIndexEntry> {
+fn build_icon_index(
+    roots: &[PathBuf],
+    search_depth: usize,
+    target_size: u32,
+) -> HashMap<String, IconIndexEntry> {
     let mut index = HashMap::<String, IconIndexEntry>::new();
-    for root in icon_roots(config) {
-        walk_files(root.as_path(), config.icon_search_depth, &mut |path| {
-            let Some((key, score)) = icon_index_candidate(path, config.icon_size) else {
+    for root in roots {
+        walk_icon_files(root.as_path(), search_depth, &mut |path| {
+            let Some((key, score)) = icon_index_candidate(path, target_size) else {
                 return;
             };
             let entry = IconIndexEntry {
@@ -1087,11 +1243,126 @@ fn build_icon_index(config: &LensConfig) -> HashMap<String, IconIndexEntry> {
 fn icon_index_candidate(path: &Path, target_size: u32) -> Option<(String, i32)> {
     let stem = path.file_stem()?.to_str()?.to_ascii_lowercase();
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    if !matches!(ext.as_str(), "svg" | "png" | "jpg" | "jpeg") {
+        return None;
+    }
+    Some((stem, icon_path_score(path, target_size)))
+}
+
+fn walk_icon_files(dir: &Path, depth: usize, f: &mut impl FnMut(&Path)) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_icon_files(path.as_path(), depth - 1, f);
+        } else {
+            f(path.as_path());
+        }
+    }
+}
+
+fn find_direct_icon(
+    roots: &[PathBuf],
+    candidates: &[String],
+    target_size: u32,
+    search_depth: usize,
+) -> Option<PathBuf> {
+    let mut best: Option<(i32, PathBuf)> = None;
+    for root in roots {
+        for lookup_root in direct_icon_roots(root.as_path(), search_depth) {
+            for candidate in candidates {
+                for path in direct_icon_candidates(lookup_root.as_path(), candidate, target_size) {
+                    if !path.is_file() {
+                        continue;
+                    }
+                    let score = icon_path_score(path.as_path(), target_size);
+                    let replace = best.as_ref().is_none_or(|(best_score, best_path)| {
+                        score < *best_score || (score == *best_score && path < *best_path)
+                    });
+                    if replace {
+                        best = Some((score, path));
+                    }
+                }
+            }
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+fn direct_icon_roots(root: &Path, search_depth: usize) -> Vec<PathBuf> {
+    let mut roots = vec![root.to_path_buf()];
+    if search_depth <= 1 {
+        return roots;
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return roots;
+    };
+    roots.extend(
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir()),
+    );
+    roots
+}
+
+fn direct_icon_candidates(root: &Path, name: &str, target_size: u32) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let filenames = icon_filenames(name);
+    let size_dir = format!("{}x{}", target_size, target_size);
+    let dirs = [
+        root.to_path_buf(),
+        root.join("apps"),
+        root.join("scalable"),
+        root.join("scalable/apps"),
+        root.join(size_dir.as_str()),
+        root.join(format!("{size_dir}/apps")),
+        root.join("48x48/apps"),
+        root.join("64x64/apps"),
+        root.join("128x128/apps"),
+        root.join("256x256/apps"),
+        root.join("hicolor/scalable/apps"),
+        root.join(format!("hicolor/{size_dir}/apps")),
+        root.join("hicolor/48x48/apps"),
+        root.join("hicolor/64x64/apps"),
+        root.join("hicolor/128x128/apps"),
+        root.join("hicolor/256x256/apps"),
+    ];
+    for dir in dirs {
+        for filename in &filenames {
+            paths.push(dir.join(filename));
+        }
+    }
+    paths
+}
+
+fn icon_filenames(name: &str) -> Vec<String> {
+    let path = Path::new(name);
+    if path.extension().is_some() {
+        return vec![name.to_string()];
+    }
+    ["svg", "png", "jpg", "jpeg"]
+        .into_iter()
+        .map(|ext| format!("{name}.{ext}"))
+        .collect()
+}
+
+fn icon_path_score(path: &Path, target_size: u32) -> i32 {
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     let format_score = match ext.as_str() {
         "svg" => 0,
         "png" => 20,
         "jpg" | "jpeg" => 40,
-        _ => return None,
+        _ => 80,
     };
     let size_score = icon_size_hint(path)
         .map(|size| (size as i32 - target_size as i32).abs())
@@ -1101,7 +1372,7 @@ fn icon_index_candidate(path: &Path, target_size: u32) -> Option<(String, i32)> 
     } else {
         0
     };
-    Some((stem, format_score + size_score + theme_score))
+    format_score + size_score + theme_score
 }
 
 fn icon_size_hint(path: &Path) -> Option<u32> {
@@ -1117,23 +1388,6 @@ fn icon_size_hint(path: &Path) -> Option<u32> {
         }
     }
     None
-}
-
-fn walk_files(dir: &Path, depth: usize, f: &mut impl FnMut(&Path)) {
-    if depth == 0 {
-        return;
-    }
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            walk_files(path.as_path(), depth - 1, f);
-        } else {
-            f(path.as_path());
-        }
-    }
 }
 
 fn load_icon(path: &Path, target_size: u32) -> Option<IconRaster> {
@@ -1170,11 +1424,10 @@ fn normalize_icon_canvas(source: RgbaImage, target_size: u32) -> RgbaImage {
 
 fn load_svg_icon(path: &Path, target_size: u32) -> Option<IconRaster> {
     let target_size = target_size.max(1);
-    let mut options = usvg::Options {
+    let options = usvg::Options {
         resources_dir: path.parent().map(Path::to_path_buf),
         ..usvg::Options::default()
     };
-    options.fontdb_mut().load_system_fonts();
     let data = fs::read(path).ok()?;
     let tree = usvg::Tree::from_data(&data, &options).ok()?;
     let svg_size = tree.size().to_int_size();

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -1297,6 +1297,7 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
             let xwayland_watch_tokens_for_timer = xwayland_watch_tokens.clone();
             let _signal = ev.get_signal();
             let mut state = Halley::new(&dh, ev.handle(), tuning.clone());
+            state.runtime.wayland_display = Some(sock_name.clone());
             state.apply_aperture_config(aperture_config);
             let capture_dmabuf_formats = {
                 let mut gpu_manager = drm_probe.gpu_manager.borrow_mut();

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -370,6 +370,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
             let xwayland_watch_tokens_for_timer = xwayland_watch_tokens.clone();
             let _signal = ev.get_signal();
             let mut state = Halley::new(&dh, ev.handle(), tuning.clone());
+            state.runtime.wayland_display = Some(sock_name.clone());
             state.apply_aperture_config(aperture_config);
             state.platform.seat.add_pointer();
             super::initialize_seat_keyboard(&mut state);

--- a/crates/halley-wl/src/compositor/clusters/state.rs
+++ b/crates/halley-wl/src/compositor/clusters/state.rs
@@ -6,10 +6,26 @@ use halley_core::field::{NodeId, Vec2};
 use halley_core::tiling::Rect;
 use halley_core::viewport::Viewport;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ClusterFinalizeAppLaunch {
+    pub(crate) app_id: String,
+    pub(crate) command: String,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct ClusterFinalizeDraftState {
     pub(crate) app_ids: Vec<String>,
+    pub(crate) app_launches: Vec<ClusterFinalizeAppLaunch>,
     pub(crate) selected_node_ids: HashSet<NodeId>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PendingLensClusterBuildState {
+    pub(crate) selected_node_ids: HashSet<NodeId>,
+    pub(crate) app_launches: Vec<ClusterFinalizeAppLaunch>,
+    pub(crate) name_record: ClusterNameRecord,
+    pub(crate) expected_members: usize,
+    pub(crate) launched: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -51,6 +67,7 @@ pub(crate) struct ClusterState {
     pub(crate) cluster_names: HashMap<ClusterId, ClusterNameRecord>,
     pub(crate) cluster_name_prompt: HashMap<String, ClusterNamingPromptState>,
     pub(crate) cluster_finalize_drafts: HashMap<String, ClusterFinalizeDraftState>,
+    pub(crate) pending_lens_cluster_builds: HashMap<String, PendingLensClusterBuildState>,
     pub(crate) active_cluster_workspaces: HashMap<String, ClusterId>,
     pub(crate) cluster_bloom_open: HashMap<String, ClusterId>,
     pub(crate) cluster_mode_selected_nodes: HashMap<String, HashSet<NodeId>>,

--- a/crates/halley-wl/src/compositor/clusters/system/naming.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/naming.rs
@@ -1,12 +1,13 @@
 use super::*;
 
 use crate::compositor::clusters::state::{
-    ClusterFinalizeDraftState, ClusterNameRecord, ClusterNamingPromptState,
+    ClusterFinalizeAppLaunch, ClusterFinalizeDraftState, ClusterNameRecord,
+    ClusterNamingPromptState, PendingLensClusterBuildState,
 };
 use crate::compositor::interaction::state::{
     ClusterNamePromptRepeatAction, ClusterNamePromptRepeatState,
 };
-use halley_core::field::NodeId;
+use halley_core::field::{NodeId, NodeKind, NodeState};
 
 pub(super) fn cluster_mode_selection_banner(
     controller: &mut impl DerefMut<Target = Halley>,
@@ -168,6 +169,22 @@ impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
             .contains_key(monitor)
     }
 
+    pub(crate) fn active_cluster_name_prompt_monitor(&self, preferred: &str) -> Option<String> {
+        if self.cluster_name_prompt_active_for_monitor(preferred) {
+            return Some(preferred.to_string());
+        }
+        (self.model.cluster_state.cluster_name_prompt.len() == 1)
+            .then(|| {
+                self.model
+                    .cluster_state
+                    .cluster_name_prompt
+                    .keys()
+                    .next()
+                    .cloned()
+            })
+            .flatten()
+    }
+
     pub(crate) fn cluster_name_record(&self, cid: ClusterId) -> Option<&ClusterNameRecord> {
         self.model.cluster_state.cluster_names.get(&cid)
     }
@@ -239,6 +256,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         name_hint: Option<&str>,
         select_all: bool,
+        show_banner: bool,
     ) -> bool {
         let generated_generic_name = format!(
             "Cluster {}",
@@ -264,7 +282,11 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             },
         );
         self.begin_modal_keyboard_capture();
-        cluster_name_prompt_banner(self, monitor);
+        if show_banner {
+            cluster_name_prompt_banner(self, monitor);
+        } else {
+            self.ui.render_state.remove_persistent_mode_banner(monitor);
+        }
         true
     }
 
@@ -273,19 +295,47 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         name_hint: Option<String>,
         app_ids: Vec<String>,
+        app_launches: Vec<ClusterFinalizeAppLaunch>,
         running_node_ids: Vec<NodeId>,
         now: Instant,
     ) -> bool {
-        let selected = running_node_ids
+        let app_launches = normalized_draft_app_launches(app_launches);
+        let mut app_ids = normalized_draft_app_ids(app_ids);
+        for launch in &app_launches {
+            let folded = launch.app_id.trim().to_ascii_lowercase();
+            if !folded.is_empty() && !app_ids.iter().any(|existing| existing == &folded) {
+                app_ids.push(folded);
+            }
+        }
+        let mut selected = running_node_ids
             .into_iter()
             .filter(|node_id| {
                 self.model.field.node(*node_id).is_some_and(|node| {
-                    node.kind == halley_core::field::NodeKind::Surface
-                        && node.state != halley_core::field::NodeState::Core
+                    node.kind == NodeKind::Surface
+                        && node.state != NodeState::Core
                         && self.model.field.is_visible(*node_id)
                 })
             })
             .collect::<std::collections::HashSet<_>>();
+        for (&node_id, node) in self.model.field.nodes() {
+            if node.kind != NodeKind::Surface
+                || node.state == NodeState::Core
+                || !self.model.field.is_visible(node_id)
+                || self
+                    .model
+                    .monitor_state
+                    .node_monitor
+                    .get(&node_id)
+                    .is_none_or(|node_monitor| node_monitor != monitor)
+            {
+                continue;
+            }
+            if let Some(app_id) = self.model.node_app_ids.get(&node_id)
+                && draft_app_ids_match(&app_ids, app_id)
+            {
+                selected.insert(node_id);
+            }
+        }
         self.model
             .cluster_state
             .cluster_mode_selected_nodes
@@ -293,7 +343,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         self.model.cluster_state.cluster_finalize_drafts.insert(
             monitor.to_string(),
             ClusterFinalizeDraftState {
-                app_ids: normalized_draft_app_ids(app_ids),
+                app_ids,
+                app_launches,
                 selected_node_ids: selected,
             },
         );
@@ -301,8 +352,12 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             .as_deref()
             .map(str::trim)
             .is_none_or(str::is_empty);
-        let opened =
-            self.open_cluster_name_prompt_for_monitor(monitor, name_hint.as_deref(), select_all);
+        let opened = self.open_cluster_name_prompt_for_monitor(
+            monitor,
+            name_hint.as_deref(),
+            select_all,
+            false,
+        );
         if opened {
             self.request_maintenance();
         } else {
@@ -329,6 +384,35 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         if app_id.is_empty() {
             return false;
         }
+        if let Some(build) = self
+            .model
+            .cluster_state
+            .pending_lens_cluster_builds
+            .get_mut(monitor)
+        {
+            let app_ids = build
+                .app_launches
+                .iter()
+                .map(|launch| launch.app_id.clone())
+                .collect::<Vec<_>>();
+            if !draft_app_ids_match(&app_ids, app_id) {
+                return false;
+            }
+            if !build.selected_node_ids.insert(node_id) {
+                return false;
+            }
+            self.model
+                .spawn_state
+                .pending_initial_reveal
+                .remove(&node_id);
+            let _ = self.model.field.set_detached(node_id, true);
+            let completed = self.try_complete_pending_lens_cluster_build(monitor, Instant::now());
+            if !completed {
+                self.request_maintenance();
+            }
+            return true;
+        }
+
         let Some(draft) = self
             .model
             .cluster_state
@@ -340,17 +424,17 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         if !draft_app_ids_match(&draft.app_ids, app_id) {
             return false;
         }
-        if !draft.selected_node_ids.insert(node_id) {
-            return false;
-        }
+        let inserted = draft.selected_node_ids.insert(node_id);
         self.model
             .cluster_state
             .cluster_mode_selected_nodes
             .entry(monitor.to_string())
             .or_default()
             .insert(node_id);
-        self.request_maintenance();
-        true
+        if inserted {
+            self.request_maintenance();
+        }
+        inserted
     }
 
     fn record_cluster_slot_for_monitor(&mut self, cid: ClusterId, monitor: &str) {
@@ -478,7 +562,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         }
 
         let _ = now;
-        self.open_cluster_name_prompt_for_monitor(monitor.as_str(), None, true)
+        self.open_cluster_name_prompt_for_monitor(monitor.as_str(), None, true, true)
     }
 
     pub(crate) fn cancel_cluster_name_prompt_for_monitor(&mut self, monitor: &str) -> bool {
@@ -746,6 +830,187 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         handled
     }
 
+    fn prompt_name_record(
+        &self,
+        monitor: &str,
+        prompt: &ClusterNamingPromptState,
+    ) -> ClusterNameRecord {
+        let submitted = prompt.input.trim();
+        let reserved_generic = parse_reserved_generic_cluster_name(submitted).is_some();
+        let exact_default = submitted.eq_ignore_ascii_case(prompt.generated_generic_name.as_str());
+        if submitted.is_empty() || exact_default || reserved_generic {
+            ClusterNameRecord::Generic {
+                slot: self.next_generic_cluster_slot_for_monitor(monitor, None),
+            }
+        } else {
+            ClusterNameRecord::Custom {
+                name: self.resolve_unique_custom_cluster_name(submitted, None),
+            }
+        }
+    }
+
+    fn selected_has_matching_app(
+        &self,
+        selected_nodes: &std::collections::HashSet<NodeId>,
+        app_id: &str,
+    ) -> bool {
+        selected_nodes.iter().any(|node_id| {
+            self.model
+                .node_app_ids
+                .get(node_id)
+                .is_some_and(|node_app_id| draft_app_ids_match(&[app_id.to_string()], node_app_id))
+        })
+    }
+
+    fn pending_lens_expected_members(
+        &self,
+        selected_nodes: &std::collections::HashSet<NodeId>,
+        app_launches: &[ClusterFinalizeAppLaunch],
+    ) -> usize {
+        let missing_launches = app_launches
+            .iter()
+            .filter(|launch| {
+                !self.selected_has_matching_app(selected_nodes, launch.app_id.as_str())
+            })
+            .count();
+        (selected_nodes.len() + missing_launches).max(2)
+    }
+
+    fn start_pending_lens_cluster_build(
+        &mut self,
+        monitor: &str,
+        draft: ClusterFinalizeDraftState,
+        name_record: ClusterNameRecord,
+        now: Instant,
+    ) -> bool {
+        let expected_members = self
+            .pending_lens_expected_members(&draft.selected_node_ids, draft.app_launches.as_slice());
+        self.model.cluster_state.cluster_name_prompt.remove(monitor);
+        self.model
+            .cluster_state
+            .cluster_finalize_drafts
+            .remove(monitor);
+        let _ = self
+            .cluster_mutation_controller()
+            .exit_cluster_mode(monitor);
+        self.ui.render_state.clear_persistent_mode_banner(monitor);
+        self.model.cluster_state.pending_lens_cluster_builds.insert(
+            monitor.to_string(),
+            PendingLensClusterBuildState {
+                selected_node_ids: draft.selected_node_ids,
+                app_launches: draft.app_launches,
+                name_record,
+                expected_members,
+                launched: false,
+            },
+        );
+        if self.try_complete_pending_lens_cluster_build(monitor, now) {
+            return true;
+        }
+        self.launch_pending_lens_cluster_apps(monitor, now);
+        let now_ms = self.now_ms(now);
+        self.ui.render_state.show_overlay_toast(
+            monitor,
+            "Building cluster\nLaunching staged apps",
+            3000,
+            now_ms,
+        );
+        self.request_maintenance();
+        true
+    }
+
+    fn launch_pending_lens_cluster_apps(&mut self, monitor: &str, now: Instant) {
+        let (selected, launches) = {
+            let Some(build) = self
+                .model
+                .cluster_state
+                .pending_lens_cluster_builds
+                .get_mut(monitor)
+            else {
+                return;
+            };
+            if build.launched {
+                return;
+            }
+            build.launched = true;
+            (build.selected_node_ids.clone(), build.app_launches.clone())
+        };
+
+        let wayland_display = self
+            .runtime
+            .wayland_display
+            .clone()
+            .or_else(|| std::env::var("WAYLAND_DISPLAY").ok())
+            .unwrap_or_default();
+        self.model.spawn_state.pending_spawn_monitor = Some(monitor.to_string());
+        for launch in launches {
+            if self.selected_has_matching_app(&selected, launch.app_id.as_str()) {
+                continue;
+            }
+            if launch.command.trim().is_empty() {
+                continue;
+            }
+            if let Some(child) = crate::input::keyboard::spawn::spawn_command(
+                launch.command.as_str(),
+                wayland_display.as_str(),
+                &self.runtime.tuning.cursor,
+                None,
+                "lens cluster app",
+            ) {
+                self.runtime.spawned_children.push(child);
+            }
+        }
+        let _ = now;
+    }
+
+    fn try_complete_pending_lens_cluster_build(&mut self, monitor: &str, now: Instant) -> bool {
+        let Some(build) = self
+            .model
+            .cluster_state
+            .pending_lens_cluster_builds
+            .get(monitor)
+            .cloned()
+        else {
+            return false;
+        };
+        if build.selected_node_ids.len() < build.expected_members
+            || build.selected_node_ids.len() < 2
+        {
+            return false;
+        }
+        let members =
+            self.order_cluster_creation_members(build.selected_node_ids.iter().copied().collect());
+        for member in &members {
+            let _ = self.model.field.set_detached(*member, false);
+        }
+        let now_ms = self.now_ms(now);
+        let created = self.create_cluster(members).ok().and_then(|cid| {
+            self.model
+                .cluster_state
+                .cluster_names
+                .insert(cid, build.name_record.clone());
+            let core = self.collapse_cluster(cid);
+            if let Some(core_id) = core {
+                self.assign_node_to_monitor(core_id, monitor);
+                let _ = self.sync_cluster_name_for_monitor(cid, monitor);
+                let _ = self.model.field.touch(core_id, now_ms);
+                self.set_interaction_focus(Some(core_id), 30_000, now);
+            }
+            core
+        });
+        if created.is_none() {
+            return false;
+        }
+        self.model
+            .cluster_state
+            .pending_lens_cluster_builds
+            .remove(monitor);
+        self.ui
+            .render_state
+            .show_overlay_toast(monitor, "Cluster ready", 1800, now_ms);
+        true
+    }
+
     pub(crate) fn confirm_cluster_name_prompt_for_monitor(
         &mut self,
         monitor: &str,
@@ -765,25 +1030,41 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             .cluster_state
             .cluster_mode_selected_nodes
             .get(monitor)
+            .cloned()
         else {
             return false;
         };
+        let draft = self
+            .model
+            .cluster_state
+            .cluster_finalize_drafts
+            .get(monitor)
+            .cloned();
+        let name_record = self.prompt_name_record(monitor, &prompt);
+        if let Some(draft) = draft.clone()
+            && !draft.app_launches.is_empty()
+        {
+            return self.start_pending_lens_cluster_build(monitor, draft, name_record, now);
+        }
         if selected_nodes.len() < 2 {
+            if self
+                .model
+                .cluster_state
+                .cluster_finalize_drafts
+                .contains_key(monitor)
+            {
+                let now_ms = self.now_ms(now);
+                self.ui.render_state.show_overlay_toast(
+                    monitor,
+                    "Waiting for staged apps\nNeed at least two windows",
+                    3000,
+                    now_ms,
+                );
+                return true;
+            }
             return false;
         }
         let members = self.order_cluster_creation_members(selected_nodes.iter().copied().collect());
-        let submitted = prompt.input.trim();
-        let reserved_generic = parse_reserved_generic_cluster_name(submitted).is_some();
-        let exact_default = submitted.eq_ignore_ascii_case(prompt.generated_generic_name.as_str());
-        let name_record = if submitted.is_empty() || exact_default || reserved_generic {
-            ClusterNameRecord::Generic {
-                slot: self.next_generic_cluster_slot_for_monitor(monitor, None),
-            }
-        } else {
-            ClusterNameRecord::Custom {
-                name: self.resolve_unique_custom_cluster_name(submitted, None),
-            }
-        };
         let now_ms = self.now_ms(now);
         let created = self.create_cluster(members).ok().and_then(|cid| {
             self.model
@@ -834,12 +1115,41 @@ fn normalized_draft_app_ids(app_ids: Vec<String>) -> Vec<String> {
     out
 }
 
+fn normalized_draft_app_launches(
+    app_launches: Vec<ClusterFinalizeAppLaunch>,
+) -> Vec<ClusterFinalizeAppLaunch> {
+    let mut out = Vec::new();
+    for launch in app_launches {
+        let app_id = launch.app_id.trim().to_ascii_lowercase();
+        let command = launch.command.trim().to_string();
+        if app_id.is_empty() || command.is_empty() {
+            continue;
+        }
+        if out
+            .iter()
+            .any(|existing: &ClusterFinalizeAppLaunch| existing.app_id == app_id)
+        {
+            continue;
+        }
+        out.push(ClusterFinalizeAppLaunch { app_id, command });
+    }
+    out
+}
+
 fn draft_app_ids_match(app_ids: &[String], app_id: &str) -> bool {
     let folded = app_id.to_ascii_lowercase();
     app_ids.iter().any(|candidate| {
         candidate == &folded
             || folded.ends_with(candidate)
             || candidate.ends_with(&folded)
-            || folded.rsplit(['.', '/']).next() == Some(candidate.as_str())
+            || compact_app_match_token(folded.as_str()) == compact_app_match_token(candidate)
     })
+}
+
+fn compact_app_match_token(value: &str) -> Option<&str> {
+    value
+        .trim_end_matches(".desktop")
+        .rsplit(['.', '/'])
+        .next()
+        .filter(|token| !token.is_empty())
 }

--- a/crates/halley-wl/src/compositor/clusters/system/tests.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/tests.rs
@@ -326,6 +326,145 @@ fn cluster_mode_confirm_opens_name_prompt_before_creating() {
 }
 
 #[test]
+fn lens_finalize_prompt_selects_existing_matching_apps_without_banner() {
+    let dh = Display::<Halley>::new().expect("display").handle();
+    let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+    let now = Instant::now();
+
+    let first = st.model.field.spawn_surface(
+        "Firefox",
+        Vec2 { x: 160.0, y: 160.0 },
+        Vec2 { x: 220.0, y: 160.0 },
+    );
+    let second = st.model.field.spawn_surface(
+        "Firefox Settings",
+        Vec2 { x: 460.0, y: 160.0 },
+        Vec2 { x: 220.0, y: 160.0 },
+    );
+    st.assign_node_to_monitor(first, "monitor_a");
+    st.assign_node_to_monitor(second, "monitor_a");
+    st.model.node_app_ids.insert(first, "firefox".to_string());
+    st.model
+        .node_app_ids
+        .insert(second, "org.mozilla.firefox".to_string());
+
+    assert!(
+        cluster_system_controller(&mut st).open_lens_cluster_finalize_draft(
+            "monitor_a",
+            Some("Browser".to_string()),
+            vec!["org.mozilla.firefox.desktop".to_string()],
+            Vec::new(),
+            Vec::new(),
+            now,
+        )
+    );
+    assert!(
+        !st.ui
+            .render_state
+            .overlays
+            .overlay_banner
+            .contains_key("monitor_a")
+    );
+    assert_eq!(
+        st.model
+            .cluster_state
+            .cluster_mode_selected_nodes
+            .get("monitor_a")
+            .map(|nodes| nodes.len()),
+        Some(2)
+    );
+
+    assert!(
+        cluster_system_controller(&mut st)
+            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
+    );
+    assert_eq!(st.model.field.cluster_ids().len(), 1);
+    assert!(
+        !st.model
+            .cluster_state
+            .cluster_name_prompt
+            .contains_key("monitor_a")
+    );
+}
+
+#[test]
+fn lens_finalize_launches_after_confirm_and_absorbs_matching_windows() {
+    let dh = Display::<Halley>::new().expect("display").handle();
+    let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
+    let now = Instant::now();
+
+    assert!(
+        cluster_system_controller(&mut st).open_lens_cluster_finalize_draft(
+            "monitor_a",
+            Some("Work".to_string()),
+            vec!["alpha.desktop".to_string(), "beta.desktop".to_string()],
+            vec![
+                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                    app_id: "alpha.desktop".to_string(),
+                    command: "true".to_string(),
+                },
+                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                    app_id: "beta.desktop".to_string(),
+                    command: "true".to_string(),
+                },
+            ],
+            Vec::new(),
+            now,
+        )
+    );
+    assert!(
+        cluster_system_controller(&mut st)
+            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
+    );
+    assert!(
+        st.model
+            .cluster_state
+            .pending_lens_cluster_builds
+            .contains_key("monitor_a")
+    );
+    assert_eq!(st.model.field.cluster_ids().len(), 0);
+
+    let alpha = st.model.field.spawn_surface(
+        "Alpha",
+        Vec2 { x: 160.0, y: 160.0 },
+        Vec2 { x: 220.0, y: 160.0 },
+    );
+    let beta = st.model.field.spawn_surface(
+        "Beta",
+        Vec2 { x: 460.0, y: 160.0 },
+        Vec2 { x: 220.0, y: 160.0 },
+    );
+    st.assign_node_to_monitor(alpha, "monitor_a");
+    st.assign_node_to_monitor(beta, "monitor_a");
+
+    assert!(
+        cluster_system_controller(&mut st).maybe_add_node_to_lens_cluster_finalize_draft(
+            "monitor_a",
+            alpha,
+            "alpha",
+        )
+    );
+    assert_eq!(st.model.field.cluster_ids().len(), 0);
+    assert!(
+        cluster_system_controller(&mut st).maybe_add_node_to_lens_cluster_finalize_draft(
+            "monitor_a",
+            beta,
+            "beta",
+        )
+    );
+
+    assert_eq!(st.model.field.cluster_ids().len(), 1);
+    assert!(
+        !st.model
+            .cluster_state
+            .pending_lens_cluster_builds
+            .contains_key("monitor_a")
+    );
+    assert!(st.model.field.cluster_id_for_member_public(alpha).is_some());
+    assert!(st.model.field.cluster_id_for_member_public(beta).is_some());
+}
+
+#[test]
 fn custom_cluster_name_stays_unique_and_survives_monitor_move() {
     let dh = Display::<Halley>::new().expect("display").handle();
     let mut st = Halley::new_for_test(&dh, dual_monitor_tuning());

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -269,6 +269,7 @@ impl Halley {
                     cluster_names: HashMap::new(),
                     cluster_name_prompt: HashMap::new(),
                     cluster_finalize_drafts: HashMap::new(),
+                    pending_lens_cluster_builds: HashMap::new(),
                     active_cluster_workspaces: HashMap::new(),
                     cluster_bloom_open: HashMap::new(),
                     cluster_mode_selected_nodes: HashMap::new(),
@@ -433,6 +434,7 @@ impl Halley {
                 pending_drm_syncobj_surfaces: Arc::new(Mutex::new(Vec::new())),
                 activation: Default::default(),
                 spawned_children: Vec::new(),
+                wayland_display: None,
             },
         };
         out.ui

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1432,11 +1432,6 @@ impl Halley {
     }
 
     #[cfg(test)]
-    pub(crate) fn spawn_star_step(&self, size: Vec2) -> f32 {
-        super::spawn::reveal::spawn_reveal_controller(self).spawn_star_step(size)
-    }
-
-    #[cfg(test)]
     pub(crate) fn star_candidate_offsets(&self, size: Vec2) -> Vec<Vec2> {
         super::spawn::reveal::spawn_reveal_controller(self).star_candidate_offsets(size)
     }
@@ -1553,16 +1548,6 @@ impl Halley {
     ) -> bool {
         super::clusters::system::cluster_system_controller(self)
             .enter_cluster_workspace_by_core(core_id, monitor, now)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn exit_cluster_workspace_for_monitor(
-        &mut self,
-        monitor: &str,
-        now: Instant,
-    ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .exit_cluster_workspace_for_monitor(monitor, now)
     }
 
     pub fn open_cluster_bloom_for_monitor(

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -32,6 +32,7 @@ pub(crate) struct RuntimeState {
     pub(crate) pending_drm_syncobj_surfaces: Arc<Mutex<Vec<ObjectId>>>,
     pub(crate) activation: ActivationRuntimeState,
     pub(crate) spawned_children: Vec<std::process::Child>,
+    pub(crate) wayland_display: Option<String>,
 }
 
 pub(crate) struct RuntimeController<T> {

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -241,12 +241,6 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
             + SPAWN_CONTACT_MARGIN
     }
 
-    #[cfg(test)]
-    pub(crate) fn spawn_star_step(&self, size: Vec2) -> f32 {
-        self.spawn_star_step_x(size)
-            .max(self.spawn_star_step_y(size))
-    }
-
     pub(crate) fn star_candidate_offsets(&self, size: Vec2) -> Vec<Vec2> {
         let step_x = self.spawn_star_step_x(size);
         let step_y = self.spawn_star_step_y(size);

--- a/crates/halley-wl/src/frame_loop/activity.rs
+++ b/crates/halley-wl/src/frame_loop/activity.rs
@@ -71,6 +71,65 @@ fn monitor_overlay_requires_full_repaint_at(st: &Halley, monitor: &str, now_ms: 
             .contains_key(monitor)
 }
 
+fn monitor_overlay_animation_active_at(st: &Halley, monitor: &str, now_ms: u64) -> bool {
+    if now_ms < st.runtime.screenshot_full_repaint_until_ms || st.runtime.tuning.debug.overlay_fps {
+        return true;
+    }
+    st.cluster_mode_active_for_monitor(monitor)
+        || st
+            .model
+            .cluster_state
+            .cluster_bloom_open
+            .contains_key(monitor)
+        || st
+            .model
+            .cluster_state
+            .cluster_overflow_visible_until_ms
+            .get(monitor)
+            .is_some_and(|visible_until_ms| *visible_until_ms > now_ms)
+        || st
+            .model
+            .cluster_state
+            .cluster_overflow_promotion_anim
+            .contains_key(monitor)
+        || crate::compositor::interaction::state::bloom_pull_preview_active_for_monitor(st, monitor)
+        || st
+            .ui
+            .render_state
+            .overlays
+            .overlay_banner
+            .contains_key(monitor)
+        || st
+            .ui
+            .render_state
+            .overlays
+            .overlay_toast
+            .contains_key(monitor)
+        || st
+            .model
+            .focus_state
+            .focus_ring_preview_until_ms
+            .get(monitor)
+            .is_some_and(|until_ms| *until_ms > now_ms)
+        || st.input.interaction_state.focus_cycle_session.is_some()
+        || cluster_name_prompt_hover_animating(st, monitor)
+        || screenshot_controller(st).screenshot_session_active()
+        || st
+            .ui
+            .render_state
+            .overlays
+            .overlay_exit_confirm
+            .contains_key(monitor)
+}
+
+fn cluster_name_prompt_hover_animating(st: &Halley, monitor: &str) -> bool {
+    st.model
+        .cluster_state
+        .cluster_name_prompt
+        .get(monitor)
+        .is_some_and(|prompt| prompt.confirm_hover_mix > 0.015 && prompt.confirm_hover_mix < 0.985)
+}
+
 pub(crate) fn tty_output_animation_redraw_state(
     st: &Halley,
     monitor: &str,
@@ -162,7 +221,7 @@ pub(crate) fn tty_output_animation_redraw_state(
             || (st.model.viewport.center.y - st.model.camera_target_center.y).abs() > 0.05
             || (st.model.zoom_ref_size.x - st.model.camera_target_view_size.x).abs() > 0.05
             || (st.model.zoom_ref_size.y - st.model.camera_target_view_size.y).abs() > 0.05);
-    let overlay_active = monitor_overlay_requires_full_repaint_at(st, monitor, now_ms)
+    let overlay_active = monitor_overlay_animation_active_at(st, monitor, now_ms)
         || st
             .ui
             .render_state

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -290,10 +290,9 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
         return;
     }
 
-    let prompt_monitor = st.model.monitor_state.current_monitor.clone();
-    if crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .cluster_name_prompt_active_for_monitor(prompt_monitor.as_str())
-    {
+    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
+        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
+    if let Some(prompt_monitor) = prompt_monitor {
         let mut repeated_char = None;
         if let Some(keyboard) = st.platform.seat.get_keyboard() {
             let _ = keyboard.input::<(), _>(

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -154,7 +154,8 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
         )
     ) || ps.drag.is_some()
         || ps.resize.is_some();
-    let prompt_monitor = st.model.monitor_state.current_monitor.clone();
+    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
+        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
     if handle_screenshot_pointer_button(
         st,
         ctx,
@@ -172,8 +173,7 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
     ) {
         return;
     }
-    if crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .cluster_name_prompt_active_for_monitor(prompt_monitor.as_str())
+    if let Some(prompt_monitor) = prompt_monitor
         && !cluster_pointer_passthrough
     {
         ps.world = world_now;

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -198,10 +198,9 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
         return;
     }
 
-    let prompt_monitor = st.model.monitor_state.current_monitor.clone();
-    if crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .cluster_name_prompt_active_for_monitor(prompt_monitor.as_str())
-    {
+    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
+        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
+    if let Some(prompt_monitor) = prompt_monitor {
         let prompt_hit = if routing.monitor == prompt_monitor {
             crate::overlay::cluster_naming_dialog_hit_test(
                 st,

--- a/crates/halley-wl/src/ipc/cluster.rs
+++ b/crates/halley-wl/src/ipc/cluster.rs
@@ -1,6 +1,7 @@
 use halley_api::{
-    ApiError, ClusterDraftRequest, ClusterInfo, ClusterLayoutKind, ClusterListResponse,
-    ClusterOutputGroup, ClusterRequest, ClusterSummary, ClusterTarget, Response,
+    ApiError, ClusterDraftAppLaunch, ClusterDraftRequest, ClusterInfo, ClusterLayoutKind,
+    ClusterListResponse, ClusterOutputGroup, ClusterRequest, ClusterSummary, ClusterTarget,
+    Response,
 };
 use halley_core::cluster::ClusterId;
 use halley_core::cluster_layout::ClusterWorkspaceLayoutKind as CoreClusterLayoutKind;
@@ -120,6 +121,7 @@ fn open_finalize_draft(
             monitor.as_str(),
             draft.name_hint,
             draft.app_ids,
+            draft_app_launches(draft.app_launches),
             running_node_ids,
             now,
         )
@@ -130,6 +132,20 @@ fn open_finalize_draft(
             "failed to open cluster finalize draft on output {monitor}"
         )))
     }
+}
+
+fn draft_app_launches(
+    app_launches: Vec<ClusterDraftAppLaunch>,
+) -> Vec<crate::compositor::clusters::state::ClusterFinalizeAppLaunch> {
+    app_launches
+        .into_iter()
+        .map(
+            |launch| crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: launch.app_id,
+                command: launch.command,
+            },
+        )
+        .collect()
 }
 
 fn activate_cluster_slot(st: &mut Halley, slot: u8, output: Option<&str>) -> Result<(), ApiError> {

--- a/crates/halley-wl/src/ipc/node.rs
+++ b/crates/halley-wl/src/ipc/node.rs
@@ -110,10 +110,13 @@ pub(super) fn focus_node(st: &mut Halley, id: NodeId, now: Instant) -> Result<()
         FieldNodeState::Active | FieldNodeState::Drifting => {
             st.set_interaction_focus(Some(id), 30_000, now);
             let _ = st.animate_viewport_center_to(node.pos, now);
+            let _ = crate::compositor::interaction::pointer::center_pointer_on_node(st, id, now);
             Ok(())
         }
         FieldNodeState::Node => {
             if promote_node_level(st, id, now) {
+                let _ =
+                    crate::compositor::interaction::pointer::center_pointer_on_node(st, id, now);
                 Ok(())
             } else {
                 Err(ApiError::Internal(format!(

--- a/crates/halley-wl/src/overlay/cluster_naming.rs
+++ b/crates/halley-wl/src/overlay/cluster_naming.rs
@@ -407,7 +407,7 @@ pub(crate) fn draw_cluster_naming_dialog(
             &visuals,
             layout.input_rect,
             12.0,
-            visuals.palette.key_fill.alpha(0.98),
+            visuals.palette.key_fill.alpha(1.0),
             true,
             damage,
             1.0,

--- a/crates/halley-wl/src/render/state/mod.rs
+++ b/crates/halley-wl/src/render/state/mod.rs
@@ -790,6 +790,10 @@ impl RenderState {
         }
     }
 
+    pub(crate) fn remove_persistent_mode_banner(&mut self, monitor: &str) {
+        self.overlays.overlay_banner.remove(monitor);
+    }
+
     pub(crate) fn persistent_mode_banner_snapshot(
         &mut self,
         monitor: &str,

--- a/examples/lens.rune
+++ b/examples/lens.rune
@@ -11,6 +11,7 @@ lens:
   icon-size 28
   icon-theme "auto"
   icon-search-depth 5
+  terminal "x-terminal-emulator -e"
   keyboard-interactivity "exclusive"
   close-on-focus-loss false
   close-on-click-away false


### PR DESCRIPTION
## Summary

This PR reworks Halley Lens to keep startup and interactive search responsive while preserving broad desktop app and icon coverage. It also replaces badge-based modes with explicit query prefixes, tightens cluster drafting behavior, adds configurable terminal launching for terminal `.desktop` entries, and carries staged app launches through the compositor so Lens-created clusters can include newly launched windows.

This also bumps the main workspace-owned crates from `0.3.2` to `0.4.0` and refreshes `Cargo.lock`. `halley-api`, `halley-aperture`, and `halley-lens` remain on their independent `0.1.0` version lines.

## Highlights

### Responsive Lens search

* Precompute desktop app search text.
* Cache node and cluster IPC state from an asynchronous refresh.
* Resolve icons cheaply for visible rows first.
* Build the broader icon index in the background after the first draw.
* Ellipsize long search text from the left so the newest input stays visible.
* Clip long result titles and subtitles before they overlap shortcut hints.

### Explicit prefix-based filtering

Lens modes are now expressed directly in the query instead of being rewritten into badges.

Supported examples include:

* `app firefox`
* `action open`
* `cluster release`
* `/app firefox`
* `/action open`
* `/cluster release`

This keeps the search field honest: what the user typed is what Lens searches.

### Explicit cluster drafting

Cluster drafting is now limited to `cluster` and `/cluster` searches.

* `Space` inserts normal text outside cluster searches.
* In cluster search, `Space` stages or unstages the selected app or running node.
* Draft summaries, staged checkmarks, and `Create cluster` only appear in cluster mode once selections exist.
* `Ctrl+Enter` refuses to finalize unless Lens is in cluster search with a non-empty staged draft.
* Empty cluster searches remain useful for staging by refreshing results and avoiding max-result truncation.

### Cluster creation from staged app launches

Lens now carries app launch metadata through the API so the compositor can launch missing staged apps only after the cluster naming prompt is confirmed.

* Add `ClusterDraftAppLaunch` to the public API.
* Include staged app launch commands in Lens cluster draft requests.
* Move staged app launching from `halley-lens` into `halley-wl`.
* Let the compositor wait for newly mapped windows and absorb them into the pending cluster.
* Match existing visible windows by normalized app IDs before launching duplicates.
* Support `.desktop` and reverse-DNS app ID variants.
* Track pending Lens cluster builds with selected nodes, expected members, launch commands, and final cluster names.

### Terminal app launching

* Add `lens.terminal` for launching `.desktop` entries with `Terminal=true`.
* Terminal apps such as `micro` or `nvim` now use the configured terminal command instead of a hardcoded launcher.

### Compositor and overlay polish

* Center the pointer when focusing nodes through IPC.
* Suppress the cluster-mode banner for Lens finalize prompts while keeping the naming prompt active.
* Store the compositor Wayland display in runtime state so spawned apps target the correct display.
* Route keyboard and pointer input to the active cluster naming prompt monitor, including the single-prompt fallback case.
* Refine overlay animation redraw detection for banners, toasts, prompts, hover states, focus previews, screenshots, and exit confirmation overlays.

### Cleanup and docs

* Remove unused test-only Halley spawn and cluster helper methods.
* Keep workspace test builds warning-free.
* Update the Lens README.
* Update the example config.
* Update the changelog for prefix filtering, drafting, terminal app launching, and background icon indexing.

## Testing

Added and updated tests covering:

* Empty cluster staging searches.
* Existing-app selection without duplicate launches.
* Pending staged app cluster completion.
* Warning-free workspace test builds.

## Notes

The main behavioral change is that Lens no longer hides mode changes behind badges. Search intent is now visible in the query itself, and cluster creation is intentionally gated behind explicit `cluster` searches so normal launcher search stays predictable.
