### PR TITLE
Halley Lift: dedupe Actions entries; fix stuck-key repeat from portal chooser modal traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,10 @@ All notable changes to this project will be documented in this file.
   mutate underneath the fading overlay. Maximized and fullscreen windows no longer flash or
   displace when selected from the overview: the close animation flies back to the actual
   presentation visual rect instead of the stale windowed field position.
+- Move the "Open Lift config" and "Open Halley config" entries out of the Halley Lift Actions
+  mode and into the Config mode only (where they already existed). Actions now exposes just
+  "Reload Halley config"; both open-config entries remain reachable from the default General
+  search via the Config provider.
 
 ### Removed
 - Remove field parallax entirely, including `field.parallax` config parsing and generated-config

--- a/crates/halley-lift/src/providers.rs
+++ b/crates/halley-lift/src/providers.rs
@@ -373,30 +373,12 @@ fn create_cluster_result(_query: &str) -> LiftResult {
 }
 
 fn search_actions(ctx: &SearchContext) -> Vec<LiftResult> {
-    let actions = [
-        (
-            "reload-config",
-            "Reload Halley config",
-            "Compositor action",
-            LiftAction::ReloadConfig,
-        ),
-        (
-            "open-lift-config",
-            "Open Lift config",
-            "Config file",
-            LiftAction::OpenConfig {
-                path: default_config_path().display().to_string(),
-            },
-        ),
-        (
-            "open-halley-config",
-            "Open Halley config",
-            "Config file",
-            LiftAction::OpenConfig {
-                path: resolved_halley_config_path().display().to_string(),
-            },
-        ),
-    ];
+    let actions = [(
+        "reload-config",
+        "Reload Halley config",
+        "Compositor action",
+        LiftAction::ReloadConfig,
+    )];
     actions
         .into_iter()
         .filter_map(|(_id, title, subtitle, action)| {

--- a/crates/halley-wl/src/compositor/portal_chooser/mod.rs
+++ b/crates/halley-wl/src/compositor/portal_chooser/mod.rs
@@ -105,9 +105,13 @@ pub(crate) fn start_portal_chooser(
     }
     let monitor = chooser_monitor(st);
     st.begin_modal_keyboard_capture();
-    if let Some(enter) = halley_config::keybinds::key_name_to_evdev("return") {
-        crate::compositor::interaction::state::trap_modal_key_release(st, enter + 8);
-    }
+    // No open-time Enter pre-trap: `begin_modal_keyboard_capture` clears keyboard
+    // focus through the `set_keyboard_focus` choke point, whose
+    // `flush_stuck_forwarded_keys` already forwards a synthetic release for the
+    // held Enter to the app that invoked the portal (e.g. OBS) before focus drops
+    // to None. The chooser arms Enter/Escape traps at genuine confirm/cancel
+    // presses, and `finish_modal_capture` clears any leftover trap on teardown so
+    // none can outlive the chooser and strand a later key in client-side repeat.
     let menu_selected = if allow_monitor { 0 } else { 1 };
     let phase = match (allow_monitor, allow_window) {
         (true, false) => PortalChooserPhase::ScreenPick,
@@ -374,6 +378,15 @@ fn finish_after_selection(st: &mut Halley, now: Instant) -> bool {
 }
 
 fn finish_modal_capture(st: &mut Halley, _session: &PortalChooserState) {
+    // Drop any modal release-traps the chooser armed (Enter/Escape on
+    // confirm/cancel). They are only meaningful while the chooser owns the
+    // keyboard; a leftover trap diverts the next unrelated key release into
+    // `flush_trapped_modal_release` and strands the client in client-side key
+    // repeat. `forwarded_pressed_keys` is already drained by the focus-clear flush
+    // at open, but clear it too as belt-and-suspenders.
+    st.input.interaction_state.modal_release_keys.clear();
+    st.input.interaction_state.forwarded_pressed_keys.clear();
+
     let restore_focus = st
         .last_input_surface_node_for_monitor(st.model.monitor_state.current_monitor.as_str())
         .or(st.last_input_surface_node());

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -50,7 +50,10 @@ fn flush_trapped_modal_release(st: &mut Halley, code: u32) {
         mods_changed,
     );
     st.input.interaction_state.modal_release_keys.remove(&code);
-    st.input.interaction_state.forwarded_pressed_keys.remove(&code);
+    st.input
+        .interaction_state
+        .forwarded_pressed_keys
+        .remove(&code);
 }
 
 /// Clear any non-modifier keys we have forwarded to a client as *pressed* but not
@@ -696,7 +699,10 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
     // focus change. Intercepted keys are never forwarded, so they stay out.
     if !intercept {
         if pressed {
-            st.input.interaction_state.forwarded_pressed_keys.insert(code);
+            st.input
+                .interaction_state
+                .forwarded_pressed_keys
+                .insert(code);
         } else {
             st.input
                 .interaction_state


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled together, both in the halley-lift / modal-key subsystem.

### 1. Move Halley Lift config entries out of Actions mode

The Actions provider in halley-lift exposed three entries: "Reload Halley
config", "Open Lift config", and "Open Halley config". The two open-config
entries were already duplicated by the Config provider, so they're dropped
from `search_actions`, leaving Actions with just the reload entry.

The Config provider and General default search are unchanged, so both
open-config entries remain reachable — only the duplication under the
"Actions" section goes away.

Changelog updated for v0.5.0 accordingly.

### 2. Clear stale modal key-traps on portal chooser teardown

The portal source chooser armed an Enter release-trap unconditionally on
open, but nothing cleared it on teardown. If the chooser was dismissed any
way other than a physical Enter press+release (mouse selection, Escape, or
a portal-side cancel), the trapped Enter lingered in `modal_release_keys`.
The next real Enter release in a focused client (e.g. a terminal running a
command) got diverted into `flush_trapped_modal_release` instead of the
normal forward path, so the client never saw a clean key-up — the key
repeated forever until another key was pressed.

Fix:
- Clear `modal_release_keys` and `forwarded_pressed_keys` in
  `finish_modal_capture`, the single choke point every chooser exit path
  (cancel, selected, cancelled) reaches, so no chooser-armed trap can
  outlive the chooser.
- Drop the now-redundant open-time Enter pre-trap in
  `start_portal_chooser`. It's covered by `begin_modal_keyboard_capture` ->
  `clear_keyboard_focus`, which routes through the `set_keyboard_focus`
  choke point whose `flush_stuck_forwarded_keys` already releases the held
  Enter to the invoking app before focus drops to `None`.

Also includes incidental rustfmt line-wrapping in the same modal-key
subsystem.

## Testing
- Verified open-config entries still reachable via Config provider / General search
- Verified Actions section now shows only the reload entry
- Reproduced the stuck-key repeat (dismiss chooser via mouse/Escape, then
  hold Enter in a terminal) and confirmed it no longer occurs after the fix