### PR TITLE
v0.5.0: controller refactor, root.rs facade trim, and apogee/cluster fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,10 +192,6 @@ All notable changes to this project will be documented in this file.
   code (unused `FullscreenCtx`, empty `debug_dump`) and clearing workspace-wide warnings. Pure
   mechanical transform; no behavior changes.
 
-### Removed
-- Remove field parallax entirely, including `field.parallax` config parsing and generated-config
-  bootstrap defaults, so backgrounds and windows no longer drift or expose cleared framebuffer.
-
 ### Fixed
 - Ensure client-side fullscreen requests still send the xdg fullscreen configure when the window
   was already fullscreened by a Halley keybind, so client fullscreen buttons map cleanly onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ All notable changes to this project will be documented in this file.
   existing Halley capture overlay. Portal requests map to compositor capture modes,
   poll the capture IPC, and return a `file://` URI. `PickColor` is advertised as
   unsupported for now. GTK remains the fallback for other portal interfaces.
+- Add `apogee.open-cluster-on-select` (default `true`) so selecting a cluster core in Apogee opens its
+  workspace (entering it via `enter_cluster_workspace_by_core`) instead of only panning to the core.
+- Surface tile-cluster overflow members in Apogee, flying in from the overflow strip with app-icon
+  fallback previews, and promote a selected overflow member into the master slot (re-laying out the
+  cluster and shifting the old master into overflow). Selecting any cluster workspace member in Apogee
+  now promotes it to master for both tiling and stacking layouts.
 
 ### Changed
 - Animate the Alt+Tab focus-cycle switcher with a quick open fade/scale and smooth carousel-style
@@ -179,6 +185,12 @@ All notable changes to this project will be documented in this file.
   mode and into the Config mode only (where they already existed). Actions now exposes just
   "Reload Halley config"; both open-config entries remain reachable from the default General
   search via the Config provider.
+- Flatten the compositor's `*Controller` wrapper structs (ClusterSystem, ClusterRead, ClusterMutation,
+  FocusSystem, FocusState, FocusCycle, FocusDecay, FocusTrail, Fullscreen, ExitConfirm, Runtime,
+  SpawnReveal, Screenshot, Camera) into free functions taking `&Halley`/`&mut Halley`, and trim the
+  thin one-line `root.rs` facade methods that only delegated to those functions, removing the last dead
+  code (unused `FullscreenCtx`, empty `debug_dump`) and clearing workspace-wide warnings. Pure
+  mechanical transform; no behavior changes.
 
 ### Removed
 - Remove field parallax entirely, including `field.parallax` config parsing and generated-config
@@ -280,6 +292,35 @@ All notable changes to this project will be documented in this file.
   from a dead layer-shell launcher, dismissed screenshot/portal overlay, or session-lock transition
   and start repeating it forever. Modifiers are preserved so held Ctrl/Alt/Shift/Super carry across
   the handoff.
+- Clear stale modal key-traps on portal chooser teardown so a dismissed screenshot/portal source chooser
+  can no longer leave a trapped Enter that repeats forever in the next focused client. The chooser's
+  `modal_release_keys` and `forwarded_pressed_keys` are now cleared in `finish_modal_capture`, the single
+  choke point every chooser exit (cancel, selected, cancelled) reaches; the redundant open-time Enter
+  pre-trap is dropped since `begin_modal_keyboard_capture` already routes through `set_keyboard_focus`.
+- Selecting a maximized window in Apogee no longer leaves it off-centre on return (the reveal pan is
+  skipped for the monitor's maximize target), closing Apogee without a selection no longer flashes the
+  wrong window z-order (each monitor's tiles are reordered to the live desktop draw order before
+  fly-back), and selecting a cluster core now opens its workspace via `apogee.open-cluster-on-select`.
+- Resolve a Lift-created cluster core dropping on top of a window by running overlap resolution
+  immediately in `finish_lift_finalized_cluster` so the core slides clear, and stop selecting a cluster
+  member in Apogee from shifting the whole cluster off-centre by skipping the reveal pan when the monitor
+  has an active cluster workspace.
+- Collapse a cluster core's open bloom when grabbing it to drag, so the bloom no longer stays fanned out
+  while the drag does nothing; covers the plain press-to-drag-threshold path in addition to the drag/move
+  binding paths that already collapsed it.
+- Give Apogee core tiles the same look as normal core nodes: themed cluster fill colour (honouring
+  `node_background_color`) and a 5px themed border ring (honouring `node_border_color_*`), plus a hover
+  ring driven by new `apogee_hover_node` state. A Lift-created core now also slides clear of windows using
+  the animated landmark push instead of a trapped-landmark teleport.
+- Keep the outgoing stack member rendering during a forward (Next) stack cycle so it flies out to the
+  left instead of vanishing. The stack-transition pose/membership is now computed before the visibility
+  gate, letting the departing top render through its transition even after the relayout marks it hidden;
+  Prev (whose incoming top becomes visible) already animated correctly.
+- Stop reloading config from resetting an active cluster workspace to its default layout. The reload
+  path now sets a one-shot `skip_next_cluster_relayout` flag that the next maintenance tick consumes,
+  suppressing the tiling re-layout that normally fires on maintenance (preserving manual member
+  positions) while leaving all other maintenance work and legitimate re-layouts (cluster entry, member
+  add, overflow animations) unaffected.
 
 ## [v0.4.0] - 2026-06-12
 

--- a/crates/halley-config/src/layout/types.rs
+++ b/crates/halley-config/src/layout/types.rs
@@ -121,6 +121,9 @@ pub struct ApogeeConfig {
     pub gap: f32,
     pub max_rows: u32,
     pub background_dim: f32,
+    /// When selecting a cluster core in Apogee, open the cluster (enter its
+    /// workspace) instead of just panning to it.
+    pub open_cluster_on_select: bool,
 }
 
 impl Default for ApogeeConfig {
@@ -132,6 +135,7 @@ impl Default for ApogeeConfig {
             gap: 24.0,
             max_rows: 3,
             background_dim: 0.85,
+            open_cluster_on_select: true,
         }
     }
 }

--- a/crates/halley-config/src/parse/sections/apogee.rs
+++ b/crates/halley-config/src/parse/sections/apogee.rs
@@ -37,6 +37,14 @@ pub(crate) fn load_apogee_section(cfg: &RuneConfig, out: &mut RuntimeTuning) {
         out.apogee.background_dim,
     )
     .clamp(0.0, 1.0);
+    out.apogee.open_cluster_on_select = pick_bool(
+        cfg,
+        &[
+            "apogee.open-cluster-on-select",
+            "apogee.open_cluster_on_select",
+        ],
+        out.apogee.open_cluster_on_select,
+    );
 }
 
 #[cfg(test)]
@@ -58,6 +66,7 @@ apogee:
   gap 32.0
   max-rows 4
         background-dim 0.6
+  open-cluster-on-select false
 end
 "#,
         )
@@ -72,6 +81,7 @@ end
         assert_eq!(out.apogee.gap, 32.0);
         assert_eq!(out.apogee.max_rows, 4);
         assert_eq!(out.apogee.background_dim, 0.6);
+        assert!(!out.apogee.open_cluster_on_select);
     }
 
     #[test]
@@ -83,6 +93,7 @@ end
         assert_eq!(out.apogee.gap, 24.0);
         assert_eq!(out.apogee.max_rows, 3);
         assert_eq!(out.apogee.background_dim, 0.85);
+        assert!(out.apogee.open_cluster_on_select);
     }
 
     #[test]

--- a/crates/halley-config/src/parse/validate.rs
+++ b/crates/halley-config/src/parse/validate.rs
@@ -243,6 +243,8 @@ impl ConfigSchema {
             "apogee.show_collapsed_as_nodes",
             "apogee.background-dim",
             "apogee.background_dim",
+            "apogee.open-cluster-on-select",
+            "apogee.open_cluster_on_select",
             "bearings.show-distance",
             "bearings.show-icons",
             "bearings.show-pinned",
@@ -676,6 +678,8 @@ fn bool_scalar(path: &str) -> bool {
             | "apogee.live_previews"
             | "apogee.show-collapsed-as-nodes"
             | "apogee.show_collapsed_as_nodes"
+            | "apogee.open-cluster-on-select"
+            | "apogee.open_cluster_on_select"
             | "bearings.show-distance"
             | "bearings.show-icons"
             | "bearings.show-pinned"

--- a/crates/halley-wl/src/backend/tty/drm.rs
+++ b/crates/halley-wl/src/backend/tty/drm.rs
@@ -1315,7 +1315,8 @@ pub(crate) fn queue_tty_drm_frame(
             crate::frame_loop::tty_output_animation_redraw_state(st, output_name, Instant::now());
 
         let local_cursor = cursor_screen.and_then(|(sx, sy)| {
-            let (target_monitor, sx, sy) = st.monitor_for_screen_clamped(sx, sy)?;
+            let (target_monitor, sx, sy) =
+                crate::compositor::monitor::state::monitor_for_screen_clamped(st, sx, sy)?;
             if target_monitor != output_name {
                 return None;
             }
@@ -2192,7 +2193,7 @@ fn fullscreen_direct_scanout_candidate(
             "top/overlay layer-shell surfaces are present on the output",
         ));
     }
-    if st.monitor_has_visible_overlap_policy_window(output_name) {
+    if crate::compositor::spawn::state::monitor_has_visible_overlap_policy_window(st, output_name) {
         return Some(blocked(
             "overlap-policy window is visible above fullscreen on the output",
         ));

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -319,7 +319,7 @@ fn advance_tty_redraw_frame(
     now: Instant,
     include_maintenance: bool,
 ) {
-    st.drain_drm_syncobj_blockers();
+    crate::compositor::platform::drain_drm_syncobj_blockers(st);
 
     let resize_active = {
         let ps = pointer_state.borrow();

--- a/crates/halley-wl/src/backend/tty/mod.rs
+++ b/crates/halley-wl/src/backend/tty/mod.rs
@@ -43,7 +43,7 @@ use crate::backend::tty::stats::{
     TtyFrameStats, maybe_log_tty_frame_stats, record_tty_frame_queue,
 };
 use crate::backend::vblank_throttle::VBlankThrottle;
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::interaction::ResizeCtx;
 use calloop::ping::make_ping;
 use smithay::backend::drm::DrmNode;
@@ -1924,7 +1924,7 @@ pub(crate) fn run_tty_backend() -> Result<(), Box<dyn Error>> {
                 drain_ipc_commands_with_fds(|request, fds| match request {
                     halley_api::Request::Compositor(halley_api::CompositorRequest::Quit) => {
                         info!("ipc: quit requested");
-                        exit_confirm_controller(&mut *st).show();
+                        exit_confirm::show(&mut *st);
                         halley_api::Response::Ok
                     }
                     halley_api::Request::Compositor(halley_api::CompositorRequest::Reload) => {

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -586,7 +586,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     }
                     WinitEvent::CloseRequested => {
                         debug!("winit event: {:?}", event);
-                        st.request_exit();
+                        crate::compositor::runtime::request_exit(st);
                     }
                     WinitEvent::Input(InputEvent::Keyboard { event }) => {
                         let code: u32 = event.key_code().into();
@@ -840,7 +840,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     ps.world = crate::spatial::screen_to_world(st, ws_w.max(1), ws_h.max(1), sx, sy);
                 }
                 let now = Instant::now();
-                st.drain_drm_syncobj_blockers();
+                crate::compositor::platform::drain_drm_syncobj_blockers(st);
 
                 st.runtime.spawned_children.retain_mut(|child| {
                     match child.try_wait() {

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -8,7 +8,6 @@ use crate::backend::interface::{
 };
 use crate::compositor::exit_confirm;
 use crate::compositor::interaction::PointerState;
-use crate::compositor::monitor::camera::camera_controller;
 use halley_api::{
     ApiError, CompositorRequest, LogicalOutputInfo, ModeInfo, OutputInfo, OutputStatus, Request,
     Response,
@@ -423,7 +422,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                     x: ws.w.max(1) as f32,
                     y: ws.h.max(1) as f32,
                 };
-                camera_controller(&mut state).snap_targets_to_live();
+                crate::compositor::monitor::camera::snap_camera_targets_to_live(&mut state);
                 state.advertise_output(
                     "winit-0",
                     smithay::output::Mode {
@@ -526,7 +525,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                             x: size.w.max(1) as f32,
                             y: size.h.max(1) as f32,
                         };
-                        camera_controller(&mut *st).snap_targets_to_live();
+                        crate::compositor::monitor::camera::snap_camera_targets_to_live(&mut *st);
                         st.advertise_output(
                             "winit-0",
                             smithay::output::Mode {

--- a/crates/halley-wl/src/backend/winit.rs
+++ b/crates/halley-wl/src/backend/winit.rs
@@ -6,7 +6,7 @@ use crate::protocol::wayland::portal;
 use crate::backend::interface::{
     BackendView, DmabufImportBackend, RenderBackend, WinitBackendHandle,
 };
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::interaction::PointerState;
 use crate::compositor::monitor::camera::camera_controller;
 use halley_api::{
@@ -860,7 +860,7 @@ pub(crate) fn run_winit_backend() -> Result<(), Box<dyn Error>> {
                 drain_ipc_commands_with_fds(|request, fds| match request {
                     Request::Compositor(CompositorRequest::Quit) => {
                         info!("ipc: quit requested");
-                        exit_confirm_controller(&mut *st).show();
+                        exit_confirm::show(&mut *st);
                         Response::Ok
                     }
                     Request::Compositor(CompositorRequest::Reload) => {

--- a/crates/halley-wl/src/bootstrap/mod.rs
+++ b/crates/halley-wl/src/bootstrap/mod.rs
@@ -137,6 +137,7 @@ fn apply_reloaded_tuning_state(st: &mut Halley, next: RuntimeTuning) {
     restore_live_camera_state(st, live_camera);
     let opacity_changed = crate::compositor::spawn::state::recompute_all_node_rule_opacities(st);
     st.ui.render_state.clear_window_offscreen_caches();
+    st.runtime.skip_next_cluster_relayout = true;
     st.request_maintenance();
     if opacity_changed {
         st.runtime.tty_redraw_all = true;

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -144,7 +144,17 @@ pub(crate) fn focus_or_reveal_surface_node(
                 .spawn_state
                 .pending_initial_reveal
                 .contains(&node_id);
-            if !is_pending_tiled && !is_pending_reveal {
+            // A maximized window draws at the monitor's usable-viewport center, not
+            // at its windowed field pos. Panning to the windowed reveal center would
+            // shift the view and leave the maximized window off-screen-center, so
+            // leave the (already-correct) maximize camera put — mirroring the guard
+            // in close_restore_pan_plan.
+            let is_maximize_target =
+                crate::compositor::workspace::state::maximize_session_target_for_monitor(
+                    st,
+                    target_monitor.as_str(),
+                ) == Some(node_id);
+            if !is_maximize_target && !is_pending_tiled && !is_pending_reveal {
                 let _ = st
                     .minimal_reveal_center_for_surface_on_monitor(target_monitor.as_str(), node_id)
                     .map(|target| st.animate_viewport_center_to(target, now));

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -154,7 +154,20 @@ pub(crate) fn focus_or_reveal_surface_node(
                     st,
                     target_monitor.as_str(),
                 ) == Some(node_id);
-            if !is_maximize_target && !is_pending_tiled && !is_pending_reveal {
+            // An active cluster workspace owns the camera/layout the same way a
+            // maximize session does, so panning to a member's reveal centre would
+            // shift the whole cluster off-centre. Mirror close_restore_pan_plan and
+            // leave the camera put in both cases.
+            let cluster_workspace_active = st
+                .model
+                .cluster_state
+                .active_cluster_workspaces
+                .contains_key(target_monitor.as_str());
+            if !is_maximize_target
+                && !cluster_workspace_active
+                && !is_pending_tiled
+                && !is_pending_reveal
+            {
                 let _ = st
                     .minimal_reveal_center_for_surface_on_monitor(target_monitor.as_str(), node_id)
                     .map(|target| st.animate_viewport_center_to(target, now));

--- a/crates/halley-wl/src/compositor/carry/system.rs
+++ b/crates/halley-wl/src/compositor/carry/system.rs
@@ -151,7 +151,7 @@ pub(crate) fn begin_carry_state_tracking(st: &mut Halley, id: NodeId) {
             .carry_state
             .carry_state_hold
             .insert(id, n.state.clone());
-        let fp = st.collision_size_for_node(n);
+        let fp = crate::compositor::overlap::system::collision_size_for_node(st, n);
         let z = zone_for_pos_with_hysteresis(st, id, n.pos, fp);
         st.model.carry_state.carry_zone_hint.insert(id, z);
         st.model
@@ -218,7 +218,11 @@ pub(crate) fn update_carry_state_preview_at(
     };
     let n_kind = n.kind.clone();
     let was_active = n.state == halley_core::field::NodeState::Active;
-    let footprint = zone_eval_footprint_for(st, id, st.collision_size_for_node(n));
+    let footprint = zone_eval_footprint_for(
+        st,
+        id,
+        crate::compositor::overlap::system::collision_size_for_node(st, n),
+    );
     if n_kind != halley_core::field::NodeKind::Surface || !st.model.field.is_visible(id) {
         return;
     }

--- a/crates/halley-wl/src/compositor/clusters/read.rs
+++ b/crates/halley-wl/src/compositor/clusters/read.rs
@@ -29,12 +29,12 @@ pub(super) struct ExitClusterWorkspacePlan {
     pub(super) hidden_ids: Vec<NodeId>,
 }
 
-pub(super) struct ClusterTilePlacement {
+pub(crate) struct ClusterTilePlacement {
     pub(super) node_id: NodeId,
     pub(super) rect: halley_core::tiling::Rect,
 }
 
-pub(super) struct ClusterLayoutPlan {
+pub(crate) struct ClusterLayoutPlan {
     pub(super) kind: ClusterWorkspaceLayoutKind,
     pub(super) tiles: Vec<ClusterTilePlacement>,
     pub(super) overflow_members: Vec<NodeId>,

--- a/crates/halley-wl/src/compositor/clusters/read.rs
+++ b/crates/halley-wl/src/compositor/clusters/read.rs
@@ -6,12 +6,13 @@ use halley_core::cluster::ClusterId;
 use halley_core::cluster_layout::{ClusterWorkspaceLayoutKind, layout_cluster_workspace};
 use halley_core::tiling::Rect;
 
-pub(super) struct ClusterReadController<'a> {
-    pub(super) field: &'a Field,
-    pub(super) cluster_state: &'a ClusterState,
-    pub(super) monitor_state: &'a MonitorState,
-    pub(super) tuning: &'a RuntimeTuning,
-}
+const OVERFLOW_STRIP_PAD_PX: f32 = 18.0;
+const OVERFLOW_STRIP_W_PX: f32 = 56.0;
+const OVERFLOW_SCROLLBAR_GUTTER_PX: f32 = 12.0;
+const OVERFLOW_ICON_PAD_PX: f32 = 8.0;
+const OVERFLOW_ICON_SIZE_PX: f32 = 40.0;
+const OVERFLOW_ICON_GAP_PX: f32 = 8.0;
+const OVERFLOW_VISIBLE_SLOTS: usize = 15;
 
 pub(super) struct EnterClusterWorkspacePlan {
     pub(super) cid: ClusterId,
@@ -39,295 +40,302 @@ pub(super) struct ClusterLayoutPlan {
     pub(super) overflow_members: Vec<NodeId>,
 }
 
-impl<'a> ClusterReadController<'a> {
-    const OVERFLOW_STRIP_PAD_PX: f32 = 18.0;
-    const OVERFLOW_STRIP_W_PX: f32 = 56.0;
-    const OVERFLOW_SCROLLBAR_GUTTER_PX: f32 = 12.0;
-    const OVERFLOW_ICON_PAD_PX: f32 = 8.0;
-    const OVERFLOW_ICON_SIZE_PX: f32 = 40.0;
-    const OVERFLOW_ICON_GAP_PX: f32 = 8.0;
-    const OVERFLOW_VISIBLE_SLOTS: usize = 15;
+pub(super) fn cluster_bloom_for_monitor(st: &Halley, monitor: &str) -> Option<ClusterId> {
+    st.model
+        .cluster_state
+        .cluster_bloom_open
+        .get(monitor)
+        .copied()
+}
 
-    pub(super) fn cluster_bloom_for_monitor(&self, monitor: &str) -> Option<ClusterId> {
-        self.cluster_state.cluster_bloom_open.get(monitor).copied()
-    }
-
-    pub(super) fn preferred_monitor_for_cluster(
-        &self,
-        cid: ClusterId,
-        preferred: Option<&str>,
-    ) -> Option<String> {
-        preferred
-            .map(str::to_string)
-            .or_else(|| {
-                self.cluster_state
-                    .active_cluster_workspaces
+pub(super) fn preferred_monitor_for_cluster(
+    st: &Halley,
+    cid: ClusterId,
+    preferred: Option<&str>,
+) -> Option<String> {
+    preferred
+        .map(str::to_string)
+        .or_else(|| {
+            st.model
+                .cluster_state
+                .active_cluster_workspaces
+                .iter()
+                .find_map(|(monitor, active_cid)| (*active_cid == cid).then(|| monitor.clone()))
+        })
+        .or_else(|| {
+            st.model
+                .cluster_state
+                .cluster_bloom_open
+                .iter()
+                .find_map(|(monitor, open_cid)| (*open_cid == cid).then(|| monitor.clone()))
+        })
+        .or_else(|| {
+            st.model
+                .field
+                .cluster(cid)
+                .and_then(|cluster| cluster.core)
+                .and_then(|core_id| st.model.monitor_state.node_monitor.get(&core_id).cloned())
+        })
+        .or_else(|| {
+            st.model.field.cluster(cid).and_then(|cluster| {
+                cluster
+                    .members()
                     .iter()
-                    .find_map(|(monitor, active_cid)| (*active_cid == cid).then(|| monitor.clone()))
+                    .find_map(|member| st.model.monitor_state.node_monitor.get(member).cloned())
             })
-            .or_else(|| {
-                self.cluster_state
-                    .cluster_bloom_open
-                    .iter()
-                    .find_map(|(monitor, open_cid)| (*open_cid == cid).then(|| monitor.clone()))
-            })
-            .or_else(|| {
-                self.field
-                    .cluster(cid)
-                    .and_then(|cluster| cluster.core)
-                    .and_then(|core_id| self.monitor_state.node_monitor.get(&core_id).cloned())
-            })
-            .or_else(|| {
-                self.field.cluster(cid).and_then(|cluster| {
-                    cluster
-                        .members()
-                        .iter()
-                        .find_map(|member| self.monitor_state.node_monitor.get(member).cloned())
-                })
-            })
-            .or_else(|| Some(self.monitor_state.current_monitor.clone()))
-    }
+        })
+        .or_else(|| Some(st.model.monitor_state.current_monitor.clone()))
+}
 
-    pub(super) fn workspace_viewport_for_monitor(
-        &self,
-        monitor: &str,
-    ) -> Option<halley_core::viewport::Viewport> {
-        self.monitor_state
-            .monitors
-            .get(monitor)
-            .map(|space| space.usable_viewport)
-    }
+pub(super) fn workspace_viewport_for_monitor(
+    st: &Halley,
+    monitor: &str,
+) -> Option<halley_core::viewport::Viewport> {
+    st.model
+        .monitor_state
+        .monitors
+        .get(monitor)
+        .map(|space| space.usable_viewport)
+}
 
-    fn cluster_layout_kind(&self) -> ClusterWorkspaceLayoutKind {
-        self.tuning.cluster_layout_kind()
-    }
+fn cluster_layout_kind(st: &Halley) -> ClusterWorkspaceLayoutKind {
+    st.runtime.tuning.cluster_layout_kind()
+}
 
-    fn cluster_layout_bounds(
-        &self,
-        viewport: halley_core::viewport::Viewport,
-    ) -> (halley_core::tiling::Rect, f32) {
-        let (outer_gap, inner_gap) = compensated_cluster_gaps(
-            self.tuning.tile_gaps_outer_px.max(0.0),
-            self.tuning.tile_gaps_inner_px.max(0.0),
-            active_window_frame_pad_px(self.tuning) as f32,
-        );
-        let outer_gap = outer_gap.max(0.0);
-        let viewport_left = viewport.center.x - viewport.size.x * 0.5;
-        let viewport_top = viewport.center.y - viewport.size.y * 0.5;
-        (
-            halley_core::tiling::Rect {
-                x: viewport_left + outer_gap,
-                y: viewport_top + outer_gap,
-                w: (viewport.size.x - outer_gap * 2.0).max(0.0),
-                h: (viewport.size.y - outer_gap * 2.0).max(0.0),
-            },
-            inner_gap.max(0.0),
-        )
-    }
+fn cluster_layout_bounds(
+    st: &Halley,
+    viewport: halley_core::viewport::Viewport,
+) -> (halley_core::tiling::Rect, f32) {
+    let (outer_gap, inner_gap) = compensated_cluster_gaps(
+        st.runtime.tuning.tile_gaps_outer_px.max(0.0),
+        st.runtime.tuning.tile_gaps_inner_px.max(0.0),
+        active_window_frame_pad_px(&st.runtime.tuning) as f32,
+    );
+    let outer_gap = outer_gap.max(0.0);
+    let viewport_left = viewport.center.x - viewport.size.x * 0.5;
+    let viewport_top = viewport.center.y - viewport.size.y * 0.5;
+    (
+        halley_core::tiling::Rect {
+            x: viewport_left + outer_gap,
+            y: viewport_top + outer_gap,
+            w: (viewport.size.x - outer_gap * 2.0).max(0.0),
+            h: (viewport.size.y - outer_gap * 2.0).max(0.0),
+        },
+        inner_gap.max(0.0),
+    )
+}
 
-    fn cluster_layout_plan_for_members(
-        &self,
-        viewport: halley_core::viewport::Viewport,
-        members: &[NodeId],
-    ) -> ClusterLayoutPlan {
-        let kind = self.cluster_layout_kind();
-        let (bounds, inner_gap) = self.cluster_layout_bounds(viewport);
-        let result = layout_cluster_workspace(
-            kind,
-            bounds,
-            inner_gap,
-            active_window_frame_pad_px(self.tuning) as f32,
-            members,
-            self.tuning.active_cluster_visible_limit(),
-        );
-        let overflow_members = if matches!(kind, ClusterWorkspaceLayoutKind::Tiling) {
-            result.queue_members.clone()
+fn cluster_layout_plan_for_members(
+    st: &Halley,
+    viewport: halley_core::viewport::Viewport,
+    members: &[NodeId],
+) -> ClusterLayoutPlan {
+    let kind = cluster_layout_kind(st);
+    let (bounds, inner_gap) = cluster_layout_bounds(st, viewport);
+    let result = layout_cluster_workspace(
+        kind,
+        bounds,
+        inner_gap,
+        active_window_frame_pad_px(&st.runtime.tuning) as f32,
+        members,
+        st.runtime.tuning.active_cluster_visible_limit(),
+    );
+    let overflow_members = if matches!(kind, ClusterWorkspaceLayoutKind::Tiling) {
+        result.queue_members.clone()
+    } else {
+        Vec::new()
+    };
+    let tiles = result
+        .placements
+        .into_iter()
+        .map(|placement| ClusterTilePlacement {
+            node_id: placement.node_id,
+            rect: placement.rect,
+        })
+        .collect::<Vec<_>>();
+    ClusterLayoutPlan {
+        kind,
+        tiles,
+        overflow_members,
+    }
+}
+
+pub(super) fn cluster_spawn_rect_for_new_member(
+    st: &Halley,
+    monitor: &str,
+    cid: ClusterId,
+) -> Option<halley_core::tiling::Rect> {
+    let cluster = st.model.field.cluster(cid)?;
+    let viewport = workspace_viewport_for_monitor(st, monitor)?;
+    let mut preview_members = cluster.members().to_vec();
+    let visible_limit = halley_core::cluster_layout::cluster_visible_limit(
+        cluster_layout_kind(st),
+        st.runtime.tuning.active_cluster_visible_limit(),
+    );
+    if visible_limit == usize::MAX || preview_members.len() < visible_limit {
+        if matches!(
+            cluster_layout_kind(st),
+            ClusterWorkspaceLayoutKind::Stacking
+        ) {
+            preview_members.insert(0, NodeId::new(u64::MAX));
         } else {
-            Vec::new()
-        };
-        let tiles = result
-            .placements
-            .into_iter()
-            .map(|placement| ClusterTilePlacement {
-                node_id: placement.node_id,
-                rect: placement.rect,
-            })
-            .collect::<Vec<_>>();
-        ClusterLayoutPlan {
-            kind,
-            tiles,
-            overflow_members,
+            preview_members.push(NodeId::new(u64::MAX));
         }
     }
+    cluster_layout_plan_for_members(st, viewport, &preview_members)
+        .tiles
+        .into_iter()
+        .last()
+        .map(|tile| tile.rect)
+}
 
-    pub(super) fn cluster_spawn_rect_for_new_member(
-        &self,
-        monitor: &str,
-        cid: ClusterId,
-    ) -> Option<halley_core::tiling::Rect> {
-        let cluster = self.field.cluster(cid)?;
-        let viewport = self.workspace_viewport_for_monitor(monitor)?;
-        let mut preview_members = cluster.members().to_vec();
-        let visible_limit = halley_core::cluster_layout::cluster_visible_limit(
-            self.cluster_layout_kind(),
-            self.tuning.active_cluster_visible_limit(),
-        );
-        if visible_limit == usize::MAX || preview_members.len() < visible_limit {
-            if matches!(
-                self.cluster_layout_kind(),
-                ClusterWorkspaceLayoutKind::Stacking
-            ) {
-                preview_members.insert(0, NodeId::new(u64::MAX));
-            } else {
-                preview_members.push(NodeId::new(u64::MAX));
-            }
+pub(super) fn overflow_strip_rect_for_monitor(
+    st: &Halley,
+    monitor: &str,
+    overflow_len: usize,
+) -> Option<halley_core::tiling::Rect> {
+    if overflow_len == 0 {
+        return None;
+    }
+    let space = st.model.monitor_state.monitors.get(monitor)?;
+    let strip_w = if overflow_len > OVERFLOW_VISIBLE_SLOTS {
+        OVERFLOW_STRIP_W_PX + OVERFLOW_SCROLLBAR_GUTTER_PX
+    } else {
+        OVERFLOW_STRIP_W_PX
+    };
+    let visible_slots = overflow_len.min(OVERFLOW_VISIBLE_SLOTS) as f32;
+    let height = OVERFLOW_ICON_PAD_PX * 2.0
+        + visible_slots * OVERFLOW_ICON_SIZE_PX
+        + (visible_slots - 1.0).max(0.0) * OVERFLOW_ICON_GAP_PX;
+    Some(halley_core::tiling::Rect {
+        x: (space.width as f32 - strip_w - OVERFLOW_STRIP_PAD_PX).max(0.0),
+        y: ((space.height as f32 - height) * 0.5).max(OVERFLOW_STRIP_PAD_PX),
+        w: strip_w,
+        h: height,
+    })
+}
+
+pub(super) fn overflow_strip_slot_rect_for_monitor(
+    st: &Halley,
+    monitor: &str,
+    overflow_len: usize,
+    slot_index: usize,
+) -> Option<Rect> {
+    let strip = overflow_strip_rect_for_monitor(st, monitor, overflow_len)?;
+    let scrollbar_extra = if overflow_len > OVERFLOW_VISIBLE_SLOTS {
+        OVERFLOW_SCROLLBAR_GUTTER_PX
+    } else {
+        0.0
+    };
+    let icon_x = strip.x + (strip.w - OVERFLOW_ICON_SIZE_PX - scrollbar_extra) * 0.5;
+    Some(Rect {
+        x: icon_x,
+        y: strip.y
+            + OVERFLOW_ICON_PAD_PX
+            + slot_index as f32 * (OVERFLOW_ICON_SIZE_PX + OVERFLOW_ICON_GAP_PX),
+        w: OVERFLOW_ICON_SIZE_PX,
+        h: OVERFLOW_ICON_SIZE_PX,
+    })
+}
+
+pub(super) fn plan_enter_cluster_workspace(
+    st: &Halley,
+    core_id: NodeId,
+    monitor: &str,
+) -> Option<EnterClusterWorkspacePlan> {
+    let cid = st.model.field.cluster_id_for_core_public(core_id)?;
+    let cluster = st.model.field.cluster(cid)?;
+    let members = cluster.members().iter().copied().collect::<HashSet<_>>();
+    let core_pos = st.model.field.node(core_id)?.pos;
+    let current_viewport = workspace_viewport_for_monitor(st, monitor)?;
+    let mut hidden_ids = Vec::new();
+    for &id in st.model.field.nodes().keys() {
+        if members.contains(&id) || id == core_id {
+            continue;
         }
-        self.cluster_layout_plan_for_members(viewport, &preview_members)
+        if st
+            .model
+            .monitor_state
+            .node_monitor
+            .get(&id)
+            .is_some_and(|node_monitor| node_monitor != monitor)
+        {
+            continue;
+        }
+        let already_detached = st
+            .model
+            .field
+            .node(id)
+            .is_some_and(|n| n.visibility.has(Visibility::DETACHED));
+        if !already_detached {
+            hidden_ids.push(id);
+        }
+    }
+    Some(EnterClusterWorkspacePlan {
+        cid,
+        core_id,
+        core_pos,
+        current_viewport,
+        hidden_ids,
+    })
+}
+
+pub(super) fn plan_exit_cluster_workspace(
+    st: &Halley,
+    monitor: &str,
+) -> Option<ExitClusterWorkspacePlan> {
+    let cid = st
+        .model
+        .cluster_state
+        .active_cluster_workspaces
+        .get(monitor)
+        .copied()?;
+    let hidden_ids = st
+        .model
+        .cluster_state
+        .workspace_hidden_nodes
+        .get(monitor)
+        .cloned()
+        .unwrap_or_default();
+    let core_id = st.model.field.cluster(cid).and_then(|c| c.core);
+    let core_pos = core_id.and_then(|id| st.model.field.node(id).map(|node| node.pos));
+    Some(ExitClusterWorkspacePlan {
+        cid,
+        core_id,
+        core_pos,
+        hidden_ids,
+    })
+}
+
+pub(super) fn plan_active_cluster_layout(st: &Halley, monitor: &str) -> Option<ClusterLayoutPlan> {
+    let cid = st
+        .model
+        .cluster_state
+        .active_cluster_workspaces
+        .get(monitor)
+        .copied()?;
+    let cluster = st.model.field.cluster(cid)?;
+    let viewport = workspace_viewport_for_monitor(st, monitor)?;
+    Some(cluster_layout_plan_for_members(
+        st,
+        viewport,
+        cluster.members(),
+    ))
+}
+
+pub(super) fn stack_layout_rects_for_members(
+    st: &Halley,
+    monitor: &str,
+    members: &[NodeId],
+) -> Option<std::collections::HashMap<NodeId, Rect>> {
+    let viewport = workspace_viewport_for_monitor(st, monitor)?;
+    Some(
+        cluster_layout_plan_for_members(st, viewport, members)
             .tiles
             .into_iter()
-            .last()
-            .map(|tile| tile.rect)
-    }
-
-    pub(super) fn overflow_strip_rect_for_monitor(
-        &self,
-        monitor: &str,
-        overflow_len: usize,
-    ) -> Option<halley_core::tiling::Rect> {
-        if overflow_len == 0 {
-            return None;
-        }
-        let space = self.monitor_state.monitors.get(monitor)?;
-        let strip_w = if overflow_len > Self::OVERFLOW_VISIBLE_SLOTS {
-            Self::OVERFLOW_STRIP_W_PX + Self::OVERFLOW_SCROLLBAR_GUTTER_PX
-        } else {
-            Self::OVERFLOW_STRIP_W_PX
-        };
-        let visible_slots = overflow_len.min(Self::OVERFLOW_VISIBLE_SLOTS) as f32;
-        let height = Self::OVERFLOW_ICON_PAD_PX * 2.0
-            + visible_slots * Self::OVERFLOW_ICON_SIZE_PX
-            + (visible_slots - 1.0).max(0.0) * Self::OVERFLOW_ICON_GAP_PX;
-        Some(halley_core::tiling::Rect {
-            x: (space.width as f32 - strip_w - Self::OVERFLOW_STRIP_PAD_PX).max(0.0),
-            y: ((space.height as f32 - height) * 0.5).max(Self::OVERFLOW_STRIP_PAD_PX),
-            w: strip_w,
-            h: height,
-        })
-    }
-
-    pub(super) fn overflow_strip_slot_rect_for_monitor(
-        &self,
-        monitor: &str,
-        overflow_len: usize,
-        slot_index: usize,
-    ) -> Option<Rect> {
-        let strip = self.overflow_strip_rect_for_monitor(monitor, overflow_len)?;
-        let scrollbar_extra = if overflow_len > Self::OVERFLOW_VISIBLE_SLOTS {
-            Self::OVERFLOW_SCROLLBAR_GUTTER_PX
-        } else {
-            0.0
-        };
-        let icon_x = strip.x + (strip.w - Self::OVERFLOW_ICON_SIZE_PX - scrollbar_extra) * 0.5;
-        Some(Rect {
-            x: icon_x,
-            y: strip.y
-                + Self::OVERFLOW_ICON_PAD_PX
-                + slot_index as f32 * (Self::OVERFLOW_ICON_SIZE_PX + Self::OVERFLOW_ICON_GAP_PX),
-            w: Self::OVERFLOW_ICON_SIZE_PX,
-            h: Self::OVERFLOW_ICON_SIZE_PX,
-        })
-    }
-
-    pub(super) fn plan_enter_cluster_workspace(
-        &self,
-        core_id: NodeId,
-        monitor: &str,
-    ) -> Option<EnterClusterWorkspacePlan> {
-        let cid = self.field.cluster_id_for_core_public(core_id)?;
-        let cluster = self.field.cluster(cid)?;
-        let members = cluster.members().iter().copied().collect::<HashSet<_>>();
-        let core_pos = self.field.node(core_id)?.pos;
-        let current_viewport = self.workspace_viewport_for_monitor(monitor)?;
-        let mut hidden_ids = Vec::new();
-        for &id in self.field.nodes().keys() {
-            if members.contains(&id) || id == core_id {
-                continue;
-            }
-            if self
-                .monitor_state
-                .node_monitor
-                .get(&id)
-                .is_some_and(|node_monitor| node_monitor != monitor)
-            {
-                continue;
-            }
-            let already_detached = self
-                .field
-                .node(id)
-                .is_some_and(|n| n.visibility.has(Visibility::DETACHED));
-            if !already_detached {
-                hidden_ids.push(id);
-            }
-        }
-        Some(EnterClusterWorkspacePlan {
-            cid,
-            core_id,
-            core_pos,
-            current_viewport,
-            hidden_ids,
-        })
-    }
-
-    pub(super) fn plan_exit_cluster_workspace(
-        &self,
-        monitor: &str,
-    ) -> Option<ExitClusterWorkspacePlan> {
-        let cid = self
-            .cluster_state
-            .active_cluster_workspaces
-            .get(monitor)
-            .copied()?;
-        let hidden_ids = self
-            .cluster_state
-            .workspace_hidden_nodes
-            .get(monitor)
-            .cloned()
-            .unwrap_or_default();
-        let core_id = self.field.cluster(cid).and_then(|c| c.core);
-        let core_pos = core_id.and_then(|id| self.field.node(id).map(|node| node.pos));
-        Some(ExitClusterWorkspacePlan {
-            cid,
-            core_id,
-            core_pos,
-            hidden_ids,
-        })
-    }
-
-    pub(super) fn plan_active_cluster_layout(&self, monitor: &str) -> Option<ClusterLayoutPlan> {
-        let cid = self
-            .cluster_state
-            .active_cluster_workspaces
-            .get(monitor)
-            .copied()?;
-        let cluster = self.field.cluster(cid)?;
-        let viewport = self.workspace_viewport_for_monitor(monitor)?;
-        Some(self.cluster_layout_plan_for_members(viewport, cluster.members()))
-    }
-
-    pub(super) fn stack_layout_rects_for_members(
-        &self,
-        monitor: &str,
-        members: &[NodeId],
-    ) -> Option<std::collections::HashMap<NodeId, Rect>> {
-        let viewport = self.workspace_viewport_for_monitor(monitor)?;
-        Some(
-            self.cluster_layout_plan_for_members(viewport, members)
-                .tiles
-                .into_iter()
-                .map(|tile| (tile.node_id, tile.rect))
-                .collect(),
-        )
-    }
+            .map(|tile| (tile.node_id, tile.rect))
+            .collect(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/clusters/system.rs
+++ b/crates/halley-wl/src/compositor/clusters/system.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::compositor::clusters::read::{
-    ClusterLayoutPlan, ClusterReadController, ClusterTilePlacement, EnterClusterWorkspacePlan,
-    ExitClusterWorkspacePlan,
+    ClusterLayoutPlan, ClusterTilePlacement, EnterClusterWorkspacePlan, ExitClusterWorkspacePlan,
 };
 use crate::compositor::clusters::state::ClusterState;
 use crate::compositor::interaction::state::InteractionState;
@@ -326,22 +325,12 @@ impl<T: DerefMut<Target = Halley>> DerefMut for ClusterSystemController<T> {
 impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
     const CLUSTER_OVERFLOW_VISIBLE_SLOTS: usize = 15;
 
-    fn cluster_read_controller(&self) -> ClusterReadController<'_> {
-        ClusterReadController {
-            field: &self.model.field,
-            cluster_state: &self.model.cluster_state,
-            monitor_state: &self.model.monitor_state,
-            tuning: &self.runtime.tuning,
-        }
-    }
-
     fn preferred_monitor_for_cluster(
         &self,
         cid: ClusterId,
         preferred: Option<&str>,
     ) -> Option<String> {
-        self.cluster_read_controller()
-            .preferred_monitor_for_cluster(cid, preferred)
+        crate::compositor::clusters::read::preferred_monitor_for_cluster(self, cid, preferred)
     }
 
     pub(crate) fn cluster_overflow_rect_for_monitor(
@@ -361,8 +350,12 @@ impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
         overflow_len: usize,
         slot_index: usize,
     ) -> Option<halley_core::tiling::Rect> {
-        self.cluster_read_controller()
-            .overflow_strip_slot_rect_for_monitor(monitor, overflow_len, slot_index)
+        crate::compositor::clusters::read::overflow_strip_slot_rect_for_monitor(
+            self,
+            monitor,
+            overflow_len,
+            slot_index,
+        )
     }
 
     pub(crate) fn active_cluster_tile_rect_for_member(
@@ -370,8 +363,7 @@ impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         member_id: NodeId,
     ) -> Option<halley_core::tiling::Rect> {
-        self.cluster_read_controller()
-            .plan_active_cluster_layout(monitor)?
+        crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)?
             .tiles
             .into_iter()
             .find(|tile| tile.node_id == member_id)
@@ -383,8 +375,7 @@ impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         cid: ClusterId,
     ) -> Option<halley_core::tiling::Rect> {
-        self.cluster_read_controller()
-            .cluster_spawn_rect_for_new_member(monitor, cid)
+        crate::compositor::clusters::read::cluster_spawn_rect_for_new_member(self, monitor, cid)
     }
 
     pub(crate) fn stack_layout_rects_for_members(
@@ -392,8 +383,7 @@ impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         members: &[NodeId],
     ) -> Option<std::collections::HashMap<NodeId, halley_core::tiling::Rect>> {
-        self.cluster_read_controller()
-            .stack_layout_rects_for_members(monitor, members)
+        crate::compositor::clusters::read::stack_layout_rects_for_members(self, monitor, members)
     }
 
     pub fn has_any_active_cluster_workspace(&self) -> bool {

--- a/crates/halley-wl/src/compositor/clusters/system.rs
+++ b/crates/halley-wl/src/compositor/clusters/system.rs
@@ -9,7 +9,6 @@ use halley_config::{ClusterDefaultLayout, DirectionalAction};
 use halley_core::cluster::{ClusterId, ClusterRemoveMemberOutcome};
 use halley_core::cluster_layout::{ClusterCycleDirection, ClusterWorkspaceLayoutKind};
 use halley_core::field::RemoveNodeClusterEffect;
-use std::ops::{Deref, DerefMut};
 
 fn cluster_mode_selected_nodes_for_monitor_mut<'a>(
     st: &'a mut Halley,
@@ -22,7 +21,7 @@ fn cluster_mode_selected_nodes_for_monitor_mut<'a>(
         .or_default()
 }
 
-fn open_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str, cid: ClusterId) -> bool {
+fn open_cluster_bloom_for_monitor_inner(st: &mut Halley, monitor: &str, cid: ClusterId) -> bool {
     let Some(cluster) = st.model.field.cluster(cid) else {
         return false;
     };
@@ -33,7 +32,7 @@ fn open_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str, cid: ClusterId
         .cluster_state
         .cluster_bloom_open
         .retain(|name, open_cid| *open_cid != cid || name == monitor);
-    let _ = close_cluster_bloom_for_monitor(st, monitor);
+    let _ = close_cluster_bloom_for_monitor_inner(st, monitor);
     let _ = st.model.field.set_pinned(core_id, true);
     st.input.interaction_state.physics_velocity.remove(&core_id);
     st.model
@@ -43,7 +42,7 @@ fn open_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str, cid: ClusterId
     true
 }
 
-fn close_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+fn close_cluster_bloom_for_monitor_inner(st: &mut Halley, monitor: &str) -> bool {
     let Some(cid) = st.model.cluster_state.cluster_bloom_open.remove(monitor) else {
         return false;
     };
@@ -53,7 +52,7 @@ fn close_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str) -> bool {
     true
 }
 
-fn enter_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
+fn enter_cluster_mode_inner(st: &mut Halley, monitor: &str) -> bool {
     if st
         .model
         .cluster_state
@@ -69,7 +68,7 @@ fn enter_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
     true
 }
 
-fn exit_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
+fn exit_cluster_mode_inner(st: &mut Halley, monitor: &str) -> bool {
     if !st
         .model
         .cluster_state
@@ -85,7 +84,7 @@ fn exit_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
     true
 }
 
-fn toggle_cluster_mode_selection(st: &mut Halley, monitor: &str, node_id: NodeId) -> bool {
+fn toggle_cluster_mode_selection_inner(st: &mut Halley, monitor: &str, node_id: NodeId) -> bool {
     if !st
         .model
         .cluster_state
@@ -109,7 +108,7 @@ fn toggle_cluster_mode_selection(st: &mut Halley, monitor: &str, node_id: NodeId
     true
 }
 
-fn detach_member_from_cluster(
+fn detach_member_from_cluster_inner(
     st: &mut Halley,
     cid: ClusterId,
     member_id: NodeId,
@@ -141,7 +140,7 @@ fn detach_member_from_cluster(
     Some(outcome)
 }
 
-fn absorb_node_into_cluster(st: &mut Halley, cid: ClusterId, node_id: NodeId) -> bool {
+fn absorb_node_into_cluster_inner(st: &mut Halley, cid: ClusterId, node_id: NodeId) -> bool {
     let active_workspace = st
         .model
         .field
@@ -278,16 +277,15 @@ mod navigation;
 mod overflow;
 mod workspace;
 
+pub(crate) use mode::*;
+pub(crate) use mutation::*;
+pub(crate) use naming::*;
+pub(crate) use navigation::*;
+pub(crate) use overflow::*;
+pub(crate) use workspace::*;
+
 #[cfg(test)]
 mod tests;
-
-pub(crate) struct ClusterSystemController<T> {
-    st: T,
-}
-
-pub(crate) fn cluster_system_controller<T>(st: T) -> ClusterSystemController<T> {
-    ClusterSystemController { st }
-}
 
 pub(crate) fn active_cluster_workspace_for_monitor(
     st: &Halley,
@@ -300,143 +298,107 @@ pub(crate) fn active_cluster_workspace_for_monitor(
         .copied()
 }
 
+pub(crate) const CLUSTER_OVERFLOW_VISIBLE_SLOTS: usize = 15;
+
+pub(crate) fn preferred_monitor_for_cluster(
+    st: &Halley,
+    cid: ClusterId,
+    preferred: Option<&str>,
+) -> Option<String> {
+    crate::compositor::clusters::read::preferred_monitor_for_cluster(st, cid, preferred)
+}
+
+pub(crate) fn cluster_overflow_rect_for_monitor(
+    st: &Halley,
+    monitor: &str,
+) -> Option<halley_core::tiling::Rect> {
+    st.model
+        .cluster_state
+        .cluster_overflow_rects
+        .get(monitor)
+        .copied()
+}
+
+pub(crate) fn cluster_overflow_slot_rect_for_monitor(
+    st: &Halley,
+    monitor: &str,
+    overflow_len: usize,
+    slot_index: usize,
+) -> Option<halley_core::tiling::Rect> {
+    crate::compositor::clusters::read::overflow_strip_slot_rect_for_monitor(
+        st,
+        monitor,
+        overflow_len,
+        slot_index,
+    )
+}
+
+pub(crate) fn active_cluster_tile_rect_for_member(
+    st: &Halley,
+    monitor: &str,
+    member_id: NodeId,
+) -> Option<halley_core::tiling::Rect> {
+    crate::compositor::clusters::read::plan_active_cluster_layout(st, monitor)?
+        .tiles
+        .into_iter()
+        .find(|tile| tile.node_id == member_id)
+        .map(|tile| tile.rect)
+}
+
+pub(crate) fn cluster_spawn_rect_for_new_member(
+    st: &Halley,
+    monitor: &str,
+    cid: ClusterId,
+) -> Option<halley_core::tiling::Rect> {
+    crate::compositor::clusters::read::cluster_spawn_rect_for_new_member(st, monitor, cid)
+}
+
 pub(crate) fn stack_layout_rects_for_members(
     st: &Halley,
     monitor: &str,
     members: &[NodeId],
 ) -> Option<std::collections::HashMap<NodeId, halley_core::tiling::Rect>> {
-    cluster_system_controller(st).stack_layout_rects_for_members(monitor, members)
+    crate::compositor::clusters::read::stack_layout_rects_for_members(st, monitor, members)
 }
 
-impl<T: Deref<Target = Halley>> Deref for ClusterSystemController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
+pub fn has_any_active_cluster_workspace(st: &Halley) -> bool {
+    !st.model.cluster_state.active_cluster_workspaces.is_empty()
 }
 
-impl<T: DerefMut<Target = Halley>> DerefMut for ClusterSystemController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
+pub fn cluster_mode_active(st: &Halley) -> bool {
+    cluster_mode_active_for_monitor(st, st.model.monitor_state.current_monitor.as_str())
 }
 
-impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
-    const CLUSTER_OVERFLOW_VISIBLE_SLOTS: usize = 15;
+pub fn cluster_mode_active_for_monitor(st: &Halley, monitor: &str) -> bool {
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .contains_key(monitor)
+}
 
-    fn preferred_monitor_for_cluster(
-        &self,
-        cid: ClusterId,
-        preferred: Option<&str>,
-    ) -> Option<String> {
-        crate::compositor::clusters::read::preferred_monitor_for_cluster(self, cid, preferred)
-    }
+pub fn has_active_cluster_workspace(st: &Halley) -> bool {
+    active_cluster_workspace_for_monitor(st, st.model.monitor_state.current_monitor.as_str())
+        .is_some()
+}
 
-    pub(crate) fn cluster_overflow_rect_for_monitor(
-        &self,
-        monitor: &str,
-    ) -> Option<halley_core::tiling::Rect> {
-        self.model
-            .cluster_state
-            .cluster_overflow_rects
-            .get(monitor)
-            .copied()
-    }
+pub(crate) fn active_cluster_layout_kind(st: &Halley) -> ClusterWorkspaceLayoutKind {
+    st.runtime.tuning.cluster_layout_kind()
+}
 
-    pub(crate) fn cluster_overflow_slot_rect_for_monitor(
-        &self,
-        monitor: &str,
-        overflow_len: usize,
-        slot_index: usize,
-    ) -> Option<halley_core::tiling::Rect> {
-        crate::compositor::clusters::read::overflow_strip_slot_rect_for_monitor(
-            self,
-            monitor,
-            overflow_len,
-            slot_index,
-        )
+pub(crate) fn cluster_overflow_len(st: &Halley, cid: ClusterId) -> usize {
+    if !matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Tiling
+    ) {
+        return 0;
     }
-
-    pub(crate) fn active_cluster_tile_rect_for_member(
-        &self,
-        monitor: &str,
-        member_id: NodeId,
-    ) -> Option<halley_core::tiling::Rect> {
-        crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)?
-            .tiles
-            .into_iter()
-            .find(|tile| tile.node_id == member_id)
-            .map(|tile| tile.rect)
-    }
-
-    pub(crate) fn cluster_spawn_rect_for_new_member(
-        &self,
-        monitor: &str,
-        cid: ClusterId,
-    ) -> Option<halley_core::tiling::Rect> {
-        crate::compositor::clusters::read::cluster_spawn_rect_for_new_member(self, monitor, cid)
-    }
-
-    pub(crate) fn stack_layout_rects_for_members(
-        &self,
-        monitor: &str,
-        members: &[NodeId],
-    ) -> Option<std::collections::HashMap<NodeId, halley_core::tiling::Rect>> {
-        crate::compositor::clusters::read::stack_layout_rects_for_members(self, monitor, members)
-    }
-
-    pub fn has_any_active_cluster_workspace(&self) -> bool {
-        !self
-            .model
-            .cluster_state
-            .active_cluster_workspaces
-            .is_empty()
-    }
-
-    pub fn cluster_mode_active(&self) -> bool {
-        self.cluster_mode_active_for_monitor(self.model.monitor_state.current_monitor.as_str())
-    }
-
-    pub fn cluster_mode_active_for_monitor(&self, monitor: &str) -> bool {
-        self.model
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .contains_key(monitor)
-    }
-
-    pub fn has_active_cluster_workspace(&self) -> bool {
-        self.active_cluster_workspace_for_monitor(self.model.monitor_state.current_monitor.as_str())
-            .is_some()
-    }
-
-    pub fn active_cluster_workspace_for_monitor(&self, monitor: &str) -> Option<ClusterId> {
-        self.model
-            .cluster_state
-            .active_cluster_workspaces
-            .get(monitor)
-            .copied()
-    }
-
-    fn active_cluster_layout_kind(&self) -> ClusterWorkspaceLayoutKind {
-        self.runtime.tuning.cluster_layout_kind()
-    }
-
-    fn cluster_overflow_len(&self, cid: ClusterId) -> usize {
-        if !matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Tiling
-        ) {
-            return 0;
-        }
-        self.model
-            .field
-            .cluster(cid)
-            .map(|cluster| {
-                cluster
-                    .overflow_members(self.runtime.tuning.tile_max_stack)
-                    .len()
-            })
-            .unwrap_or(0)
-    }
+    st.model
+        .field
+        .cluster(cid)
+        .map(|cluster| {
+            cluster
+                .overflow_members(st.runtime.tuning.tile_max_stack)
+                .len()
+        })
+        .unwrap_or(0)
 }

--- a/crates/halley-wl/src/compositor/clusters/system.rs
+++ b/crates/halley-wl/src/compositor/clusters/system.rs
@@ -12,186 +12,190 @@ use halley_core::cluster_layout::{ClusterCycleDirection, ClusterWorkspaceLayoutK
 use halley_core::field::RemoveNodeClusterEffect;
 use std::ops::{Deref, DerefMut};
 
-struct ClusterMutationController<'a> {
-    field: &'a mut Field,
-    cluster_state: &'a mut ClusterState,
-    interaction_state: &'a mut InteractionState,
-    tuning: &'a halley_config::RuntimeTuning,
+fn cluster_mode_selected_nodes_for_monitor_mut<'a>(
+    st: &'a mut Halley,
+    monitor: &str,
+) -> &'a mut std::collections::HashSet<NodeId> {
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .entry(monitor.to_string())
+        .or_default()
 }
 
-impl<'a> ClusterMutationController<'a> {
-    fn cluster_mode_selected_nodes_for_monitor_mut(
-        &mut self,
-        monitor: &str,
-    ) -> &mut std::collections::HashSet<NodeId> {
-        self.cluster_state
-            .cluster_mode_selected_nodes
-            .entry(monitor.to_string())
-            .or_default()
-    }
+fn open_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str, cid: ClusterId) -> bool {
+    let Some(cluster) = st.model.field.cluster(cid) else {
+        return false;
+    };
+    let Some(core_id) = cluster.core else {
+        return false;
+    };
+    st.model
+        .cluster_state
+        .cluster_bloom_open
+        .retain(|name, open_cid| *open_cid != cid || name == monitor);
+    let _ = close_cluster_bloom_for_monitor(st, monitor);
+    let _ = st.model.field.set_pinned(core_id, true);
+    st.input.interaction_state.physics_velocity.remove(&core_id);
+    st.model
+        .cluster_state
+        .cluster_bloom_open
+        .insert(monitor.to_string(), cid);
+    true
+}
 
-    fn open_cluster_bloom_for_monitor(&mut self, monitor: &str, cid: ClusterId) -> bool {
-        let Some(cluster) = self.field.cluster(cid) else {
-            return false;
-        };
-        let Some(core_id) = cluster.core else {
-            return false;
-        };
-        self.cluster_state
-            .cluster_bloom_open
-            .retain(|name, open_cid| *open_cid != cid || name == monitor);
-        let _ = self.close_cluster_bloom_for_monitor(monitor);
-        let _ = self.field.set_pinned(core_id, true);
-        self.interaction_state.physics_velocity.remove(&core_id);
-        self.cluster_state
-            .cluster_bloom_open
-            .insert(monitor.to_string(), cid);
-        true
+fn close_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let Some(cid) = st.model.cluster_state.cluster_bloom_open.remove(monitor) else {
+        return false;
+    };
+    if let Some(core_id) = st.model.field.cluster(cid).and_then(|cluster| cluster.core) {
+        let _ = st.model.field.set_pinned(core_id, false);
     }
+    true
+}
 
-    fn close_cluster_bloom_for_monitor(&mut self, monitor: &str) -> bool {
-        let Some(cid) = self.cluster_state.cluster_bloom_open.remove(monitor) else {
-            return false;
-        };
-        if let Some(core_id) = self.field.cluster(cid).and_then(|cluster| cluster.core) {
-            let _ = self.field.set_pinned(core_id, false);
-        }
-        true
+fn enter_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
+    if st
+        .model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .contains_key(monitor)
+    {
+        return true;
     }
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .insert(monitor.to_string(), std::collections::HashSet::new());
+    true
+}
 
-    fn enter_cluster_mode(&mut self, monitor: &str) -> bool {
-        if self
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .contains_key(monitor)
-        {
-            return true;
-        }
-        self.cluster_state
-            .cluster_mode_selected_nodes
-            .insert(monitor.to_string(), std::collections::HashSet::new());
-        true
+fn exit_cluster_mode(st: &mut Halley, monitor: &str) -> bool {
+    if !st
+        .model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .contains_key(monitor)
+    {
+        return false;
     }
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .remove(monitor);
+    true
+}
 
-    fn exit_cluster_mode(&mut self, monitor: &str) -> bool {
-        if !self
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .contains_key(monitor)
-        {
-            return false;
-        }
-        self.cluster_state
-            .cluster_mode_selected_nodes
-            .remove(monitor);
-        true
+fn toggle_cluster_mode_selection(st: &mut Halley, monitor: &str, node_id: NodeId) -> bool {
+    if !st
+        .model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .contains_key(monitor)
+    {
+        return false;
     }
-
-    fn toggle_cluster_mode_selection(&mut self, monitor: &str, node_id: NodeId) -> bool {
-        if !self
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .contains_key(monitor)
-        {
-            return false;
-        }
-        let Some(node) = self.field.node(node_id) else {
-            return false;
-        };
-        if node.kind != halley_core::field::NodeKind::Surface
-            || node.state == halley_core::field::NodeState::Core
-            || !self.field.is_visible(node_id)
-        {
-            return false;
-        }
-        if !self
-            .cluster_mode_selected_nodes_for_monitor_mut(monitor)
-            .insert(node_id)
-        {
-            self.cluster_mode_selected_nodes_for_monitor_mut(monitor)
-                .remove(&node_id);
-        }
-        true
+    let Some(node) = st.model.field.node(node_id) else {
+        return false;
+    };
+    if node.kind != halley_core::field::NodeKind::Surface
+        || node.state == halley_core::field::NodeState::Core
+        || !st.model.field.is_visible(node_id)
+    {
+        return false;
     }
+    if !cluster_mode_selected_nodes_for_monitor_mut(st, monitor).insert(node_id) {
+        cluster_mode_selected_nodes_for_monitor_mut(st, monitor).remove(&node_id);
+    }
+    true
+}
 
-    fn detach_member_from_cluster(
-        &mut self,
-        cid: ClusterId,
-        member_id: NodeId,
-        world_pos: Vec2,
-        now_ms: u64,
-    ) -> Option<ClusterRemoveMemberOutcome> {
-        let was_active = self
+fn detach_member_from_cluster(
+    st: &mut Halley,
+    cid: ClusterId,
+    member_id: NodeId,
+    world_pos: Vec2,
+    now_ms: u64,
+) -> Option<ClusterRemoveMemberOutcome> {
+    let was_active = st
+        .model
+        .field
+        .cluster(cid)
+        .is_some_and(|cluster| cluster.is_active());
+    let outcome = st.model.field.remove_member_from_cluster(cid, member_id)?;
+    if matches!(outcome, ClusterRemoveMemberOutcome::Removed) && was_active {
+        let _ = st
+            .model
             .field
-            .cluster(cid)
-            .is_some_and(|cluster| cluster.is_active());
-        let outcome = self.field.remove_member_from_cluster(cid, member_id)?;
-        if matches!(outcome, ClusterRemoveMemberOutcome::Removed) && was_active {
-            let _ = self
-                .field
-                .move_member_out_of_active_cluster_workspace(cid, member_id);
-        }
-        let _ = self.field.set_detached(member_id, false);
-        let _ = self
+            .move_member_out_of_active_cluster_workspace(cid, member_id);
+    }
+    let _ = st.model.field.set_detached(member_id, false);
+    let _ = st
+        .model
+        .field
+        .set_state(member_id, halley_core::field::NodeState::Active);
+    if let Some(node) = st.model.field.node_mut(member_id) {
+        node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
+        node.pos = world_pos;
+    }
+    let _ = st.model.field.touch(member_id, now_ms);
+    Some(outcome)
+}
+
+fn absorb_node_into_cluster(st: &mut Halley, cid: ClusterId, node_id: NodeId) -> bool {
+    let active_workspace = st
+        .model
+        .field
+        .cluster(cid)
+        .is_some_and(|cluster| cluster.is_active());
+    let add_result = if matches!(
+        st.runtime.tuning.cluster_layout_kind(),
+        ClusterWorkspaceLayoutKind::Stacking
+    ) {
+        st.model.field.add_member_to_cluster_front(cid, node_id)
+    } else {
+        st.model.field.add_member_to_cluster(cid, node_id)
+    };
+    if add_result.is_err() {
+        return false;
+    }
+    if st.runtime.tuning.tile_new_on_top
+        && matches!(
+            st.runtime.tuning.cluster_layout_kind(),
+            ClusterWorkspaceLayoutKind::Tiling
+        )
+    {
+        let _ = st
+            .model
             .field
-            .set_state(member_id, halley_core::field::NodeState::Active);
-        if let Some(node) = self.field.node_mut(member_id) {
+            .promote_cluster_member_to_master(cid, node_id);
+    }
+    if active_workspace {
+        if !st
+            .model
+            .field
+            .move_member_into_active_cluster_workspace(cid, node_id)
+        {
+            return false;
+        }
+        if let Some(cluster) = st.model.field.cluster_mut(cid)
+            && let Some(node) = cluster.workspace_member_mut(node_id)
+        {
             node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
-            node.pos = world_pos;
+            node.visibility.set(Visibility::DETACHED, false);
+            node.state = halley_core::field::NodeState::Active;
         }
-        let _ = self.field.touch(member_id, now_ms);
-        Some(outcome)
-    }
-
-    fn absorb_node_into_cluster(&mut self, cid: ClusterId, node_id: NodeId) -> bool {
-        let active_workspace = self
+    } else {
+        let _ = st
+            .model
             .field
-            .cluster(cid)
-            .is_some_and(|cluster| cluster.is_active());
-        let add_result = if matches!(
-            self.tuning.cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Stacking
-        ) {
-            self.field.add_member_to_cluster_front(cid, node_id)
-        } else {
-            self.field.add_member_to_cluster(cid, node_id)
-        };
-        if add_result.is_err() {
-            return false;
+            .set_state(node_id, halley_core::field::NodeState::Node);
+        if let Some(node) = st.model.field.node_mut(node_id) {
+            node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, true);
         }
-        if self.tuning.tile_new_on_top
-            && matches!(
-                self.tuning.cluster_layout_kind(),
-                ClusterWorkspaceLayoutKind::Tiling
-            )
-        {
-            let _ = self.field.promote_cluster_member_to_master(cid, node_id);
-        }
-        if active_workspace {
-            if !self
-                .field
-                .move_member_into_active_cluster_workspace(cid, node_id)
-            {
-                return false;
-            }
-            if let Some(cluster) = self.field.cluster_mut(cid)
-                && let Some(node) = cluster.workspace_member_mut(node_id)
-            {
-                node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
-                node.visibility.set(Visibility::DETACHED, false);
-                node.state = halley_core::field::NodeState::Active;
-            }
-        } else {
-            let _ = self
-                .field
-                .set_state(node_id, halley_core::field::NodeState::Node);
-            if let Some(node) = self.field.node_mut(node_id) {
-                node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, true);
-            }
-            let _ = self.field.set_detached(node_id, false);
-        }
-        true
+        let _ = st.model.field.set_detached(node_id, false);
     }
+    true
 }
 
 fn rect_center(rect: halley_core::tiling::Rect) -> Vec2 {

--- a/crates/halley-wl/src/compositor/clusters/system/mode.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mode.rs
@@ -6,8 +6,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         &mut self,
         monitor: &str,
     ) -> Option<halley_core::cluster::ClusterId> {
-        self.cluster_read_controller()
-            .cluster_bloom_for_monitor(monitor)
+        crate::compositor::clusters::read::cluster_bloom_for_monitor(self, monitor)
     }
 
     pub fn open_cluster_bloom_for_monitor(

--- a/crates/halley-wl/src/compositor/clusters/system/mode.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mode.rs
@@ -1,165 +1,147 @@
 use super::naming::cluster_mode_selection_banner;
 use super::*;
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    pub fn cluster_bloom_for_monitor(
-        &mut self,
-        monitor: &str,
-    ) -> Option<halley_core::cluster::ClusterId> {
-        crate::compositor::clusters::read::cluster_bloom_for_monitor(self, monitor)
-    }
+pub fn cluster_bloom_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+) -> Option<halley_core::cluster::ClusterId> {
+    crate::compositor::clusters::read::cluster_bloom_for_monitor(st, monitor)
+}
 
-    pub fn open_cluster_bloom_for_monitor(
-        &mut self,
-        monitor: &str,
-        cid: halley_core::cluster::ClusterId,
-    ) -> bool {
-        let _ = self.sync_cluster_monitor(cid, Some(monitor));
-        let opened = super::open_cluster_bloom_for_monitor(self, monitor, cid);
-        if opened
-            && let Some(core_id) = self
-                .model
-                .field
-                .cluster(cid)
-                .and_then(|cluster| cluster.core)
-        {
-            self.set_interaction_focus(Some(core_id), 30_000, Instant::now());
-        }
-        opened
+pub fn open_cluster_bloom_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    cid: halley_core::cluster::ClusterId,
+) -> bool {
+    let _ = sync_cluster_monitor(st, cid, Some(monitor));
+    let opened = super::open_cluster_bloom_for_monitor_inner(st, monitor, cid);
+    if opened && let Some(core_id) = st.model.field.cluster(cid).and_then(|cluster| cluster.core) {
+        st.set_interaction_focus(Some(core_id), 30_000, Instant::now());
     }
+    opened
+}
 
-    pub fn close_cluster_bloom_for_monitor(&mut self, monitor: &str) -> bool {
-        let core_id = self.cluster_bloom_for_monitor(monitor).and_then(|cid| {
-            self.model
-                .field
-                .cluster(cid)
-                .and_then(|cluster| cluster.core)
-        });
-        let closed = super::close_cluster_bloom_for_monitor(self, monitor);
-        if closed {
-            let now = Instant::now();
-            if let Some(core_id) = core_id {
-                self.set_recent_top_node(core_id, now + std::time::Duration::from_millis(1200));
-                self.set_interaction_focus(Some(core_id), 30_000, now);
-            }
+pub fn close_cluster_bloom_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let core_id = cluster_bloom_for_monitor(st, monitor)
+        .and_then(|cid| st.model.field.cluster(cid).and_then(|cluster| cluster.core));
+    let closed = super::close_cluster_bloom_for_monitor_inner(st, monitor);
+    if closed {
+        let now = Instant::now();
+        if let Some(core_id) = core_id {
+            st.set_recent_top_node(core_id, now + std::time::Duration::from_millis(1200));
+            st.set_interaction_focus(Some(core_id), 30_000, now);
         }
-        closed
     }
+    closed
+}
 
-    pub fn enter_cluster_mode(&mut self) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        if self
-            .active_cluster_workspace_for_monitor(monitor.as_str())
-            .is_some()
-        {
-            let now_ms = self.now_ms(Instant::now());
-            self.ui.render_state.show_overlay_toast(
-                monitor.as_str(),
-                "Cluster mode unavailable\nExit the workspace first",
-                3200,
-                now_ms,
-            );
-            return false;
-        }
-        if !super::enter_cluster_mode(self, monitor.as_str()) {
-            return false;
-        }
-        self.begin_modal_keyboard_capture();
-        cluster_mode_selection_banner(self, monitor.as_str());
-        true
+pub fn enter_cluster_mode(st: &mut Halley) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    if active_cluster_workspace_for_monitor(st, monitor.as_str()).is_some() {
+        let now_ms = st.now_ms(Instant::now());
+        st.ui.render_state.show_overlay_toast(
+            monitor.as_str(),
+            "Cluster mode unavailable\nExit the workspace first",
+            3200,
+            now_ms,
+        );
+        return false;
     }
+    if !super::enter_cluster_mode_inner(st, monitor.as_str()) {
+        return false;
+    }
+    st.begin_modal_keyboard_capture();
+    cluster_mode_selection_banner(st, monitor.as_str());
+    true
+}
 
-    pub fn exit_cluster_mode(&mut self) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        if !super::exit_cluster_mode(self, monitor.as_str()) {
-            return false;
-        }
-        self.model
-            .cluster_state
-            .cluster_name_prompt
-            .remove(monitor.as_str());
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor
-            .as_deref()
-            == Some(monitor.as_str())
-        {
-            self.input
-                .interaction_state
-                .cluster_name_prompt_drag_monitor = None;
-        }
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_repeat
-            .as_ref()
-            .is_some_and(|repeat| repeat.monitor == monitor)
-        {
-            self.input.interaction_state.cluster_name_prompt_repeat = None;
-        }
-        self.ui
-            .render_state
-            .clear_persistent_mode_banner(monitor.as_str());
-        let focused_surface = self
-            .model
-            .focus_state
-            .primary_interaction_focus
-            .filter(|&id| {
-                self.model.field.node(id).is_some_and(|node| {
-                    self.model.field.is_visible(id)
-                        && node.kind == halley_core::field::NodeKind::Surface
-                })
+pub fn exit_cluster_mode(st: &mut Halley) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    if !super::exit_cluster_mode_inner(st, monitor.as_str()) {
+        return false;
+    }
+    st.model
+        .cluster_state
+        .cluster_name_prompt
+        .remove(monitor.as_str());
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_drag_monitor
+        .as_deref()
+        == Some(monitor.as_str())
+    {
+        st.input.interaction_state.cluster_name_prompt_drag_monitor = None;
+    }
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_repeat
+        .as_ref()
+        .is_some_and(|repeat| repeat.monitor == monitor)
+    {
+        st.input.interaction_state.cluster_name_prompt_repeat = None;
+    }
+    st.ui
+        .render_state
+        .clear_persistent_mode_banner(monitor.as_str());
+    let focused_surface = st
+        .model
+        .focus_state
+        .primary_interaction_focus
+        .filter(|&id| {
+            st.model.field.node(id).is_some_and(|node| {
+                st.model.field.is_visible(id) && node.kind == halley_core::field::NodeKind::Surface
             })
-            .or_else(|| self.last_input_surface_node_for_monitor(monitor.as_str()));
-        self.schedule_modal_focus_restore(focused_surface, Instant::now());
-        true
+        })
+        .or_else(|| st.last_input_surface_node_for_monitor(monitor.as_str()));
+    st.schedule_modal_focus_restore(focused_surface, Instant::now());
+    true
+}
+
+pub fn toggle_cluster_mode_selection(st: &mut Halley, node_id: NodeId) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    super::toggle_cluster_mode_selection_inner(st, monitor.as_str(), node_id)
+}
+
+pub(super) fn order_cluster_creation_members(st: &Halley, members: Vec<NodeId>) -> Vec<NodeId> {
+    if members.len() <= 1 {
+        return members;
     }
 
-    pub fn toggle_cluster_mode_selection(&mut self, node_id: NodeId) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        super::toggle_cluster_mode_selection(self, monitor.as_str(), node_id)
-    }
-
-    pub(super) fn order_cluster_creation_members(&self, members: Vec<NodeId>) -> Vec<NodeId> {
-        if members.len() <= 1 {
-            return members;
-        }
-
-        let selected = members.iter().copied().collect::<HashSet<_>>();
-        let master = self
-            .model
-            .focus_state
-            .primary_interaction_focus
-            .filter(|id| selected.contains(id))
-            .or_else(|| {
-                members.iter().copied().max_by_key(|id| {
-                    (
-                        self.model
-                            .focus_state
-                            .last_surface_focus_ms
-                            .get(id)
-                            .copied()
-                            .unwrap_or(0),
-                        std::cmp::Reverse(id.as_u64()),
-                    )
-                })
+    let selected = members.iter().copied().collect::<HashSet<_>>();
+    let master = st
+        .model
+        .focus_state
+        .primary_interaction_focus
+        .filter(|id| selected.contains(id))
+        .or_else(|| {
+            members.iter().copied().max_by_key(|id| {
+                (
+                    st.model
+                        .focus_state
+                        .last_surface_focus_ms
+                        .get(id)
+                        .copied()
+                        .unwrap_or(0),
+                    std::cmp::Reverse(id.as_u64()),
+                )
             })
-            .unwrap_or(members[0]);
+        })
+        .unwrap_or(members[0]);
 
-        let mut secondaries = members
-            .into_iter()
-            .filter(|id| *id != master)
-            .collect::<Vec<_>>();
-        secondaries.sort_by_key(|id| id.as_u64());
+    let mut secondaries = members
+        .into_iter()
+        .filter(|id| *id != master)
+        .collect::<Vec<_>>();
+    secondaries.sort_by_key(|id| id.as_u64());
 
-        let mut ordered = Vec::with_capacity(secondaries.len() + 1);
-        ordered.push(master);
-        ordered.extend(secondaries);
-        ordered
-    }
+    let mut ordered = Vec::with_capacity(secondaries.len() + 1);
+    ordered.push(master);
+    ordered.extend(secondaries);
+    ordered
+}
 
-    pub fn confirm_cluster_mode(&mut self, now: Instant) -> bool {
-        self.open_cluster_name_prompt(now)
-    }
+pub fn confirm_cluster_mode(st: &mut Halley, now: Instant) -> bool {
+    open_cluster_name_prompt(st, now)
 }

--- a/crates/halley-wl/src/compositor/clusters/system/mode.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mode.rs
@@ -16,9 +16,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         cid: halley_core::cluster::ClusterId,
     ) -> bool {
         let _ = self.sync_cluster_monitor(cid, Some(monitor));
-        let opened = self
-            .cluster_mutation_controller()
-            .open_cluster_bloom_for_monitor(monitor, cid);
+        let opened = super::open_cluster_bloom_for_monitor(self, monitor, cid);
         if opened
             && let Some(core_id) = self
                 .model
@@ -38,9 +36,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
                 .cluster(cid)
                 .and_then(|cluster| cluster.core)
         });
-        let closed = self
-            .cluster_mutation_controller()
-            .close_cluster_bloom_for_monitor(monitor);
+        let closed = super::close_cluster_bloom_for_monitor(self, monitor);
         if closed {
             let now = Instant::now();
             if let Some(core_id) = core_id {
@@ -66,10 +62,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             );
             return false;
         }
-        if !self
-            .cluster_mutation_controller()
-            .enter_cluster_mode(monitor.as_str())
-        {
+        if !super::enter_cluster_mode(self, monitor.as_str()) {
             return false;
         }
         self.begin_modal_keyboard_capture();
@@ -79,10 +72,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
 
     pub fn exit_cluster_mode(&mut self) -> bool {
         let monitor = self.model.monitor_state.current_monitor.clone();
-        if !self
-            .cluster_mutation_controller()
-            .exit_cluster_mode(monitor.as_str())
-        {
+        if !super::exit_cluster_mode(self, monitor.as_str()) {
             return false;
         }
         self.model
@@ -129,8 +119,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
 
     pub fn toggle_cluster_mode_selection(&mut self, node_id: NodeId) -> bool {
         let monitor = self.model.monitor_state.current_monitor.clone();
-        self.cluster_mutation_controller()
-            .toggle_cluster_mode_selection(monitor.as_str(), node_id)
+        super::toggle_cluster_mode_selection(self, monitor.as_str(), node_id)
     }
 
     pub(super) fn order_cluster_creation_members(&self, members: Vec<NodeId>) -> Vec<NodeId> {

--- a/crates/halley-wl/src/compositor/clusters/system/mutation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mutation.rs
@@ -29,21 +29,6 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         self.model.focus_state.monitor_focus.remove(monitor);
     }
 
-    pub(super) fn cluster_mutation_controller(&mut self) -> ClusterMutationController<'_> {
-        let crate::compositor::root::Halley {
-            model,
-            input,
-            runtime,
-            ..
-        } = &mut **self;
-        ClusterMutationController {
-            field: &mut model.field,
-            cluster_state: &mut model.cluster_state,
-            interaction_state: &mut input.interaction_state,
-            tuning: &runtime.tuning,
-        }
-    }
-
     pub(crate) fn sync_cluster_monitor(
         &mut self,
         cid: halley_core::cluster::ClusterId,
@@ -236,9 +221,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         now: Instant,
     ) -> bool {
         let now_ms = self.now_ms(now);
-        let Some(outcome) = self
-            .cluster_mutation_controller()
-            .detach_member_from_cluster(cid, member_id, world_pos, now_ms)
+        let Some(outcome) =
+            super::detach_member_from_cluster(self, cid, member_id, world_pos, now_ms)
         else {
             return false;
         };
@@ -290,10 +274,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
                 (monitor, old_visible)
             });
         let was_pinned = self.node_user_pinned(node_id);
-        if !self
-            .cluster_mutation_controller()
-            .absorb_node_into_cluster(cid, node_id)
-        {
+        if !super::absorb_node_into_cluster(self, cid, node_id) {
             return false;
         }
 

--- a/crates/halley-wl/src/compositor/clusters/system/mutation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mutation.rs
@@ -18,7 +18,8 @@ pub(crate) fn reset_empty_monitor_spawn_state(st: &mut Halley, monitor: &str) {
         return;
     }
 
-    let view_anchor = st.default_spawn_view_anchor_for_monitor(monitor);
+    let view_anchor =
+        crate::compositor::spawn::state::default_spawn_view_anchor_for_monitor(st, monitor);
     let spawn = st.spawn_monitor_state_mut(monitor);
     spawn.spawn_patch = None;
     spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;

--- a/crates/halley-wl/src/compositor/clusters/system/mutation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/mutation.rs
@@ -1,367 +1,334 @@
 use super::*;
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    fn monitor_has_visible_surface_node(&self, monitor: &str) -> bool {
-        self.model.field.nodes().values().any(|node| {
-            node.kind == halley_core::field::NodeKind::Surface
-                && self.model.field.is_visible(node.id)
-                && self
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&node.id)
-                    .is_some_and(|node_monitor| node_monitor == monitor)
+pub(crate) fn monitor_has_visible_surface_node(st: &Halley, monitor: &str) -> bool {
+    st.model.field.nodes().values().any(|node| {
+        node.kind == halley_core::field::NodeKind::Surface
+            && st.model.field.is_visible(node.id)
+            && st
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&node.id)
+                .is_some_and(|node_monitor| node_monitor == monitor)
+    })
+}
+
+pub(crate) fn reset_empty_monitor_spawn_state(st: &mut Halley, monitor: &str) {
+    if monitor_has_visible_surface_node(st, monitor) {
+        return;
+    }
+
+    let view_anchor = st.default_spawn_view_anchor_for_monitor(monitor);
+    let spawn = st.spawn_monitor_state_mut(monitor);
+    spawn.spawn_patch = None;
+    spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+    spawn.spawn_view_anchor = view_anchor;
+    spawn.spawn_focus_override = None;
+    spawn.spawn_pan_start_center = None;
+    st.model.focus_state.monitor_focus.remove(monitor);
+}
+
+pub(crate) fn sync_cluster_monitor(
+    st: &mut Halley,
+    cid: halley_core::cluster::ClusterId,
+    preferred: Option<&str>,
+) -> bool {
+    let Some(target_monitor) = preferred_monitor_for_cluster(st, cid, preferred) else {
+        return false;
+    };
+
+    let (core_id, members) = if let Some(cluster) = st.model.field.cluster(cid) {
+        (cluster.core, cluster.members().to_vec())
+    } else {
+        return false;
+    };
+
+    if let Some(core_id) = core_id {
+        st.assign_node_to_monitor(core_id, target_monitor.as_str());
+    }
+    for member_id in members {
+        st.assign_node_to_monitor(member_id, target_monitor.as_str());
+    }
+    let _ = sync_cluster_name_for_monitor(st, cid, target_monitor.as_str());
+    true
+}
+
+pub(crate) fn dissolve_cluster(st: &mut Halley, cid: ClusterId) -> bool {
+    let core_id = st.model.field.cluster(cid).and_then(|cluster| cluster.core);
+    clear_cluster_shell_state(st, cid);
+    if let Some(core_id) = core_id {
+        st.model.monitor_state.node_monitor.remove(&core_id);
+        st.model.workspace_state.user_pinned_nodes.remove(&core_id);
+    }
+    remove_cluster_name_record(st, cid);
+    st.model.field.dissolve_cluster(cid)
+}
+
+pub(crate) fn remove_node_from_field(st: &mut Halley, id: NodeId, now_ms: u64) -> bool {
+    let removed_monitor = st.model.monitor_state.node_monitor.get(&id).cloned();
+    let stack_remove_transition = st
+        .model
+        .field
+        .cluster_id_for_member_public(id)
+        .and_then(|cid| preferred_monitor_for_cluster(st, cid, None).map(|monitor| (cid, monitor)))
+        .filter(|(cid, monitor)| {
+            active_cluster_workspace_for_monitor(st, monitor.as_str()) == Some(*cid)
         })
-    }
+        .filter(|_| {
+            matches!(
+                active_cluster_layout_kind(st),
+                ClusterWorkspaceLayoutKind::Stacking
+            )
+        })
+        .map(|(_, monitor)| {
+            let old_visible =
+                crate::compositor::surface::active_stacking_visible_members_for_monitor(
+                    st,
+                    monitor.as_str(),
+                );
+            (monitor, old_visible)
+        });
+    let cluster_snapshot = st
+        .model
+        .field
+        .cluster_id_for_member_public(id)
+        .and_then(|cid| {
+            st.model
+                .field
+                .cluster(cid)
+                .map(|cluster| (cid, cluster.members().to_vec(), cluster.core))
+        });
+    let (snapshot_cid, snapshot_members, snapshot_core_id) =
+        cluster_snapshot.unwrap_or((ClusterId::new(0), Vec::new(), None));
+    let Some((_, effect)) = st.model.field.remove_node_cluster_safe(id) else {
+        return false;
+    };
 
-    fn reset_empty_monitor_spawn_state(&mut self, monitor: &str) {
-        if self.monitor_has_visible_surface_node(monitor) {
-            return;
-        }
-
-        let view_anchor = self.default_spawn_view_anchor_for_monitor(monitor);
-        let spawn = self.spawn_monitor_state_mut(monitor);
-        spawn.spawn_patch = None;
-        spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
-        spawn.spawn_view_anchor = view_anchor;
-        spawn.spawn_focus_override = None;
-        spawn.spawn_pan_start_center = None;
-        self.model.focus_state.monitor_focus.remove(monitor);
-    }
-
-    pub(crate) fn sync_cluster_monitor(
-        &mut self,
-        cid: halley_core::cluster::ClusterId,
-        preferred: Option<&str>,
-    ) -> bool {
-        let Some(target_monitor) = self.preferred_monitor_for_cluster(cid, preferred) else {
-            return false;
-        };
-
-        let (core_id, members) = if let Some(cluster) = self.model.field.cluster(cid) {
-            (cluster.core, cluster.members().to_vec())
-        } else {
-            return false;
-        };
-
-        if let Some(core_id) = core_id {
-            self.assign_node_to_monitor(core_id, target_monitor.as_str());
-        }
-        for member_id in members {
-            self.assign_node_to_monitor(member_id, target_monitor.as_str());
-        }
-        let _ = self.sync_cluster_name_for_monitor(cid, target_monitor.as_str());
-        true
-    }
-
-    fn dissolve_cluster(&mut self, cid: ClusterId) -> bool {
-        let core_id = self
-            .model
-            .field
-            .cluster(cid)
-            .and_then(|cluster| cluster.core);
-        self.clear_cluster_shell_state(cid);
-        if let Some(core_id) = core_id {
-            self.model.monitor_state.node_monitor.remove(&core_id);
-            self.model
-                .workspace_state
-                .user_pinned_nodes
-                .remove(&core_id);
-        }
-        self.remove_cluster_name_record(cid);
-        self.model.field.dissolve_cluster(cid)
-    }
-
-    pub(crate) fn remove_node_from_field(&mut self, id: NodeId, now_ms: u64) -> bool {
-        let removed_monitor = self.model.monitor_state.node_monitor.get(&id).cloned();
-        let stack_remove_transition = self
-            .model
-            .field
-            .cluster_id_for_member_public(id)
-            .and_then(|cid| {
-                self.preferred_monitor_for_cluster(cid, None)
-                    .map(|monitor| (cid, monitor))
-            })
-            .filter(|(cid, monitor)| {
-                self.active_cluster_workspace_for_monitor(monitor.as_str()) == Some(*cid)
-            })
-            .filter(|_| {
-                matches!(
-                    self.active_cluster_layout_kind(),
-                    ClusterWorkspaceLayoutKind::Stacking
-                )
-            })
-            .map(|(_, monitor)| {
-                let old_visible =
-                    crate::compositor::surface::active_stacking_visible_members_for_monitor(
-                        self,
-                        monitor.as_str(),
-                    );
-                (monitor, old_visible)
-            });
-        let cluster_snapshot = self
-            .model
-            .field
-            .cluster_id_for_member_public(id)
-            .and_then(|cid| {
-                self.model
-                    .field
-                    .cluster(cid)
-                    .map(|cluster| (cid, cluster.members().to_vec(), cluster.core))
-            });
-        let (snapshot_cid, snapshot_members, snapshot_core_id) =
-            cluster_snapshot.unwrap_or((ClusterId::new(0), Vec::new(), None));
-        let Some((_, effect)) = self.model.field.remove_node_cluster_safe(id) else {
-            return false;
-        };
-
-        match effect {
-            Some(RemoveNodeClusterEffect::RemovedMember(cid)) => {
-                if let Some(cluster_monitor) = self.preferred_monitor_for_cluster(cid, None)
-                    && self.active_cluster_workspace_for_monitor(cluster_monitor.as_str())
-                        == Some(cid)
+    match effect {
+        Some(RemoveNodeClusterEffect::RemovedMember(cid)) => {
+            if let Some(cluster_monitor) = preferred_monitor_for_cluster(st, cid, None)
+                && active_cluster_workspace_for_monitor(st, cluster_monitor.as_str()) == Some(cid)
+            {
+                layout_active_cluster_workspace_for_monitor(st, cluster_monitor.as_str(), now_ms);
+                if let Some((transition_monitor, old_visible)) = stack_remove_transition.as_ref()
+                    && transition_monitor == &cluster_monitor
                 {
-                    self.layout_active_cluster_workspace_for_monitor(
-                        cluster_monitor.as_str(),
-                        now_ms,
-                    );
-                    if let Some((transition_monitor, old_visible)) =
-                        stack_remove_transition.as_ref()
-                        && transition_monitor == &cluster_monitor
-                    {
-                        let duration_ms = self.runtime.tuning.stack_animation_duration_ms();
-                        let new_visible =
-                            crate::compositor::surface::active_stacking_visible_members_for_monitor(
-                                self,
-                                cluster_monitor.as_str(),
-                            );
-                        if self.runtime.tuning.stack_animation_enabled() {
-                            let transition_now = Instant::now();
-                            for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
-                                self.request_window_animation_prewarm(node_id, transition_now);
-                            }
-                            self.ui.render_state.start_stack_cycle_transition(
-                                cluster_monitor.as_str(),
-                                ClusterCycleDirection::Prev,
-                                old_visible.clone(),
-                                new_visible,
-                                transition_now,
-                                duration_ms,
-                            );
-                            self.request_maintenance();
-                        }
-                    }
-                }
-            }
-            Some(RemoveNodeClusterEffect::DissolvedCluster(cid)) => {
-                self.remove_cluster_name_record(cid);
-                let survivors = if snapshot_cid == cid {
-                    snapshot_members
-                        .iter()
-                        .copied()
-                        .filter(|member| *member != id && self.model.field.node(*member).is_some())
-                        .collect::<Vec<_>>()
-                } else {
-                    Vec::new()
-                };
-                self.clear_cluster_shell_state(cid);
-                if let Some(core_id) = snapshot_core_id.filter(|_| snapshot_cid == cid) {
-                    self.model.monitor_state.node_monitor.remove(&core_id);
-                }
-                for survivor in survivors {
-                    if self
-                        .model
-                        .workspace_state
-                        .pending_silent_close_until_ms
-                        .contains_key(&survivor)
-                        && let Some(node) = self.model.field.node_mut(survivor)
-                    {
-                        node.visibility
-                            .set(halley_core::field::Visibility::HIDDEN_BY_CLUSTER, true);
-                    }
-                    let _ = self.model.field.set_detached(survivor, false);
-                    if let Some(size) = self
-                        .model
-                        .workspace_state
-                        .last_active_size
-                        .get(&survivor)
-                        .copied()
-                    {
-                        if let Some(node) = self.model.field.node_mut(survivor) {
-                            node.intrinsic_size = size;
-                        }
-                        self.request_toplevel_resize(
-                            survivor,
-                            size.x.round() as i32,
-                            size.y.round() as i32,
+                    let duration_ms = st.runtime.tuning.stack_animation_duration_ms();
+                    let new_visible =
+                        crate::compositor::surface::active_stacking_visible_members_for_monitor(
+                            st,
+                            cluster_monitor.as_str(),
                         );
-                    }
-                    let _ = self.model.field.touch(survivor, now_ms);
-                }
-            }
-            Some(RemoveNodeClusterEffect::RemovedCore(cid)) => {
-                self.model.monitor_state.node_monitor.remove(&id);
-                let _ = self.sync_cluster_monitor(cid, None);
-            }
-            None => {}
-        }
-
-        if let Some(monitor) = removed_monitor {
-            self.reset_empty_monitor_spawn_state(monitor.as_str());
-        }
-
-        true
-    }
-
-    pub fn detach_member_from_cluster(
-        &mut self,
-        cid: halley_core::cluster::ClusterId,
-        member_id: NodeId,
-        world_pos: Vec2,
-        now: Instant,
-    ) -> bool {
-        let now_ms = self.now_ms(now);
-        let Some(outcome) =
-            super::detach_member_from_cluster(self, cid, member_id, world_pos, now_ms)
-        else {
-            return false;
-        };
-        match outcome {
-            ClusterRemoveMemberOutcome::Removed => {
-                if let Some(cluster_monitor) = self.preferred_monitor_for_cluster(cid, None)
-                    && self.active_cluster_workspace_for_monitor(cluster_monitor.as_str())
-                        == Some(cid)
-                {
-                    self.layout_active_cluster_workspace_for_monitor(
-                        cluster_monitor.as_str(),
-                        now_ms,
-                    );
-                }
-            }
-            ClusterRemoveMemberOutcome::RequiresDissolve => {
-                if !self.dissolve_cluster(cid) {
-                    return false;
-                }
-            }
-        }
-        true
-    }
-
-    pub fn absorb_node_into_cluster(
-        &mut self,
-        cid: halley_core::cluster::ClusterId,
-        node_id: NodeId,
-        now: Instant,
-    ) -> bool {
-        let previous_overflow_len = self.cluster_overflow_len(cid);
-        let stack_insert_transition = self
-            .preferred_monitor_for_cluster(cid, None)
-            .filter(|monitor| {
-                self.active_cluster_workspace_for_monitor(monitor.as_str()) == Some(cid)
-            })
-            .filter(|_| {
-                matches!(
-                    self.active_cluster_layout_kind(),
-                    ClusterWorkspaceLayoutKind::Stacking
-                )
-            })
-            .map(|monitor| {
-                let old_visible =
-                    crate::compositor::surface::active_stacking_visible_members_for_monitor(
-                        self,
-                        monitor.as_str(),
-                    );
-                (monitor, old_visible)
-            });
-        let was_pinned = self.node_user_pinned(node_id);
-        if !super::absorb_node_into_cluster(self, cid, node_id) {
-            return false;
-        }
-
-        if was_pinned {
-            self.model
-                .workspace_state
-                .user_pinned_nodes
-                .remove(&node_id);
-            if let Some(core_id) = self.model.field.cluster(cid).and_then(|c| c.core) {
-                self.model.workspace_state.user_pinned_nodes.insert(core_id);
-            }
-        }
-
-        if let Some(cluster_monitor) = self.preferred_monitor_for_cluster(cid, None) {
-            self.assign_node_to_monitor(node_id, cluster_monitor.as_str());
-            if self.active_cluster_workspace_for_monitor(cluster_monitor.as_str()) == Some(cid) {
-                if let Some(node) = self.model.field.node_mut(node_id) {
-                    node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
-                }
-                let now_ms = self.now_ms(now);
-                self.layout_active_cluster_workspace_for_monitor(cluster_monitor.as_str(), now_ms);
-                if matches!(
-                    self.active_cluster_layout_kind(),
-                    ClusterWorkspaceLayoutKind::Stacking
-                ) {
-                    if let Some((transition_monitor, old_visible)) =
-                        stack_insert_transition.as_ref()
-                        && transition_monitor == &cluster_monitor
-                    {
-                        let duration_ms = self.runtime.tuning.stack_animation_duration_ms();
-                        let new_visible =
-                            crate::compositor::surface::active_stacking_visible_members_for_monitor(
-                                self,
-                                cluster_monitor.as_str(),
-                            );
-                        if self.runtime.tuning.stack_animation_enabled() {
-                            for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
-                                self.request_window_animation_prewarm(node_id, now);
-                            }
-                            self.ui.render_state.start_stack_cycle_transition(
-                                cluster_monitor.as_str(),
-                                ClusterCycleDirection::Prev,
-                                old_visible.clone(),
-                                new_visible,
-                                now,
-                                duration_ms,
-                            );
-                            self.request_maintenance();
+                    if st.runtime.tuning.stack_animation_enabled() {
+                        let transition_now = Instant::now();
+                        for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
+                            st.request_window_animation_prewarm(node_id, transition_now);
                         }
+                        st.ui.render_state.start_stack_cycle_transition(
+                            cluster_monitor.as_str(),
+                            ClusterCycleDirection::Prev,
+                            old_visible.clone(),
+                            new_visible,
+                            transition_now,
+                            duration_ms,
+                        );
+                        st.request_maintenance();
                     }
-                    self.set_recent_top_node(node_id, now + std::time::Duration::from_millis(1200));
-                    self.set_interaction_focus(Some(node_id), 30_000, now);
-                    self.update_focus_tracking_for_surface(node_id, now_ms);
-                }
-                let overflow_len = self.cluster_overflow_len(cid);
-                if overflow_len > previous_overflow_len {
-                    self.reveal_cluster_overflow_for_monitor(cluster_monitor.as_str(), now_ms);
                 }
             }
         }
-        if let Some(core_id) = self
-            .model
-            .field
-            .cluster(cid)
-            .and_then(|cluster| cluster.core)
-        {
-            let now_ms = self.now_ms(now);
-            let _ = self.model.field.touch(core_id, now_ms);
+        Some(RemoveNodeClusterEffect::DissolvedCluster(cid)) => {
+            remove_cluster_name_record(st, cid);
+            let survivors = if snapshot_cid == cid {
+                snapshot_members
+                    .iter()
+                    .copied()
+                    .filter(|member| *member != id && st.model.field.node(*member).is_some())
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            clear_cluster_shell_state(st, cid);
+            if let Some(core_id) = snapshot_core_id.filter(|_| snapshot_cid == cid) {
+                st.model.monitor_state.node_monitor.remove(&core_id);
+            }
+            for survivor in survivors {
+                if st
+                    .model
+                    .workspace_state
+                    .pending_silent_close_until_ms
+                    .contains_key(&survivor)
+                    && let Some(node) = st.model.field.node_mut(survivor)
+                {
+                    node.visibility
+                        .set(halley_core::field::Visibility::HIDDEN_BY_CLUSTER, true);
+                }
+                let _ = st.model.field.set_detached(survivor, false);
+                if let Some(size) = st
+                    .model
+                    .workspace_state
+                    .last_active_size
+                    .get(&survivor)
+                    .copied()
+                {
+                    if let Some(node) = st.model.field.node_mut(survivor) {
+                        node.intrinsic_size = size;
+                    }
+                    st.request_toplevel_resize(
+                        survivor,
+                        size.x.round() as i32,
+                        size.y.round() as i32,
+                    );
+                }
+                let _ = st.model.field.touch(survivor, now_ms);
+            }
         }
-        true
+        Some(RemoveNodeClusterEffect::RemovedCore(cid)) => {
+            st.model.monitor_state.node_monitor.remove(&id);
+            let _ = sync_cluster_monitor(st, cid, None);
+        }
+        None => {}
     }
 
-    pub(crate) fn commit_ready_cluster_join_for_node(
-        &mut self,
-        node_id: NodeId,
-        now: Instant,
-    ) -> bool {
-        let Some(candidate) = self
-            .input
-            .interaction_state
-            .cluster_join_candidate
-            .clone()
-            .filter(|candidate| candidate.node_id == node_id && candidate.ready)
-        else {
-            return false;
-        };
-        self.input.interaction_state.cluster_join_candidate = None;
-        self.absorb_node_into_cluster(candidate.cluster_id, node_id, now)
+    if let Some(monitor) = removed_monitor {
+        reset_empty_monitor_spawn_state(st, monitor.as_str());
     }
+
+    true
+}
+
+pub fn detach_member_from_cluster(
+    st: &mut Halley,
+    cid: halley_core::cluster::ClusterId,
+    member_id: NodeId,
+    world_pos: Vec2,
+    now: Instant,
+) -> bool {
+    let now_ms = st.now_ms(now);
+    let Some(outcome) =
+        super::detach_member_from_cluster_inner(st, cid, member_id, world_pos, now_ms)
+    else {
+        return false;
+    };
+    match outcome {
+        ClusterRemoveMemberOutcome::Removed => {
+            if let Some(cluster_monitor) = preferred_monitor_for_cluster(st, cid, None)
+                && active_cluster_workspace_for_monitor(st, cluster_monitor.as_str()) == Some(cid)
+            {
+                layout_active_cluster_workspace_for_monitor(st, cluster_monitor.as_str(), now_ms);
+            }
+        }
+        ClusterRemoveMemberOutcome::RequiresDissolve => {
+            if !dissolve_cluster(st, cid) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+pub fn absorb_node_into_cluster(
+    st: &mut Halley,
+    cid: halley_core::cluster::ClusterId,
+    node_id: NodeId,
+    now: Instant,
+) -> bool {
+    let previous_overflow_len = cluster_overflow_len(st, cid);
+    let stack_insert_transition = preferred_monitor_for_cluster(st, cid, None)
+        .filter(|monitor| active_cluster_workspace_for_monitor(st, monitor.as_str()) == Some(cid))
+        .filter(|_| {
+            matches!(
+                active_cluster_layout_kind(st),
+                ClusterWorkspaceLayoutKind::Stacking
+            )
+        })
+        .map(|monitor| {
+            let old_visible =
+                crate::compositor::surface::active_stacking_visible_members_for_monitor(
+                    st,
+                    monitor.as_str(),
+                );
+            (monitor, old_visible)
+        });
+    let was_pinned = st.node_user_pinned(node_id);
+    if !super::absorb_node_into_cluster_inner(st, cid, node_id) {
+        return false;
+    }
+
+    if was_pinned {
+        st.model.workspace_state.user_pinned_nodes.remove(&node_id);
+        if let Some(core_id) = st.model.field.cluster(cid).and_then(|c| c.core) {
+            st.model.workspace_state.user_pinned_nodes.insert(core_id);
+        }
+    }
+
+    if let Some(cluster_monitor) = preferred_monitor_for_cluster(st, cid, None) {
+        st.assign_node_to_monitor(node_id, cluster_monitor.as_str());
+        if active_cluster_workspace_for_monitor(st, cluster_monitor.as_str()) == Some(cid) {
+            if let Some(node) = st.model.field.node_mut(node_id) {
+                node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
+            }
+            let now_ms = st.now_ms(now);
+            layout_active_cluster_workspace_for_monitor(st, cluster_monitor.as_str(), now_ms);
+            if matches!(
+                active_cluster_layout_kind(st),
+                ClusterWorkspaceLayoutKind::Stacking
+            ) {
+                if let Some((transition_monitor, old_visible)) = stack_insert_transition.as_ref()
+                    && transition_monitor == &cluster_monitor
+                {
+                    let duration_ms = st.runtime.tuning.stack_animation_duration_ms();
+                    let new_visible =
+                        crate::compositor::surface::active_stacking_visible_members_for_monitor(
+                            st,
+                            cluster_monitor.as_str(),
+                        );
+                    if st.runtime.tuning.stack_animation_enabled() {
+                        for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
+                            st.request_window_animation_prewarm(node_id, now);
+                        }
+                        st.ui.render_state.start_stack_cycle_transition(
+                            cluster_monitor.as_str(),
+                            ClusterCycleDirection::Prev,
+                            old_visible.clone(),
+                            new_visible,
+                            now,
+                            duration_ms,
+                        );
+                        st.request_maintenance();
+                    }
+                }
+                st.set_recent_top_node(node_id, now + std::time::Duration::from_millis(1200));
+                st.set_interaction_focus(Some(node_id), 30_000, now);
+                st.update_focus_tracking_for_surface(node_id, now_ms);
+            }
+            let overflow_len = cluster_overflow_len(st, cid);
+            if overflow_len > previous_overflow_len {
+                reveal_cluster_overflow_for_monitor(st, cluster_monitor.as_str(), now_ms);
+            }
+        }
+    }
+    if let Some(core_id) = st.model.field.cluster(cid).and_then(|cluster| cluster.core) {
+        let now_ms = st.now_ms(now);
+        let _ = st.model.field.touch(core_id, now_ms);
+    }
+    true
+}
+
+pub(crate) fn commit_ready_cluster_join_for_node(
+    st: &mut Halley,
+    node_id: NodeId,
+    now: Instant,
+) -> bool {
+    let Some(candidate) = st
+        .input
+        .interaction_state
+        .cluster_join_candidate
+        .clone()
+        .filter(|candidate| candidate.node_id == node_id && candidate.ready)
+    else {
+        return false;
+    };
+    st.input.interaction_state.cluster_join_candidate = None;
+    absorb_node_into_cluster(st, candidate.cluster_id, node_id, now)
 }

--- a/crates/halley-wl/src/compositor/clusters/system/naming.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/naming.rs
@@ -897,6 +897,11 @@ pub(crate) fn finish_lift_finalized_cluster(
     let now_ms = st.now_ms(now);
     let _ = st.model.field.touch(core_id, now_ms);
     st.set_interaction_focus(Some(core_id), 30_000, now);
+    // The core is dropped at the view centre and may land on top of a window;
+    // resolve overlap immediately so it slides clear like a freshly spawned node
+    // (mirrors the spawn path), instead of only correcting on the next interaction.
+    st.resolve_overlap_now();
+    st.request_maintenance();
     Some(core_id)
 }
 

--- a/crates/halley-wl/src/compositor/clusters/system/naming.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/naming.rs
@@ -9,11 +9,8 @@ use crate::compositor::interaction::state::{
 };
 use halley_core::field::{NodeId, NodeKind, NodeState};
 
-pub(super) fn cluster_mode_selection_banner(
-    controller: &mut impl DerefMut<Target = Halley>,
-    monitor: &str,
-) {
-    controller.ui.render_state.set_persistent_mode_banner(
+pub(super) fn cluster_mode_selection_banner(st: &mut Halley, monitor: &str) {
+    st.ui.render_state.set_persistent_mode_banner(
         monitor,
         "Cluster mode",
         Some("Select windows"),
@@ -30,11 +27,8 @@ pub(super) fn cluster_mode_selection_banner(
     );
 }
 
-pub(super) fn cluster_name_prompt_banner(
-    controller: &mut impl DerefMut<Target = Halley>,
-    monitor: &str,
-) {
-    controller.ui.render_state.set_persistent_mode_banner(
+pub(super) fn cluster_name_prompt_banner(st: &mut Halley, monitor: &str) {
+    st.ui.render_state.set_persistent_mode_banner(
         monitor,
         "Cluster mode",
         Some("Name new cluster"),
@@ -135,1025 +129,966 @@ fn parse_reserved_generic_cluster_name(value: &str) -> Option<u32> {
     (slot > 0).then_some(slot)
 }
 
-impl<T: Deref<Target = Halley>> ClusterSystemController<T> {
-    pub(crate) fn cluster_slot_order_for_monitor(&self, monitor: &str) -> Vec<ClusterId> {
-        self.model
-            .cluster_state
-            .cluster_slot_order
-            .get(monitor)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|&cid| {
-                self.model.field.cluster(cid).is_some()
-                    && self.preferred_monitor_for_cluster(cid, None).as_deref() == Some(monitor)
-            })
-            .collect()
-    }
+pub(crate) fn cluster_slot_order_for_monitor(st: &Halley, monitor: &str) -> Vec<ClusterId> {
+    st.model
+        .cluster_state
+        .cluster_slot_order
+        .get(monitor)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|&cid| {
+            st.model.field.cluster(cid).is_some()
+                && preferred_monitor_for_cluster(st, cid, None).as_deref() == Some(monitor)
+        })
+        .collect()
+}
 
-    pub(crate) fn cluster_slot_cluster_for_monitor(
-        &self,
-        monitor: &str,
-        slot: u8,
-    ) -> Option<ClusterId> {
-        let slot_index = usize::from(slot.saturating_sub(1));
-        self.cluster_slot_order_for_monitor(monitor)
-            .get(slot_index)
-            .copied()
-    }
+pub(crate) fn cluster_slot_cluster_for_monitor(
+    st: &Halley,
+    monitor: &str,
+    slot: u8,
+) -> Option<ClusterId> {
+    let slot_index = usize::from(slot.saturating_sub(1));
+    cluster_slot_order_for_monitor(st, monitor)
+        .get(slot_index)
+        .copied()
+}
 
-    pub(crate) fn cluster_name_prompt_active_for_monitor(&self, monitor: &str) -> bool {
-        self.model
-            .cluster_state
-            .cluster_name_prompt
-            .contains_key(monitor)
-    }
+pub(crate) fn cluster_name_prompt_active_for_monitor(st: &Halley, monitor: &str) -> bool {
+    st.model
+        .cluster_state
+        .cluster_name_prompt
+        .contains_key(monitor)
+}
 
-    pub(crate) fn active_cluster_name_prompt_monitor(&self, preferred: &str) -> Option<String> {
-        if self.cluster_name_prompt_active_for_monitor(preferred) {
-            return Some(preferred.to_string());
-        }
-        (self.model.cluster_state.cluster_name_prompt.len() == 1)
-            .then(|| {
-                self.model
-                    .cluster_state
-                    .cluster_name_prompt
-                    .keys()
-                    .next()
-                    .cloned()
-            })
-            .flatten()
+pub(crate) fn active_cluster_name_prompt_monitor(st: &Halley, preferred: &str) -> Option<String> {
+    if cluster_name_prompt_active_for_monitor(st, preferred) {
+        return Some(preferred.to_string());
     }
+    (st.model.cluster_state.cluster_name_prompt.len() == 1)
+        .then(|| {
+            st.model
+                .cluster_state
+                .cluster_name_prompt
+                .keys()
+                .next()
+                .cloned()
+        })
+        .flatten()
+}
 
-    pub(crate) fn pending_lift_cluster_build_waits_for_candidate_identity(
-        &self,
-        monitor: &str,
-        node_id: NodeId,
-    ) -> bool {
-        self.model
-            .cluster_state
-            .pending_lift_cluster_builds
-            .get(monitor)
-            .is_some_and(|build| {
-                build.candidate_node_ids.contains(&node_id)
-                    && !build.app_launches.is_empty()
-                    && build.selected_node_ids.len() < build.expected_members
-            })
-    }
+pub(crate) fn pending_lift_cluster_build_waits_for_candidate_identity(
+    st: &Halley,
+    monitor: &str,
+    node_id: NodeId,
+) -> bool {
+    st.model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .get(monitor)
+        .is_some_and(|build| {
+            build.candidate_node_ids.contains(&node_id)
+                && !build.app_launches.is_empty()
+                && build.selected_node_ids.len() < build.expected_members
+        })
+}
 
-    pub(crate) fn pending_lift_cluster_node_staged(&self, node_id: NodeId) -> bool {
-        self.model
-            .cluster_state
-            .pending_lift_cluster_builds
-            .values()
-            .any(|build| build.staged_node_ids.contains(&node_id))
-    }
+pub(crate) fn pending_lift_cluster_node_staged(st: &Halley, node_id: NodeId) -> bool {
+    st.model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .values()
+        .any(|build| build.staged_node_ids.contains(&node_id))
+}
 
-    pub(crate) fn cluster_name_record(&self, cid: ClusterId) -> Option<&ClusterNameRecord> {
-        self.model.cluster_state.cluster_names.get(&cid)
-    }
+pub(crate) fn cluster_name_record(st: &Halley, cid: ClusterId) -> Option<&ClusterNameRecord> {
+    st.model.cluster_state.cluster_names.get(&cid)
+}
 
-    pub(crate) fn cluster_display_name(&self, cid: ClusterId) -> Option<String> {
-        match self.cluster_name_record(cid)? {
-            ClusterNameRecord::Generic { slot } => Some(format!("Cluster {slot}")),
-            ClusterNameRecord::Custom { name } => Some(name.clone()),
-        }
-    }
-
-    pub(crate) fn next_generic_cluster_slot_for_monitor(
-        &self,
-        monitor: &str,
-        exclude: Option<ClusterId>,
-    ) -> u32 {
-        let mut used = std::collections::HashSet::new();
-        for (&cid, record) in &self.model.cluster_state.cluster_names {
-            if Some(cid) == exclude {
-                continue;
-            }
-            let ClusterNameRecord::Generic { slot } = record else {
-                continue;
-            };
-            if self.preferred_monitor_for_cluster(cid, None).as_deref() == Some(monitor) {
-                used.insert(*slot);
-            }
-        }
-        let mut slot = 1;
-        while used.contains(&slot) {
-            slot += 1;
-        }
-        slot
-    }
-
-    fn resolve_unique_custom_cluster_name(
-        &self,
-        proposed: &str,
-        exclude: Option<ClusterId>,
-    ) -> String {
-        let base = proposed.trim();
-        if base.is_empty() {
-            return "Cluster".to_string();
-        }
-        let mut candidate = base.to_string();
-        let mut suffix = 1u32;
-        while self
-            .model
-            .cluster_state
-            .cluster_names
-            .iter()
-            .filter(|(cid, _)| Some(**cid) != exclude)
-            .filter_map(|(_, record)| match record {
-                ClusterNameRecord::Custom { name } => Some(name),
-                ClusterNameRecord::Generic { .. } => None,
-            })
-            .any(|name| name.eq_ignore_ascii_case(candidate.as_str()))
-        {
-            candidate = format!("{base} ({suffix})");
-            suffix += 1;
-        }
-        candidate
+pub(crate) fn cluster_display_name(st: &Halley, cid: ClusterId) -> Option<String> {
+    match cluster_name_record(st, cid)? {
+        ClusterNameRecord::Generic { slot } => Some(format!("Cluster {slot}")),
+        ClusterNameRecord::Custom { name } => Some(name.clone()),
     }
 }
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    pub(crate) fn note_pending_lift_cluster_candidate_node(
-        &mut self,
-        monitor: &str,
-        node_id: NodeId,
-    ) -> bool {
-        let Some(build) = self
+pub(crate) fn next_generic_cluster_slot_for_monitor(
+    st: &Halley,
+    monitor: &str,
+    exclude: Option<ClusterId>,
+) -> u32 {
+    let mut used = std::collections::HashSet::new();
+    for (&cid, record) in &st.model.cluster_state.cluster_names {
+        if Some(cid) == exclude {
+            continue;
+        }
+        let ClusterNameRecord::Generic { slot } = record else {
+            continue;
+        };
+        if preferred_monitor_for_cluster(st, cid, None).as_deref() == Some(monitor) {
+            used.insert(*slot);
+        }
+    }
+    let mut slot = 1;
+    while used.contains(&slot) {
+        slot += 1;
+    }
+    slot
+}
+
+pub(crate) fn resolve_unique_custom_cluster_name(
+    st: &Halley,
+    proposed: &str,
+    exclude: Option<ClusterId>,
+) -> String {
+    let base = proposed.trim();
+    if base.is_empty() {
+        return "Cluster".to_string();
+    }
+    let mut candidate = base.to_string();
+    let mut suffix = 1u32;
+    while st
+        .model
+        .cluster_state
+        .cluster_names
+        .iter()
+        .filter(|(cid, _)| Some(**cid) != exclude)
+        .filter_map(|(_, record)| match record {
+            ClusterNameRecord::Custom { name } => Some(name),
+            ClusterNameRecord::Generic { .. } => None,
+        })
+        .any(|name| name.eq_ignore_ascii_case(candidate.as_str()))
+    {
+        candidate = format!("{base} ({suffix})");
+        suffix += 1;
+    }
+    candidate
+}
+
+pub(crate) fn note_pending_lift_cluster_candidate_node(
+    st: &mut Halley,
+    monitor: &str,
+    node_id: NodeId,
+) -> bool {
+    let Some(build) = st
+        .model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .get_mut(monitor)
+    else {
+        return false;
+    };
+    if build.app_launches.is_empty() || build.selected_node_ids.len() >= build.expected_members {
+        return false;
+    }
+    build.staged_node_ids.insert(node_id);
+    build.candidate_node_ids.insert(node_id)
+}
+
+pub(crate) fn open_cluster_name_prompt_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    name_hint: Option<&str>,
+    select_all: bool,
+    show_banner: bool,
+) -> bool {
+    let generated_generic_name = format!(
+        "Cluster {}",
+        next_generic_cluster_slot_for_monitor(st, monitor, None)
+    );
+    let input = name_hint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| generated_generic_name.clone());
+    let char_len = prompt_char_len(input.as_str());
+    let selection_anchor_char = if select_all { 0 } else { char_len };
+    st.model.cluster_state.cluster_name_prompt.insert(
+        monitor.to_string(),
+        ClusterNamingPromptState {
+            generated_generic_name,
+            input,
+            caret_char: char_len,
+            selection_anchor_char,
+            selection_focus_char: char_len,
+            scroll_char: 0,
+            confirm_hover_mix: 0.0,
+        },
+    );
+    st.begin_modal_keyboard_capture();
+    if show_banner {
+        cluster_name_prompt_banner(st, monitor);
+    } else {
+        st.ui.render_state.remove_persistent_mode_banner(monitor);
+    }
+    true
+}
+
+pub(crate) fn open_lift_cluster_finalize_draft(
+    st: &mut Halley,
+    monitor: &str,
+    name_hint: Option<String>,
+    app_ids: Vec<String>,
+    app_launches: Vec<ClusterFinalizeAppLaunch>,
+    running_node_ids: Vec<NodeId>,
+    now: Instant,
+) -> bool {
+    let app_launches = normalized_draft_app_launches(app_launches);
+    let app_ids = normalized_draft_app_ids(app_ids);
+    let mut selected = running_node_ids
+        .into_iter()
+        .filter(|node_id| {
+            st.model.field.node(*node_id).is_some_and(|node| {
+                node.kind == NodeKind::Surface
+                    && node.state != NodeState::Core
+                    && st.model.field.is_visible(*node_id)
+            })
+        })
+        .collect::<std::collections::HashSet<_>>();
+    for (&node_id, node) in st.model.field.nodes() {
+        if node.kind != NodeKind::Surface
+            || node.state == NodeState::Core
+            || !st.model.field.is_visible(node_id)
+            || st
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&node_id)
+                .is_none_or(|node_monitor| node_monitor != monitor)
+        {
+            continue;
+        }
+        if let Some(app_id) = st.model.node_app_ids.get(&node_id)
+            && draft_app_ids_match(&app_ids, app_id)
+        {
+            selected.insert(node_id);
+        }
+    }
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .insert(monitor.to_string(), selected.clone());
+    st.model.cluster_state.cluster_finalize_drafts.insert(
+        monitor.to_string(),
+        ClusterFinalizeDraftState {
+            app_ids,
+            app_launches,
+            selected_node_ids: selected,
+        },
+    );
+    let select_all = name_hint
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty);
+    let opened =
+        open_cluster_name_prompt_for_monitor(st, monitor, name_hint.as_deref(), select_all, false);
+    if opened {
+        st.request_maintenance();
+    } else {
+        st.model
+            .cluster_state
+            .cluster_finalize_drafts
+            .remove(monitor);
+        st.model
+            .cluster_state
+            .cluster_mode_selected_nodes
+            .remove(monitor);
+    }
+    let _ = now;
+    opened
+}
+
+pub(crate) fn maybe_add_node_to_lift_cluster_finalize_draft(
+    st: &mut Halley,
+    monitor: &str,
+    node_id: NodeId,
+    app_id: &str,
+) -> bool {
+    let app_id = app_id.trim();
+    if app_id.is_empty() {
+        return false;
+    }
+    if let Some(build) = st
+        .model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .get_mut(monitor)
+    {
+        if !build.candidate_node_ids.contains(&node_id) {
+            return false;
+        }
+        let app_ids = build
+            .app_launches
+            .iter()
+            .map(|launch| launch.app_id.clone())
+            .collect::<Vec<_>>();
+        if !draft_app_ids_match(&app_ids, app_id) {
+            build.candidate_node_ids.remove(&node_id);
+            build.staged_node_ids.remove(&node_id);
+            return false;
+        }
+        if !build.selected_node_ids.insert(node_id) {
+            return false;
+        }
+        build.candidate_node_ids.remove(&node_id);
+        st.model.spawn_state.pending_initial_reveal.remove(&node_id);
+        let _ = st.model.field.set_detached(node_id, true);
+        let completed = try_complete_pending_lift_cluster_build(st, monitor, Instant::now());
+        if !completed {
+            st.request_maintenance();
+        }
+        return true;
+    }
+
+    let Some(draft) = st
+        .model
+        .cluster_state
+        .cluster_finalize_drafts
+        .get_mut(monitor)
+    else {
+        return false;
+    };
+    if !draft_app_ids_match(&draft.app_ids, app_id) {
+        return false;
+    }
+    let inserted = draft.selected_node_ids.insert(node_id);
+    st.model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .entry(monitor.to_string())
+        .or_default()
+        .insert(node_id);
+    if inserted {
+        st.request_maintenance();
+    }
+    inserted
+}
+
+pub(crate) fn record_cluster_slot_for_monitor(st: &mut Halley, cid: ClusterId, monitor: &str) {
+    let target_monitor = monitor.to_string();
+    let already_on_target = st
+        .model
+        .cluster_state
+        .cluster_slot_order
+        .get(target_monitor.as_str())
+        .is_some_and(|order| order.contains(&cid));
+    for (name, order) in &mut st.model.cluster_state.cluster_slot_order {
+        if name != &target_monitor {
+            order.retain(|existing| *existing != cid);
+        }
+    }
+    if !already_on_target {
+        st.model
+            .cluster_state
+            .cluster_slot_order
+            .entry(target_monitor)
+            .or_default()
+            .push(cid);
+    }
+}
+
+pub(crate) fn remove_cluster_slot_record(st: &mut Halley, cid: ClusterId) {
+    st.model
+        .cluster_state
+        .cluster_slot_order
+        .retain(|_, order| {
+            order.retain(|existing| *existing != cid);
+            !order.is_empty()
+        });
+    st.model
+        .cluster_state
+        .pending_cluster_slot_transition
+        .retain(|_, pending| pending.cid != cid);
+}
+
+pub(crate) fn relabel_cluster_core(st: &mut Halley, cid: ClusterId) -> bool {
+    let Some(label) = cluster_display_name(st, cid) else {
+        return false;
+    };
+    let Some(core_id) = st.model.field.cluster(cid).and_then(|cluster| cluster.core) else {
+        return false;
+    };
+    if let Some(node) = st.model.field.node_mut(core_id) {
+        node.label = label;
+        return true;
+    }
+    false
+}
+
+pub(crate) fn ensure_cluster_name_record_for_monitor(
+    st: &mut Halley,
+    cid: ClusterId,
+    monitor: &str,
+) -> bool {
+    if st.model.cluster_state.cluster_names.contains_key(&cid) {
+        record_cluster_slot_for_monitor(st, cid, monitor);
+        return relabel_cluster_core(st, cid);
+    }
+    let slot = next_generic_cluster_slot_for_monitor(st, monitor, Some(cid));
+    st.model
+        .cluster_state
+        .cluster_names
+        .insert(cid, ClusterNameRecord::Generic { slot });
+    record_cluster_slot_for_monitor(st, cid, monitor);
+    relabel_cluster_core(st, cid)
+}
+
+pub(crate) fn sync_cluster_name_for_monitor(
+    st: &mut Halley,
+    cid: ClusterId,
+    monitor: &str,
+) -> bool {
+    let next_record = match st.model.cluster_state.cluster_names.get(&cid).cloned() {
+        Some(ClusterNameRecord::Generic { .. }) => ClusterNameRecord::Generic {
+            slot: next_generic_cluster_slot_for_monitor(st, monitor, Some(cid)),
+        },
+        Some(ClusterNameRecord::Custom { name }) => ClusterNameRecord::Custom { name },
+        None => ClusterNameRecord::Generic {
+            slot: next_generic_cluster_slot_for_monitor(st, monitor, Some(cid)),
+        },
+    };
+    st.model
+        .cluster_state
+        .cluster_names
+        .insert(cid, next_record);
+    record_cluster_slot_for_monitor(st, cid, monitor);
+    relabel_cluster_core(st, cid)
+}
+
+pub(crate) fn remove_cluster_name_record(st: &mut Halley, cid: ClusterId) {
+    st.model.cluster_state.cluster_names.remove(&cid);
+    remove_cluster_slot_record(st, cid);
+}
+
+pub(crate) fn sync_cluster_name_for_node_monitor(st: &mut Halley, node_id: NodeId, monitor: &str) {
+    if let Some(cid) = st.model.field.cluster_id_for_core_public(node_id) {
+        let _ = sync_cluster_name_for_monitor(st, cid, monitor);
+    }
+}
+
+pub(crate) fn open_cluster_name_prompt(st: &mut Halley, now: Instant) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    let Some(selected_nodes) = st
+        .model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .get(monitor.as_str())
+    else {
+        return false;
+    };
+    let now_ms = st.now_ms(now);
+    if selected_nodes.is_empty() {
+        st.ui.render_state.show_overlay_toast(
+            monitor.as_str(),
+            "Not enough selections\nSelect at least one window",
+            3000,
+            now_ms,
+        );
+        return false;
+    }
+
+    let _ = now;
+    open_cluster_name_prompt_for_monitor(st, monitor.as_str(), None, true, true)
+}
+
+pub(crate) fn cancel_cluster_name_prompt_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let removed = st
+        .model
+        .cluster_state
+        .cluster_name_prompt
+        .remove(monitor)
+        .is_some();
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_drag_monitor
+        .as_deref()
+        == Some(monitor)
+    {
+        st.input.interaction_state.cluster_name_prompt_drag_monitor = None;
+    }
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_repeat
+        .as_ref()
+        .is_some_and(|repeat| repeat.monitor == monitor)
+    {
+        st.input.interaction_state.cluster_name_prompt_repeat = None;
+    }
+    if removed && cluster_mode_active_for_monitor(st, monitor) {
+        cluster_mode_selection_banner(st, monitor);
+    }
+    if removed {
+        st.model
+            .cluster_state
+            .cluster_finalize_drafts
+            .remove(monitor);
+        let focused_surface = st
+            .last_input_surface_node_for_monitor(monitor)
+            .or(st.last_input_surface_node());
+        st.schedule_modal_focus_restore(focused_surface, Instant::now());
+    }
+    removed
+}
+
+pub(crate) fn insert_cluster_name_prompt_char_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    ch: char,
+) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    prompt_replace_selection(prompt, ch.encode_utf8(&mut [0; 4]));
+    true
+}
+
+pub(crate) fn cluster_name_prompt_backspace_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    prompt_delete_backspace(prompt);
+    true
+}
+
+pub(crate) fn cluster_name_prompt_delete_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    prompt_delete_forward(prompt);
+    true
+}
+
+pub(crate) fn cluster_name_prompt_move_left_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    if let Some((start, _)) = prompt_selection_range(prompt) {
+        prompt.caret_char = start;
+    } else if prompt.caret_char > 0 {
+        prompt.caret_char -= 1;
+    }
+    prompt.selection_anchor_char = prompt.caret_char;
+    prompt.selection_focus_char = prompt.caret_char;
+    true
+}
+
+pub(crate) fn cluster_name_prompt_move_right_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    let char_len = prompt_char_len(prompt.input.as_str());
+    if let Some((_, end)) = prompt_selection_range(prompt) {
+        prompt.caret_char = end;
+    } else if prompt.caret_char < char_len {
+        prompt.caret_char += 1;
+    }
+    prompt.selection_anchor_char = prompt.caret_char;
+    prompt.selection_focus_char = prompt.caret_char;
+    true
+}
+
+pub(crate) fn begin_cluster_name_prompt_drag_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    caret_char: usize,
+) -> bool {
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    let char_len = prompt_char_len(prompt.input.as_str());
+    prompt.caret_char = caret_char.min(char_len);
+    prompt.selection_anchor_char = prompt.caret_char;
+    prompt.selection_focus_char = prompt.caret_char;
+    st.input.interaction_state.cluster_name_prompt_drag_monitor = Some(monitor.to_string());
+    true
+}
+
+pub(crate) fn drag_cluster_name_prompt_selection_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    caret_char: usize,
+) -> bool {
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_drag_monitor
+        .as_deref()
+        != Some(monitor)
+    {
+        return false;
+    }
+    let Some(prompt) = st.model.cluster_state.cluster_name_prompt.get_mut(monitor) else {
+        return false;
+    };
+    let char_len = prompt_char_len(prompt.input.as_str());
+    prompt.caret_char = caret_char.min(char_len);
+    prompt.selection_focus_char = prompt.caret_char;
+    true
+}
+
+pub(crate) fn end_cluster_name_prompt_drag_for_monitor(st: &mut Halley, monitor: &str) -> bool {
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_drag_monitor
+        .as_deref()
+        != Some(monitor)
+    {
+        return false;
+    }
+    st.input.interaction_state.cluster_name_prompt_drag_monitor = None;
+    true
+}
+
+pub(crate) fn start_cluster_name_prompt_repeat_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    code: u32,
+    action: ClusterNamePromptRepeatAction,
+    now_ms: u64,
+) {
+    st.input.interaction_state.cluster_name_prompt_repeat = Some(ClusterNamePromptRepeatState {
+        monitor: monitor.to_string(),
+        code,
+        action,
+        next_repeat_ms: now_ms.saturating_add(360),
+        interval_ms: 34,
+    });
+    st.request_maintenance();
+}
+
+pub(crate) fn stop_cluster_name_prompt_repeat_for_code(st: &mut Halley, code: u32) {
+    if st
+        .input
+        .interaction_state
+        .cluster_name_prompt_repeat
+        .as_ref()
+        .is_some_and(|repeat| repeat.code == code)
+    {
+        st.input.interaction_state.cluster_name_prompt_repeat = None;
+    }
+}
+
+pub(crate) fn repeat_cluster_name_prompt_input_if_due(st: &mut Halley, now_ms: u64) -> bool {
+    let Some(repeat) = st
+        .input
+        .interaction_state
+        .cluster_name_prompt_repeat
+        .clone()
+    else {
+        return false;
+    };
+    if now_ms < repeat.next_repeat_ms {
+        return false;
+    }
+    let handled = match repeat.action {
+        ClusterNamePromptRepeatAction::Insert(ch) => {
+            insert_cluster_name_prompt_char_for_monitor(st, repeat.monitor.as_str(), ch)
+        }
+        ClusterNamePromptRepeatAction::Backspace => {
+            cluster_name_prompt_backspace_for_monitor(st, repeat.monitor.as_str())
+        }
+        ClusterNamePromptRepeatAction::Delete => {
+            cluster_name_prompt_delete_for_monitor(st, repeat.monitor.as_str())
+        }
+        ClusterNamePromptRepeatAction::MoveLeft => {
+            cluster_name_prompt_move_left_for_monitor(st, repeat.monitor.as_str())
+        }
+        ClusterNamePromptRepeatAction::MoveRight => {
+            cluster_name_prompt_move_right_for_monitor(st, repeat.monitor.as_str())
+        }
+    };
+    if handled {
+        if let Some(state) = st
+            .input
+            .interaction_state
+            .cluster_name_prompt_repeat
+            .as_mut()
+        {
+            state.next_repeat_ms = now_ms.saturating_add(state.interval_ms);
+        }
+        st.request_maintenance();
+    }
+    handled
+}
+
+pub(crate) fn prompt_name_record(
+    st: &Halley,
+    monitor: &str,
+    prompt: &ClusterNamingPromptState,
+) -> ClusterNameRecord {
+    let submitted = prompt.input.trim();
+    let reserved_generic = parse_reserved_generic_cluster_name(submitted).is_some();
+    let exact_default = submitted.eq_ignore_ascii_case(prompt.generated_generic_name.as_str());
+    if submitted.is_empty() || exact_default || reserved_generic {
+        ClusterNameRecord::Generic {
+            slot: next_generic_cluster_slot_for_monitor(st, monitor, None),
+        }
+    } else {
+        ClusterNameRecord::Custom {
+            name: resolve_unique_custom_cluster_name(st, submitted, None),
+        }
+    }
+}
+
+pub(crate) fn pending_lift_expected_members(
+    selected_nodes: &std::collections::HashSet<NodeId>,
+    app_launches: &[ClusterFinalizeAppLaunch],
+) -> usize {
+    selected_nodes.len() + app_launches.len()
+}
+
+pub(crate) fn start_pending_lift_cluster_build(
+    st: &mut Halley,
+    monitor: &str,
+    draft: ClusterFinalizeDraftState,
+    name_record: ClusterNameRecord,
+    now: Instant,
+) -> bool {
+    let expected_members =
+        pending_lift_expected_members(&draft.selected_node_ids, draft.app_launches.as_slice());
+    st.model.cluster_state.cluster_name_prompt.remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_finalize_drafts
+        .remove(monitor);
+    let _ = super::exit_cluster_mode_inner(st, monitor);
+    st.ui.render_state.clear_persistent_mode_banner(monitor);
+    st.model.cluster_state.pending_lift_cluster_builds.insert(
+        monitor.to_string(),
+        PendingLiftClusterBuildState {
+            selected_node_ids: draft.selected_node_ids,
+            candidate_node_ids: std::collections::HashSet::new(),
+            staged_node_ids: std::collections::HashSet::new(),
+            app_launches: draft.app_launches,
+            name_record,
+            expected_members,
+            launched: false,
+        },
+    );
+    if try_complete_pending_lift_cluster_build(st, monitor, now) {
+        return true;
+    }
+    launch_pending_lift_cluster_apps(st, monitor, now);
+    st.request_maintenance();
+    true
+}
+
+pub(crate) fn finish_lift_finalized_cluster(
+    st: &mut Halley,
+    cid: ClusterId,
+    monitor: &str,
+    name_record: ClusterNameRecord,
+    now: Instant,
+) -> Option<NodeId> {
+    st.model
+        .cluster_state
+        .cluster_names
+        .insert(cid, name_record);
+    let core_id = st.collapse_cluster(cid)?;
+    let _ = sync_cluster_monitor(st, cid, Some(monitor));
+    let target_pos = st.view_center_for_monitor(monitor);
+    if let Some(core) = st.model.field.node_mut(core_id) {
+        core.pos = target_pos;
+    }
+    let now_ms = st.now_ms(now);
+    let _ = st.model.field.touch(core_id, now_ms);
+    st.set_interaction_focus(Some(core_id), 30_000, now);
+    Some(core_id)
+}
+
+pub(crate) fn launch_pending_lift_cluster_apps(st: &mut Halley, monitor: &str, now: Instant) {
+    let launches = {
+        let Some(build) = st
             .model
             .cluster_state
             .pending_lift_cluster_builds
             .get_mut(monitor)
         else {
-            return false;
+            return;
         };
-        if build.app_launches.is_empty() || build.selected_node_ids.len() >= build.expected_members
-        {
-            return false;
+        if build.launched {
+            return;
         }
-        build.staged_node_ids.insert(node_id);
-        build.candidate_node_ids.insert(node_id)
-    }
+        build.launched = true;
+        build.app_launches.clone()
+    };
 
-    fn open_cluster_name_prompt_for_monitor(
-        &mut self,
-        monitor: &str,
-        name_hint: Option<&str>,
-        select_all: bool,
-        show_banner: bool,
-    ) -> bool {
-        let generated_generic_name = format!(
-            "Cluster {}",
-            self.next_generic_cluster_slot_for_monitor(monitor, None)
-        );
-        let input = name_hint
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| generated_generic_name.clone());
-        let char_len = prompt_char_len(input.as_str());
-        let selection_anchor_char = if select_all { 0 } else { char_len };
-        self.model.cluster_state.cluster_name_prompt.insert(
-            monitor.to_string(),
-            ClusterNamingPromptState {
-                generated_generic_name,
-                input,
-                caret_char: char_len,
-                selection_anchor_char,
-                selection_focus_char: char_len,
-                scroll_char: 0,
-                confirm_hover_mix: 0.0,
-            },
-        );
-        self.begin_modal_keyboard_capture();
-        if show_banner {
-            cluster_name_prompt_banner(self, monitor);
-        } else {
-            self.ui.render_state.remove_persistent_mode_banner(monitor);
+    let wayland_display = st
+        .runtime
+        .wayland_display
+        .clone()
+        .or_else(|| std::env::var("WAYLAND_DISPLAY").ok())
+        .unwrap_or_default();
+    st.model.spawn_state.pending_spawn_monitor = Some(monitor.to_string());
+    for launch in launches {
+        if launch.command.trim().is_empty() {
+            continue;
         }
-        true
+        if let Some(child) = crate::input::keyboard::spawn::spawn_command(
+            launch.command.as_str(),
+            wayland_display.as_str(),
+            &st.runtime.tuning.cursor,
+            None,
+            "lift cluster app",
+        ) {
+            st.runtime.spawned_children.push(child);
+        }
     }
+    let _ = now;
+}
 
-    pub(crate) fn open_lift_cluster_finalize_draft(
-        &mut self,
-        monitor: &str,
-        name_hint: Option<String>,
-        app_ids: Vec<String>,
-        app_launches: Vec<ClusterFinalizeAppLaunch>,
-        running_node_ids: Vec<NodeId>,
-        now: Instant,
-    ) -> bool {
-        let app_launches = normalized_draft_app_launches(app_launches);
-        let app_ids = normalized_draft_app_ids(app_ids);
-        let mut selected = running_node_ids
-            .into_iter()
-            .filter(|node_id| {
-                self.model.field.node(*node_id).is_some_and(|node| {
-                    node.kind == NodeKind::Surface
-                        && node.state != NodeState::Core
-                        && self.model.field.is_visible(*node_id)
-                })
-            })
-            .collect::<std::collections::HashSet<_>>();
-        for (&node_id, node) in self.model.field.nodes() {
-            if node.kind != NodeKind::Surface
-                || node.state == NodeState::Core
-                || !self.model.field.is_visible(node_id)
-                || self
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&node_id)
-                    .is_none_or(|node_monitor| node_monitor != monitor)
+pub(crate) fn try_complete_pending_lift_cluster_build(
+    st: &mut Halley,
+    monitor: &str,
+    now: Instant,
+) -> bool {
+    let Some(build) = st
+        .model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .get(monitor)
+        .cloned()
+    else {
+        return false;
+    };
+    if build.selected_node_ids.len() < build.expected_members || build.selected_node_ids.is_empty()
+    {
+        return false;
+    }
+    let members =
+        order_cluster_creation_members(st, build.selected_node_ids.iter().copied().collect());
+    let created = st.create_cluster(members.clone()).ok().and_then(|cid| {
+        finish_lift_finalized_cluster(st, cid, monitor, build.name_record.clone(), now)
+    });
+    if created.is_none() {
+        for node_id in &build.staged_node_ids {
+            st.model.spawn_state.pending_initial_reveal.remove(node_id);
+            if st
+                .model
+                .field
+                .cluster_id_for_member_public(*node_id)
+                .is_none()
             {
-                continue;
-            }
-            if let Some(app_id) = self.model.node_app_ids.get(&node_id)
-                && draft_app_ids_match(&app_ids, app_id)
-            {
-                selected.insert(node_id);
+                let _ = st.model.field.set_detached(*node_id, false);
             }
         }
-        self.model
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .insert(monitor.to_string(), selected.clone());
-        self.model.cluster_state.cluster_finalize_drafts.insert(
-            monitor.to_string(),
-            ClusterFinalizeDraftState {
-                app_ids,
-                app_launches,
-                selected_node_ids: selected,
-            },
-        );
-        let select_all = name_hint
-            .as_deref()
-            .map(str::trim)
-            .is_none_or(str::is_empty);
-        let opened = self.open_cluster_name_prompt_for_monitor(
-            monitor,
-            name_hint.as_deref(),
-            select_all,
-            false,
-        );
-        if opened {
-            self.request_maintenance();
-        } else {
-            self.model
-                .cluster_state
-                .cluster_finalize_drafts
-                .remove(monitor);
-            self.model
-                .cluster_state
-                .cluster_mode_selected_nodes
-                .remove(monitor);
-        }
-        let _ = now;
-        opened
-    }
-
-    pub(crate) fn maybe_add_node_to_lift_cluster_finalize_draft(
-        &mut self,
-        monitor: &str,
-        node_id: NodeId,
-        app_id: &str,
-    ) -> bool {
-        let app_id = app_id.trim();
-        if app_id.is_empty() {
-            return false;
-        }
-        if let Some(build) = self
-            .model
+        st.model
             .cluster_state
             .pending_lift_cluster_builds
-            .get_mut(monitor)
-        {
-            if !build.candidate_node_ids.contains(&node_id) {
-                return false;
-            }
-            let app_ids = build
-                .app_launches
-                .iter()
-                .map(|launch| launch.app_id.clone())
-                .collect::<Vec<_>>();
-            if !draft_app_ids_match(&app_ids, app_id) {
-                build.candidate_node_ids.remove(&node_id);
-                build.staged_node_ids.remove(&node_id);
-                return false;
-            }
-            if !build.selected_node_ids.insert(node_id) {
-                return false;
-            }
-            build.candidate_node_ids.remove(&node_id);
-            self.model
-                .spawn_state
-                .pending_initial_reveal
-                .remove(&node_id);
-            let _ = self.model.field.set_detached(node_id, true);
-            let completed = self.try_complete_pending_lift_cluster_build(monitor, Instant::now());
-            if !completed {
-                self.request_maintenance();
-            }
-            return true;
-        }
+            .remove(monitor);
+        return false;
+    }
+    for member in &members {
+        st.model.spawn_state.pending_initial_reveal.remove(member);
+        let _ = st.model.field.set_detached(*member, false);
+    }
+    for node_id in build
+        .staged_node_ids
+        .iter()
+        .filter(|node_id| !build.selected_node_ids.contains(node_id))
+    {
+        st.model.spawn_state.pending_initial_reveal.remove(node_id);
+        let _ = st.model.field.set_detached(*node_id, false);
+    }
+    st.model
+        .cluster_state
+        .pending_lift_cluster_builds
+        .remove(monitor);
+    true
+}
 
-        let Some(draft) = self
+pub(crate) fn confirm_cluster_name_prompt_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    now: Instant,
+) -> bool {
+    let Some(prompt) = st
+        .model
+        .cluster_state
+        .cluster_name_prompt
+        .get(monitor)
+        .cloned()
+    else {
+        return false;
+    };
+    let Some(selected_nodes) = st
+        .model
+        .cluster_state
+        .cluster_mode_selected_nodes
+        .get(monitor)
+        .cloned()
+    else {
+        return false;
+    };
+    let draft = st
+        .model
+        .cluster_state
+        .cluster_finalize_drafts
+        .get(monitor)
+        .cloned();
+    let name_record = prompt_name_record(st, monitor, &prompt);
+    if let Some(draft) = draft.clone()
+        && !draft.app_launches.is_empty()
+    {
+        return start_pending_lift_cluster_build(st, monitor, draft, name_record, now);
+    }
+    if selected_nodes.is_empty() {
+        if st
             .model
             .cluster_state
             .cluster_finalize_drafts
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        if !draft_app_ids_match(&draft.app_ids, app_id) {
-            return false;
-        }
-        let inserted = draft.selected_node_ids.insert(node_id);
-        self.model
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .entry(monitor.to_string())
-            .or_default()
-            .insert(node_id);
-        if inserted {
-            self.request_maintenance();
-        }
-        inserted
-    }
-
-    fn record_cluster_slot_for_monitor(&mut self, cid: ClusterId, monitor: &str) {
-        let target_monitor = monitor.to_string();
-        let already_on_target = self
-            .model
-            .cluster_state
-            .cluster_slot_order
-            .get(target_monitor.as_str())
-            .is_some_and(|order| order.contains(&cid));
-        for (name, order) in &mut self.model.cluster_state.cluster_slot_order {
-            if name != &target_monitor {
-                order.retain(|existing| *existing != cid);
-            }
-        }
-        if !already_on_target {
-            self.model
-                .cluster_state
-                .cluster_slot_order
-                .entry(target_monitor)
-                .or_default()
-                .push(cid);
-        }
-    }
-
-    fn remove_cluster_slot_record(&mut self, cid: ClusterId) {
-        self.model
-            .cluster_state
-            .cluster_slot_order
-            .retain(|_, order| {
-                order.retain(|existing| *existing != cid);
-                !order.is_empty()
-            });
-        self.model
-            .cluster_state
-            .pending_cluster_slot_transition
-            .retain(|_, pending| pending.cid != cid);
-    }
-
-    pub(crate) fn relabel_cluster_core(&mut self, cid: ClusterId) -> bool {
-        let Some(label) = self.cluster_display_name(cid) else {
-            return false;
-        };
-        let Some(core_id) = self
-            .model
-            .field
-            .cluster(cid)
-            .and_then(|cluster| cluster.core)
-        else {
-            return false;
-        };
-        if let Some(node) = self.model.field.node_mut(core_id) {
-            node.label = label;
-            return true;
-        }
-        false
-    }
-
-    pub(crate) fn ensure_cluster_name_record_for_monitor(
-        &mut self,
-        cid: ClusterId,
-        monitor: &str,
-    ) -> bool {
-        if self.model.cluster_state.cluster_names.contains_key(&cid) {
-            self.record_cluster_slot_for_monitor(cid, monitor);
-            return self.relabel_cluster_core(cid);
-        }
-        let slot = self.next_generic_cluster_slot_for_monitor(monitor, Some(cid));
-        self.model
-            .cluster_state
-            .cluster_names
-            .insert(cid, ClusterNameRecord::Generic { slot });
-        self.record_cluster_slot_for_monitor(cid, monitor);
-        self.relabel_cluster_core(cid)
-    }
-
-    pub(crate) fn sync_cluster_name_for_monitor(&mut self, cid: ClusterId, monitor: &str) -> bool {
-        let next_record = match self.model.cluster_state.cluster_names.get(&cid).cloned() {
-            Some(ClusterNameRecord::Generic { .. }) => ClusterNameRecord::Generic {
-                slot: self.next_generic_cluster_slot_for_monitor(monitor, Some(cid)),
-            },
-            Some(ClusterNameRecord::Custom { name }) => ClusterNameRecord::Custom { name },
-            None => ClusterNameRecord::Generic {
-                slot: self.next_generic_cluster_slot_for_monitor(monitor, Some(cid)),
-            },
-        };
-        self.model
-            .cluster_state
-            .cluster_names
-            .insert(cid, next_record);
-        self.record_cluster_slot_for_monitor(cid, monitor);
-        self.relabel_cluster_core(cid)
-    }
-
-    pub(crate) fn remove_cluster_name_record(&mut self, cid: ClusterId) {
-        self.model.cluster_state.cluster_names.remove(&cid);
-        self.remove_cluster_slot_record(cid);
-    }
-
-    pub(crate) fn sync_cluster_name_for_node_monitor(&mut self, node_id: NodeId, monitor: &str) {
-        if let Some(cid) = self.model.field.cluster_id_for_core_public(node_id) {
-            let _ = self.sync_cluster_name_for_monitor(cid, monitor);
-        }
-    }
-
-    pub(crate) fn open_cluster_name_prompt(&mut self, now: Instant) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        let Some(selected_nodes) = self
-            .model
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .get(monitor.as_str())
-        else {
-            return false;
-        };
-        let now_ms = self.now_ms(now);
-        if selected_nodes.is_empty() {
-            self.ui.render_state.show_overlay_toast(
-                monitor.as_str(),
-                "Not enough selections\nSelect at least one window",
+            .contains_key(monitor)
+        {
+            let now_ms = st.now_ms(now);
+            st.ui.render_state.show_overlay_toast(
+                monitor,
+                "Waiting for staged apps\nNeed at least one window",
                 3000,
                 now_ms,
             );
-            return false;
+            return true;
         }
-
-        let _ = now;
-        self.open_cluster_name_prompt_for_monitor(monitor.as_str(), None, true, true)
+        return false;
     }
-
-    pub(crate) fn cancel_cluster_name_prompt_for_monitor(&mut self, monitor: &str) -> bool {
-        let removed = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .remove(monitor)
-            .is_some();
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor
-            .as_deref()
-            == Some(monitor)
-        {
-            self.input
-                .interaction_state
-                .cluster_name_prompt_drag_monitor = None;
-        }
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_repeat
-            .as_ref()
-            .is_some_and(|repeat| repeat.monitor == monitor)
-        {
-            self.input.interaction_state.cluster_name_prompt_repeat = None;
-        }
-        if removed && self.cluster_mode_active_for_monitor(monitor) {
-            cluster_mode_selection_banner(self, monitor);
-        }
-        if removed {
-            self.model
-                .cluster_state
-                .cluster_finalize_drafts
-                .remove(monitor);
-            let focused_surface = self
-                .last_input_surface_node_for_monitor(monitor)
-                .or(self.last_input_surface_node());
-            self.schedule_modal_focus_restore(focused_surface, Instant::now());
-        }
-        removed
-    }
-
-    pub(crate) fn insert_cluster_name_prompt_char_for_monitor(
-        &mut self,
-        monitor: &str,
-        ch: char,
-    ) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        prompt_replace_selection(prompt, ch.encode_utf8(&mut [0; 4]));
-        true
-    }
-
-    pub(crate) fn cluster_name_prompt_backspace_for_monitor(&mut self, monitor: &str) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        prompt_delete_backspace(prompt);
-        true
-    }
-
-    pub(crate) fn cluster_name_prompt_delete_for_monitor(&mut self, monitor: &str) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        prompt_delete_forward(prompt);
-        true
-    }
-
-    pub(crate) fn cluster_name_prompt_move_left_for_monitor(&mut self, monitor: &str) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        if let Some((start, _)) = prompt_selection_range(prompt) {
-            prompt.caret_char = start;
-        } else if prompt.caret_char > 0 {
-            prompt.caret_char -= 1;
-        }
-        prompt.selection_anchor_char = prompt.caret_char;
-        prompt.selection_focus_char = prompt.caret_char;
-        true
-    }
-
-    pub(crate) fn cluster_name_prompt_move_right_for_monitor(&mut self, monitor: &str) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        let char_len = prompt_char_len(prompt.input.as_str());
-        if let Some((_, end)) = prompt_selection_range(prompt) {
-            prompt.caret_char = end;
-        } else if prompt.caret_char < char_len {
-            prompt.caret_char += 1;
-        }
-        prompt.selection_anchor_char = prompt.caret_char;
-        prompt.selection_focus_char = prompt.caret_char;
-        true
-    }
-
-    pub(crate) fn begin_cluster_name_prompt_drag_for_monitor(
-        &mut self,
-        monitor: &str,
-        caret_char: usize,
-    ) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        let char_len = prompt_char_len(prompt.input.as_str());
-        prompt.caret_char = caret_char.min(char_len);
-        prompt.selection_anchor_char = prompt.caret_char;
-        prompt.selection_focus_char = prompt.caret_char;
-        self.input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor = Some(monitor.to_string());
-        true
-    }
-
-    pub(crate) fn drag_cluster_name_prompt_selection_for_monitor(
-        &mut self,
-        monitor: &str,
-        caret_char: usize,
-    ) -> bool {
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor
-            .as_deref()
-            != Some(monitor)
-        {
-            return false;
-        }
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get_mut(monitor)
-        else {
-            return false;
-        };
-        let char_len = prompt_char_len(prompt.input.as_str());
-        prompt.caret_char = caret_char.min(char_len);
-        prompt.selection_focus_char = prompt.caret_char;
-        true
-    }
-
-    pub(crate) fn end_cluster_name_prompt_drag_for_monitor(&mut self, monitor: &str) -> bool {
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor
-            .as_deref()
-            != Some(monitor)
-        {
-            return false;
-        }
-        self.input
-            .interaction_state
-            .cluster_name_prompt_drag_monitor = None;
-        true
-    }
-
-    pub(crate) fn start_cluster_name_prompt_repeat_for_monitor(
-        &mut self,
-        monitor: &str,
-        code: u32,
-        action: ClusterNamePromptRepeatAction,
-        now_ms: u64,
-    ) {
-        self.input.interaction_state.cluster_name_prompt_repeat =
-            Some(ClusterNamePromptRepeatState {
-                monitor: monitor.to_string(),
-                code,
-                action,
-                next_repeat_ms: now_ms.saturating_add(360),
-                interval_ms: 34,
-            });
-        self.request_maintenance();
-    }
-
-    pub(crate) fn stop_cluster_name_prompt_repeat_for_code(&mut self, code: u32) {
-        if self
-            .input
-            .interaction_state
-            .cluster_name_prompt_repeat
-            .as_ref()
-            .is_some_and(|repeat| repeat.code == code)
-        {
-            self.input.interaction_state.cluster_name_prompt_repeat = None;
-        }
-    }
-
-    pub(crate) fn repeat_cluster_name_prompt_input_if_due(&mut self, now_ms: u64) -> bool {
-        let Some(repeat) = self
-            .input
-            .interaction_state
-            .cluster_name_prompt_repeat
-            .clone()
-        else {
-            return false;
-        };
-        if now_ms < repeat.next_repeat_ms {
-            return false;
-        }
-        let handled = match repeat.action {
-            ClusterNamePromptRepeatAction::Insert(ch) => {
-                self.insert_cluster_name_prompt_char_for_monitor(repeat.monitor.as_str(), ch)
-            }
-            ClusterNamePromptRepeatAction::Backspace => {
-                self.cluster_name_prompt_backspace_for_monitor(repeat.monitor.as_str())
-            }
-            ClusterNamePromptRepeatAction::Delete => {
-                self.cluster_name_prompt_delete_for_monitor(repeat.monitor.as_str())
-            }
-            ClusterNamePromptRepeatAction::MoveLeft => {
-                self.cluster_name_prompt_move_left_for_monitor(repeat.monitor.as_str())
-            }
-            ClusterNamePromptRepeatAction::MoveRight => {
-                self.cluster_name_prompt_move_right_for_monitor(repeat.monitor.as_str())
-            }
-        };
-        if handled {
-            if let Some(state) = self
-                .input
-                .interaction_state
-                .cluster_name_prompt_repeat
-                .as_mut()
-            {
-                state.next_repeat_ms = now_ms.saturating_add(state.interval_ms);
-            }
-            self.request_maintenance();
-        }
-        handled
-    }
-
-    fn prompt_name_record(
-        &self,
-        monitor: &str,
-        prompt: &ClusterNamingPromptState,
-    ) -> ClusterNameRecord {
-        let submitted = prompt.input.trim();
-        let reserved_generic = parse_reserved_generic_cluster_name(submitted).is_some();
-        let exact_default = submitted.eq_ignore_ascii_case(prompt.generated_generic_name.as_str());
-        if submitted.is_empty() || exact_default || reserved_generic {
-            ClusterNameRecord::Generic {
-                slot: self.next_generic_cluster_slot_for_monitor(monitor, None),
-            }
+    let members = order_cluster_creation_members(st, selected_nodes.iter().copied().collect());
+    let created = st.create_cluster(members).ok().and_then(|cid| {
+        if draft.is_some() {
+            finish_lift_finalized_cluster(st, cid, monitor, name_record.clone(), now)
         } else {
-            ClusterNameRecord::Custom {
-                name: self.resolve_unique_custom_cluster_name(submitted, None),
+            let now_ms = st.now_ms(now);
+            st.model
+                .cluster_state
+                .cluster_names
+                .insert(cid, name_record.clone());
+            let core = st.collapse_cluster(cid);
+            if let Some(core_id) = core {
+                st.assign_node_to_monitor(core_id, monitor);
+                let _ = sync_cluster_name_for_monitor(st, cid, monitor);
+                let _ = st.model.field.touch(core_id, now_ms);
+                st.set_interaction_focus(Some(core_id), 30_000, now);
             }
+            core
         }
-    }
-
-    fn pending_lift_expected_members(
-        &self,
-        selected_nodes: &std::collections::HashSet<NodeId>,
-        app_launches: &[ClusterFinalizeAppLaunch],
-    ) -> usize {
-        selected_nodes.len() + app_launches.len()
-    }
-
-    fn start_pending_lift_cluster_build(
-        &mut self,
-        monitor: &str,
-        draft: ClusterFinalizeDraftState,
-        name_record: ClusterNameRecord,
-        now: Instant,
-    ) -> bool {
-        let expected_members = self
-            .pending_lift_expected_members(&draft.selected_node_ids, draft.app_launches.as_slice());
-        self.model.cluster_state.cluster_name_prompt.remove(monitor);
-        self.model
+    });
+    if created.is_some() {
+        st.model.cluster_state.cluster_name_prompt.remove(monitor);
+        st.model
             .cluster_state
             .cluster_finalize_drafts
             .remove(monitor);
-        let _ = super::exit_cluster_mode(self, monitor);
-        self.ui.render_state.clear_persistent_mode_banner(monitor);
-        self.model.cluster_state.pending_lift_cluster_builds.insert(
-            monitor.to_string(),
-            PendingLiftClusterBuildState {
-                selected_node_ids: draft.selected_node_ids,
-                candidate_node_ids: std::collections::HashSet::new(),
-                staged_node_ids: std::collections::HashSet::new(),
-                app_launches: draft.app_launches,
-                name_record,
-                expected_members,
-                launched: false,
-            },
-        );
-        if self.try_complete_pending_lift_cluster_build(monitor, now) {
-            return true;
-        }
-        self.launch_pending_lift_cluster_apps(monitor, now);
-        self.request_maintenance();
-        true
+        let _ = super::exit_cluster_mode_inner(st, monitor);
+        st.ui.render_state.clear_persistent_mode_banner(monitor);
+        let focused_surface = st
+            .last_input_surface_node_for_monitor(monitor)
+            .or(st.last_input_surface_node());
+        st.schedule_modal_focus_restore(focused_surface, Instant::now());
+        return true;
     }
-
-    fn finish_lift_finalized_cluster(
-        &mut self,
-        cid: ClusterId,
-        monitor: &str,
-        name_record: ClusterNameRecord,
-        now: Instant,
-    ) -> Option<NodeId> {
-        self.model
-            .cluster_state
-            .cluster_names
-            .insert(cid, name_record);
-        let core_id = self.collapse_cluster(cid)?;
-        let _ = self.sync_cluster_monitor(cid, Some(monitor));
-        let target_pos = self.view_center_for_monitor(monitor);
-        if let Some(core) = self.model.field.node_mut(core_id) {
-            core.pos = target_pos;
-        }
-        let now_ms = self.now_ms(now);
-        let _ = self.model.field.touch(core_id, now_ms);
-        self.set_interaction_focus(Some(core_id), 30_000, now);
-        Some(core_id)
-    }
-
-    fn launch_pending_lift_cluster_apps(&mut self, monitor: &str, now: Instant) {
-        let launches = {
-            let Some(build) = self
-                .model
-                .cluster_state
-                .pending_lift_cluster_builds
-                .get_mut(monitor)
-            else {
-                return;
-            };
-            if build.launched {
-                return;
-            }
-            build.launched = true;
-            build.app_launches.clone()
-        };
-
-        let wayland_display = self
-            .runtime
-            .wayland_display
-            .clone()
-            .or_else(|| std::env::var("WAYLAND_DISPLAY").ok())
-            .unwrap_or_default();
-        self.model.spawn_state.pending_spawn_monitor = Some(monitor.to_string());
-        for launch in launches {
-            if launch.command.trim().is_empty() {
-                continue;
-            }
-            if let Some(child) = crate::input::keyboard::spawn::spawn_command(
-                launch.command.as_str(),
-                wayland_display.as_str(),
-                &self.runtime.tuning.cursor,
-                None,
-                "lift cluster app",
-            ) {
-                self.runtime.spawned_children.push(child);
-            }
-        }
-        let _ = now;
-    }
-
-    fn try_complete_pending_lift_cluster_build(&mut self, monitor: &str, now: Instant) -> bool {
-        let Some(build) = self
-            .model
-            .cluster_state
-            .pending_lift_cluster_builds
-            .get(monitor)
-            .cloned()
-        else {
-            return false;
-        };
-        if build.selected_node_ids.len() < build.expected_members
-            || build.selected_node_ids.is_empty()
-        {
-            return false;
-        }
-        let members =
-            self.order_cluster_creation_members(build.selected_node_ids.iter().copied().collect());
-        let created = self.create_cluster(members.clone()).ok().and_then(|cid| {
-            self.finish_lift_finalized_cluster(cid, monitor, build.name_record.clone(), now)
-        });
-        if created.is_none() {
-            for node_id in &build.staged_node_ids {
-                self.model
-                    .spawn_state
-                    .pending_initial_reveal
-                    .remove(node_id);
-                if self
-                    .model
-                    .field
-                    .cluster_id_for_member_public(*node_id)
-                    .is_none()
-                {
-                    let _ = self.model.field.set_detached(*node_id, false);
-                }
-            }
-            self.model
-                .cluster_state
-                .pending_lift_cluster_builds
-                .remove(monitor);
-            return false;
-        }
-        for member in &members {
-            self.model.spawn_state.pending_initial_reveal.remove(member);
-            let _ = self.model.field.set_detached(*member, false);
-        }
-        for node_id in build
-            .staged_node_ids
-            .iter()
-            .filter(|node_id| !build.selected_node_ids.contains(node_id))
-        {
-            self.model
-                .spawn_state
-                .pending_initial_reveal
-                .remove(node_id);
-            let _ = self.model.field.set_detached(*node_id, false);
-        }
-        self.model
-            .cluster_state
-            .pending_lift_cluster_builds
-            .remove(monitor);
-        true
-    }
-
-    pub(crate) fn confirm_cluster_name_prompt_for_monitor(
-        &mut self,
-        monitor: &str,
-        now: Instant,
-    ) -> bool {
-        let Some(prompt) = self
-            .model
-            .cluster_state
-            .cluster_name_prompt
-            .get(monitor)
-            .cloned()
-        else {
-            return false;
-        };
-        let Some(selected_nodes) = self
-            .model
-            .cluster_state
-            .cluster_mode_selected_nodes
-            .get(monitor)
-            .cloned()
-        else {
-            return false;
-        };
-        let draft = self
-            .model
-            .cluster_state
-            .cluster_finalize_drafts
-            .get(monitor)
-            .cloned();
-        let name_record = self.prompt_name_record(monitor, &prompt);
-        if let Some(draft) = draft.clone()
-            && !draft.app_launches.is_empty()
-        {
-            return self.start_pending_lift_cluster_build(monitor, draft, name_record, now);
-        }
-        if selected_nodes.is_empty() {
-            if self
-                .model
-                .cluster_state
-                .cluster_finalize_drafts
-                .contains_key(monitor)
-            {
-                let now_ms = self.now_ms(now);
-                self.ui.render_state.show_overlay_toast(
-                    monitor,
-                    "Waiting for staged apps\nNeed at least one window",
-                    3000,
-                    now_ms,
-                );
-                return true;
-            }
-            return false;
-        }
-        let members = self.order_cluster_creation_members(selected_nodes.iter().copied().collect());
-        let created = self.create_cluster(members).ok().and_then(|cid| {
-            if draft.is_some() {
-                self.finish_lift_finalized_cluster(cid, monitor, name_record.clone(), now)
-            } else {
-                let now_ms = self.now_ms(now);
-                self.model
-                    .cluster_state
-                    .cluster_names
-                    .insert(cid, name_record.clone());
-                let core = self.collapse_cluster(cid);
-                if let Some(core_id) = core {
-                    self.assign_node_to_monitor(core_id, monitor);
-                    let _ = self.sync_cluster_name_for_monitor(cid, monitor);
-                    let _ = self.model.field.touch(core_id, now_ms);
-                    self.set_interaction_focus(Some(core_id), 30_000, now);
-                }
-                core
-            }
-        });
-        if created.is_some() {
-            self.model.cluster_state.cluster_name_prompt.remove(monitor);
-            self.model
-                .cluster_state
-                .cluster_finalize_drafts
-                .remove(monitor);
-            let _ = super::exit_cluster_mode(self, monitor);
-            self.ui.render_state.clear_persistent_mode_banner(monitor);
-            let focused_surface = self
-                .last_input_surface_node_for_monitor(monitor)
-                .or(self.last_input_surface_node());
-            self.schedule_modal_focus_restore(focused_surface, Instant::now());
-            return true;
-        }
-        false
-    }
+    false
 }
 
 fn normalized_draft_app_ids(app_ids: Vec<String>) -> Vec<String> {

--- a/crates/halley-wl/src/compositor/clusters/system/naming.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/naming.rs
@@ -916,9 +916,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             .cluster_state
             .cluster_finalize_drafts
             .remove(monitor);
-        let _ = self
-            .cluster_mutation_controller()
-            .exit_cluster_mode(monitor);
+        let _ = super::exit_cluster_mode(self, monitor);
         self.ui.render_state.clear_persistent_mode_banner(monitor);
         self.model.cluster_state.pending_lift_cluster_builds.insert(
             monitor.to_string(),
@@ -1146,9 +1144,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
                 .cluster_state
                 .cluster_finalize_drafts
                 .remove(monitor);
-            let _ = self
-                .cluster_mutation_controller()
-                .exit_cluster_mode(monitor);
+            let _ = super::exit_cluster_mode(self, monitor);
             self.ui.render_state.clear_persistent_mode_banner(monitor);
             let focused_surface = self
                 .last_input_surface_node_for_monitor(monitor)

--- a/crates/halley-wl/src/compositor/clusters/system/naming.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/naming.rs
@@ -897,10 +897,31 @@ pub(crate) fn finish_lift_finalized_cluster(
     let now_ms = st.now_ms(now);
     let _ = st.model.field.touch(core_id, now_ms);
     st.set_interaction_focus(Some(core_id), 30_000, now);
-    // The core is dropped at the view centre and may land on top of a window;
-    // resolve overlap immediately so it slides clear like a freshly spawned node
-    // (mirrors the spawn path), instead of only correcting on the next interaction.
-    st.resolve_overlap_now();
+    // The core is dropped at the view centre and may land on top of a window.
+    // Slide it clear with the same animated landmark push normal nodes get when a
+    // window is revealed over them, instead of the trapped-landmark teleport that
+    // resolve_overlap_now would produce.
+    let overlapping_windows: Vec<NodeId> = st
+        .model
+        .field
+        .nodes()
+        .iter()
+        .filter(|(id, node)| {
+            node.kind == halley_core::field::NodeKind::Surface
+                && node.state == halley_core::field::NodeState::Active
+                && st
+                    .model
+                    .monitor_state
+                    .node_monitor
+                    .get(id)
+                    .map(String::as_str)
+                    == Some(monitor)
+        })
+        .map(|(id, _)| *id)
+        .collect();
+    for window_id in overlapping_windows {
+        st.resolve_landmarks_overlapped_by_active_window(window_id);
+    }
     st.request_maintenance();
     Some(core_id)
 }

--- a/crates/halley-wl/src/compositor/clusters/system/navigation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/navigation.rs
@@ -80,9 +80,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
     ) -> Option<(ClusterId, Vec<ClusterTilePlacement>)> {
         let cid = self.active_cluster_workspace_for_monitor(monitor)?;
-        let plan = self
-            .cluster_read_controller()
-            .plan_active_cluster_layout(monitor)?;
+        let plan = crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)?;
         if !matches!(plan.kind, ClusterWorkspaceLayoutKind::Tiling) {
             return None;
         }
@@ -357,8 +355,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         let previous_layout_kind = self.active_cluster_layout_kind();
         let tile_to_stack_transition =
             if matches!(previous_layout_kind, ClusterWorkspaceLayoutKind::Tiling) {
-                self.cluster_read_controller()
-                    .plan_active_cluster_layout(monitor)
+                crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
                     .map(|plan| {
                         let source_rects = plan
                             .tiles

--- a/crates/halley-wl/src/compositor/clusters/system/navigation.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/navigation.rs
@@ -1,504 +1,475 @@
 use super::*;
 use crate::compositor::clusters::state::PendingClusterSlotTransition;
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    pub(crate) fn activate_cluster_slot_on_current_monitor(
-        &mut self,
-        slot: u8,
-        now: Instant,
-    ) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        self.model
+pub(crate) fn activate_cluster_slot_on_current_monitor(
+    st: &mut Halley,
+    slot: u8,
+    now: Instant,
+) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    st.model
+        .cluster_state
+        .pending_cluster_slot_transition
+        .remove(monitor.as_str());
+    let Some(cid) = cluster_slot_cluster_for_monitor(st, monitor.as_str(), slot) else {
+        return false;
+    };
+
+    if active_cluster_workspace_for_monitor(st, monitor.as_str()) == Some(cid) {
+        return exit_cluster_workspace_for_monitor(st, monitor.as_str(), now);
+    }
+
+    if active_cluster_workspace_for_monitor(st, monitor.as_str()).is_some() {
+        let _ = exit_cluster_workspace_for_monitor(st, monitor.as_str(), now);
+    }
+
+    let Some(core_id) = st.model.field.cluster(cid).and_then(|cluster| cluster.core) else {
+        return false;
+    };
+    let Some(target_center) = st.model.field.node(core_id).map(|node| node.pos) else {
+        return false;
+    };
+
+    if st.animate_viewport_center_to(target_center, now) {
+        st.model
             .cluster_state
             .pending_cluster_slot_transition
-            .remove(monitor.as_str());
-        let Some(cid) = self.cluster_slot_cluster_for_monitor(monitor.as_str(), slot) else {
-            return false;
-        };
-
-        if self.active_cluster_workspace_for_monitor(monitor.as_str()) == Some(cid) {
-            return self.exit_cluster_workspace_for_monitor(monitor.as_str(), now);
-        }
-
-        if self
-            .active_cluster_workspace_for_monitor(monitor.as_str())
-            .is_some()
-        {
-            let _ = self.exit_cluster_workspace_for_monitor(monitor.as_str(), now);
-        }
-
-        let Some(core_id) = self
-            .model
-            .field
-            .cluster(cid)
-            .and_then(|cluster| cluster.core)
-        else {
-            return false;
-        };
-        let Some(target_center) = self.model.field.node(core_id).map(|node| node.pos) else {
-            return false;
-        };
-
-        if self.animate_viewport_center_to(target_center, now) {
-            self.model
-                .cluster_state
-                .pending_cluster_slot_transition
-                .insert(monitor, PendingClusterSlotTransition { slot, cid, core_id });
-            self.request_maintenance();
-            true
-        } else {
-            self.enter_cluster_workspace_by_core(core_id, monitor.as_str(), now)
-        }
-    }
-
-    pub(crate) fn process_pending_cluster_slot_transition_for_current_monitor(
-        &mut self,
-        now: Instant,
-    ) -> bool {
-        if self.input.interaction_state.viewport_pan_anim.is_some() {
-            return false;
-        }
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        let Some(pending) = self
-            .model
-            .cluster_state
-            .pending_cluster_slot_transition
-            .remove(monitor.as_str())
-        else {
-            return false;
-        };
-        if self.cluster_slot_cluster_for_monitor(monitor.as_str(), pending.slot)
-            != Some(pending.cid)
-        {
-            return false;
-        }
-        self.enter_cluster_workspace_by_core(pending.core_id, monitor.as_str(), now)
-    }
-
-    fn visible_tiled_cluster_tiles_for_monitor(
-        &self,
-        monitor: &str,
-    ) -> Option<(ClusterId, Vec<ClusterTilePlacement>)> {
-        let cid = self.active_cluster_workspace_for_monitor(monitor)?;
-        let plan = crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)?;
-        if !matches!(plan.kind, ClusterWorkspaceLayoutKind::Tiling) {
-            return None;
-        }
-
-        let visible_tiles = plan
-            .tiles
-            .into_iter()
-            .filter(|tile| {
-                !self
-                    .model
-                    .spawn_state
-                    .pending_tiled_insert_reveal_at_ms
-                    .contains_key(&tile.node_id)
-            })
-            .collect::<Vec<_>>();
-        Some((cid, visible_tiles))
-    }
-
-    fn directional_target_member(
-        &self,
-        visible_tiles: &[ClusterTilePlacement],
-        direction: DirectionalAction,
-    ) -> Option<(NodeId, NodeId)> {
-        if visible_tiles.is_empty() {
-            return None;
-        }
-
-        let current_member = self
-            .model
-            .focus_state
-            .primary_interaction_focus
-            .filter(|id| visible_tiles.iter().any(|tile| tile.node_id == *id))
-            .unwrap_or(visible_tiles[0].node_id);
-        let current_rect = visible_tiles
-            .iter()
-            .find(|tile| tile.node_id == current_member)
-            .map(|tile| tile.rect)?;
-        let target = visible_tiles
-            .iter()
-            .filter(|tile| tile.node_id != current_member)
-            .filter_map(|tile| {
-                directional_candidate_score(current_rect, tile.rect, direction)
-                    .map(|score| (score, tile.node_id))
-            })
-            .min_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(_, node_id)| node_id)?;
-        Some((current_member, target))
-    }
-
-    pub(crate) fn move_active_cluster_member_to_drop_tile(
-        &mut self,
-        monitor: &str,
-        member: NodeId,
-        world_pos: Vec2,
-        now_ms: u64,
-    ) -> bool {
-        let Some((cid, visible_tiles)) = self.visible_tiled_cluster_tiles_for_monitor(monitor)
-        else {
-            return false;
-        };
-        if !visible_tiles.iter().any(|tile| tile.node_id == member) {
-            return false;
-        }
-
-        let Some(target_member) = visible_tiles
-            .iter()
-            .find(|tile| {
-                world_pos.x >= tile.rect.x
-                    && world_pos.x <= tile.rect.x + tile.rect.w
-                    && world_pos.y >= tile.rect.y
-                    && world_pos.y <= tile.rect.y + tile.rect.h
-            })
-            .map(|tile| tile.node_id)
-        else {
-            return false;
-        };
-        if target_member == member {
-            return false;
-        }
-
-        let Some(members) = self
-            .model
-            .field
-            .cluster(cid)
-            .map(|cluster| cluster.members().to_vec())
-        else {
-            return false;
-        };
-        let Some(from_index) = members.iter().position(|&id| id == member) else {
-            return false;
-        };
-        let Some(target_index) = members.iter().position(|&id| id == target_member) else {
-            return false;
-        };
-
-        let mut reordered = members;
-        let moved = reordered.remove(from_index);
-        reordered.insert(target_index.min(reordered.len()), moved);
-        if self
-            .model
-            .field
-            .reorder_cluster_members(cid, reordered)
-            .is_err()
-        {
-            return false;
-        }
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
+            .insert(monitor, PendingClusterSlotTransition { slot, cid, core_id });
+        st.request_maintenance();
         true
+    } else {
+        enter_cluster_workspace_by_core(st, core_id, monitor.as_str(), now)
+    }
+}
+
+pub(crate) fn process_pending_cluster_slot_transition_for_current_monitor(
+    st: &mut Halley,
+    now: Instant,
+) -> bool {
+    if st.input.interaction_state.viewport_pan_anim.is_some() {
+        return false;
+    }
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    let Some(pending) = st
+        .model
+        .cluster_state
+        .pending_cluster_slot_transition
+        .remove(monitor.as_str())
+    else {
+        return false;
+    };
+    if cluster_slot_cluster_for_monitor(st, monitor.as_str(), pending.slot) != Some(pending.cid) {
+        return false;
+    }
+    enter_cluster_workspace_by_core(st, pending.core_id, monitor.as_str(), now)
+}
+
+pub(crate) fn visible_tiled_cluster_tiles_for_monitor(
+    st: &Halley,
+    monitor: &str,
+) -> Option<(ClusterId, Vec<ClusterTilePlacement>)> {
+    let cid = active_cluster_workspace_for_monitor(st, monitor)?;
+    let plan = crate::compositor::clusters::read::plan_active_cluster_layout(st, monitor)?;
+    if !matches!(plan.kind, ClusterWorkspaceLayoutKind::Tiling) {
+        return None;
     }
 
-    pub(crate) fn focus_active_tiled_cluster_member_for_monitor(
-        &mut self,
-        monitor: &str,
-        preferred_index: Option<usize>,
-        now: Instant,
-    ) -> bool {
-        let Some((_, visible_tiles)) = self.visible_tiled_cluster_tiles_for_monitor(monitor) else {
-            return false;
-        };
-        let visible_members = visible_tiles
-            .into_iter()
-            .map(|tile| tile.node_id)
-            .collect::<Vec<_>>();
-        let Some(target) = visible_members
-            .get(
-                preferred_index
-                    .unwrap_or(0)
-                    .min(visible_members.len().saturating_sub(1)),
-            )
-            .copied()
-        else {
-            return false;
-        };
-        let now_ms = self.now_ms(now);
-        self.set_interaction_focus(Some(target), 30_000, now);
-        self.update_focus_tracking_for_surface(target, now_ms);
-        true
+    let visible_tiles = plan
+        .tiles
+        .into_iter()
+        .filter(|tile| {
+            !st.model
+                .spawn_state
+                .pending_tiled_insert_reveal_at_ms
+                .contains_key(&tile.node_id)
+        })
+        .collect::<Vec<_>>();
+    Some((cid, visible_tiles))
+}
+
+pub(crate) fn directional_target_member(
+    st: &Halley,
+    visible_tiles: &[ClusterTilePlacement],
+    direction: DirectionalAction,
+) -> Option<(NodeId, NodeId)> {
+    if visible_tiles.is_empty() {
+        return None;
     }
 
-    pub(crate) fn tile_focus_active_cluster_member_for_monitor(
-        &mut self,
-        monitor: &str,
-        direction: DirectionalAction,
-        now: Instant,
-    ) -> bool {
-        let Some((_, visible_tiles)) = self.visible_tiled_cluster_tiles_for_monitor(monitor) else {
-            return false;
-        };
-        let Some((_, target)) = self.directional_target_member(&visible_tiles, direction) else {
-            return false;
-        };
-        let now_ms = self.now_ms(now);
-        self.set_interaction_focus(Some(target), 30_000, now);
-        self.update_focus_tracking_for_surface(target, now_ms);
-        true
+    let current_member = st
+        .model
+        .focus_state
+        .primary_interaction_focus
+        .filter(|id| visible_tiles.iter().any(|tile| tile.node_id == *id))
+        .unwrap_or(visible_tiles[0].node_id);
+    let current_rect = visible_tiles
+        .iter()
+        .find(|tile| tile.node_id == current_member)
+        .map(|tile| tile.rect)?;
+    let target = visible_tiles
+        .iter()
+        .filter(|tile| tile.node_id != current_member)
+        .filter_map(|tile| {
+            directional_candidate_score(current_rect, tile.rect, direction)
+                .map(|score| (score, tile.node_id))
+        })
+        .min_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(_, node_id)| node_id)?;
+    Some((current_member, target))
+}
+
+pub(crate) fn move_active_cluster_member_to_drop_tile(
+    st: &mut Halley,
+    monitor: &str,
+    member: NodeId,
+    world_pos: Vec2,
+    now_ms: u64,
+) -> bool {
+    let Some((cid, visible_tiles)) = visible_tiled_cluster_tiles_for_monitor(st, monitor) else {
+        return false;
+    };
+    if !visible_tiles.iter().any(|tile| tile.node_id == member) {
+        return false;
     }
 
-    pub(crate) fn tile_swap_active_cluster_member_for_monitor(
-        &mut self,
-        monitor: &str,
-        direction: DirectionalAction,
-        now: Instant,
-    ) -> bool {
-        let Some((cid, visible_tiles)) = self.visible_tiled_cluster_tiles_for_monitor(monitor)
-        else {
-            return false;
-        };
-        if visible_tiles.len() < 2 {
-            return false;
-        }
-        let Some((current_member, target_member)) =
-            self.directional_target_member(&visible_tiles, direction)
-        else {
-            return false;
-        };
-
-        let Some(mut members) = self
-            .model
-            .field
-            .cluster(cid)
-            .map(|cluster| cluster.members().to_vec())
-        else {
-            return false;
-        };
-        let Some(current_index) = members.iter().position(|id| *id == current_member) else {
-            return false;
-        };
-        let Some(target_index) = members.iter().position(|id| *id == target_member) else {
-            return false;
-        };
-        members.swap(current_index, target_index);
-        if self
-            .model
-            .field
-            .reorder_cluster_members(cid, members)
-            .is_err()
-        {
-            return false;
-        }
-        let now_ms = self.now_ms(now);
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
-        self.set_interaction_focus(Some(current_member), 30_000, now);
-        self.update_focus_tracking_for_surface(current_member, now_ms);
-        true
+    let Some(target_member) = visible_tiles
+        .iter()
+        .find(|tile| {
+            world_pos.x >= tile.rect.x
+                && world_pos.x <= tile.rect.x + tile.rect.w
+                && world_pos.y >= tile.rect.y
+                && world_pos.y <= tile.rect.y + tile.rect.h
+        })
+        .map(|tile| tile.node_id)
+    else {
+        return false;
+    };
+    if target_member == member {
+        return false;
     }
 
-    pub(crate) fn cycle_active_stack_for_monitor(
-        &mut self,
-        monitor: &str,
-        direction: ClusterCycleDirection,
-        now: Instant,
-    ) -> bool {
-        if !matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Stacking
-        ) {
-            return false;
-        }
-        let Some(cid) = self.active_cluster_workspace_for_monitor(monitor) else {
-            return false;
-        };
-        let old_visible =
-            crate::compositor::surface::active_stacking_visible_members_for_monitor(self, monitor);
-        let Some(front) = self
-            .model
-            .field
-            .cycle_cluster_stacking_members(cid, direction)
-        else {
-            return false;
-        };
-        if self.focused_monitor() != monitor {
-            self.focus_monitor_view(monitor, now);
-        }
-        let now_ms = self.now_ms(now);
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
-        let new_visible =
-            crate::compositor::surface::active_stacking_visible_members_for_monitor(self, monitor);
-        let duration_ms = self.runtime.tuning.stack_animation_duration_ms();
-        if self.runtime.tuning.stack_animation_enabled() {
-            for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
-                self.request_window_animation_prewarm(node_id, now);
-            }
-            self.ui.render_state.start_stack_cycle_transition(
-                monitor,
-                direction,
-                old_visible,
-                new_visible,
-                now,
-                duration_ms,
-            );
-            self.request_maintenance();
-        }
-        self.set_recent_top_node(front, now + std::time::Duration::from_millis(1200));
-        self.set_interaction_focus(Some(front), 30_000, now);
-        self.update_focus_tracking_for_surface(front, now_ms);
-        true
+    let Some(members) = st
+        .model
+        .field
+        .cluster(cid)
+        .map(|cluster| cluster.members().to_vec())
+    else {
+        return false;
+    };
+    let Some(from_index) = members.iter().position(|&id| id == member) else {
+        return false;
+    };
+    let Some(target_index) = members.iter().position(|&id| id == target_member) else {
+        return false;
+    };
+
+    let mut reordered = members;
+    let moved = reordered.remove(from_index);
+    reordered.insert(target_index.min(reordered.len()), moved);
+    if st
+        .model
+        .field
+        .reorder_cluster_members(cid, reordered)
+        .is_err()
+    {
+        return false;
     }
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+    true
+}
 
-    pub(crate) fn cycle_active_cluster_layout_for_monitor(
-        &mut self,
-        monitor: &str,
-        now: Instant,
-    ) -> bool {
-        let Some(cid) = self.active_cluster_workspace_for_monitor(monitor) else {
-            return false;
-        };
-        let current_focus = self
-            .model
-            .focus_state
-            .primary_interaction_focus
-            .filter(|id| self.model.field.cluster_id_for_member_public(*id) == Some(cid));
-        let previous_layout_kind = self.active_cluster_layout_kind();
-        let tile_to_stack_transition =
-            if matches!(previous_layout_kind, ClusterWorkspaceLayoutKind::Tiling) {
-                crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
-                    .map(|plan| {
-                        let source_rects = plan
-                            .tiles
-                            .iter()
-                            .map(|tile| (tile.node_id, tile.rect))
-                            .collect::<HashMap<_, _>>();
-                        let old_visible = plan
-                            .tiles
-                            .into_iter()
-                            .map(|tile| tile.node_id)
-                            .collect::<Vec<_>>();
-                        (!source_rects.is_empty()).then_some((old_visible, source_rects))
-                    })
-                    .flatten()
-            } else {
-                None
-            };
+pub(crate) fn focus_active_tiled_cluster_member_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    preferred_index: Option<usize>,
+    now: Instant,
+) -> bool {
+    let Some((_, visible_tiles)) = visible_tiled_cluster_tiles_for_monitor(st, monitor) else {
+        return false;
+    };
+    let visible_members = visible_tiles
+        .into_iter()
+        .map(|tile| tile.node_id)
+        .collect::<Vec<_>>();
+    let Some(target) = visible_members
+        .get(
+            preferred_index
+                .unwrap_or(0)
+                .min(visible_members.len().saturating_sub(1)),
+        )
+        .copied()
+    else {
+        return false;
+    };
+    let now_ms = st.now_ms(now);
+    st.set_interaction_focus(Some(target), 30_000, now);
+    st.update_focus_tracking_for_surface(target, now_ms);
+    true
+}
 
-        self.runtime.tuning.cluster_default_layout =
-            match self.runtime.tuning.cluster_default_layout {
-                ClusterDefaultLayout::Tiling => ClusterDefaultLayout::Stacking,
-                ClusterDefaultLayout::Stacking => ClusterDefaultLayout::Tiling,
-            };
+pub(crate) fn tile_focus_active_cluster_member_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    direction: DirectionalAction,
+    now: Instant,
+) -> bool {
+    let Some((_, visible_tiles)) = visible_tiled_cluster_tiles_for_monitor(st, monitor) else {
+        return false;
+    };
+    let Some((_, target)) = directional_target_member(st, &visible_tiles, direction) else {
+        return false;
+    };
+    let now_ms = st.now_ms(now);
+    st.set_interaction_focus(Some(target), 30_000, now);
+    st.update_focus_tracking_for_surface(target, now_ms);
+    true
+}
 
-        let is_tiling = matches!(
-            self.runtime.tuning.cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Tiling
+pub(crate) fn tile_swap_active_cluster_member_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    direction: DirectionalAction,
+    now: Instant,
+) -> bool {
+    let Some((cid, visible_tiles)) = visible_tiled_cluster_tiles_for_monitor(st, monitor) else {
+        return false;
+    };
+    if visible_tiles.len() < 2 {
+        return false;
+    }
+    let Some((current_member, target_member)) =
+        directional_target_member(st, &visible_tiles, direction)
+    else {
+        return false;
+    };
+
+    let Some(mut members) = st
+        .model
+        .field
+        .cluster(cid)
+        .map(|cluster| cluster.members().to_vec())
+    else {
+        return false;
+    };
+    let Some(current_index) = members.iter().position(|id| *id == current_member) else {
+        return false;
+    };
+    let Some(target_index) = members.iter().position(|id| *id == target_member) else {
+        return false;
+    };
+    members.swap(current_index, target_index);
+    if st
+        .model
+        .field
+        .reorder_cluster_members(cid, members)
+        .is_err()
+    {
+        return false;
+    }
+    let now_ms = st.now_ms(now);
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+    st.set_interaction_focus(Some(current_member), 30_000, now);
+    st.update_focus_tracking_for_surface(current_member, now_ms);
+    true
+}
+
+pub(crate) fn cycle_active_stack_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    direction: ClusterCycleDirection,
+    now: Instant,
+) -> bool {
+    if !matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Stacking
+    ) {
+        return false;
+    }
+    let Some(cid) = active_cluster_workspace_for_monitor(st, monitor) else {
+        return false;
+    };
+    let old_visible =
+        crate::compositor::surface::active_stacking_visible_members_for_monitor(st, monitor);
+    let Some(front) = st
+        .model
+        .field
+        .cycle_cluster_stacking_members(cid, direction)
+    else {
+        return false;
+    };
+    if st.focused_monitor() != monitor {
+        st.focus_monitor_view(monitor, now);
+    }
+    let now_ms = st.now_ms(now);
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+    let new_visible =
+        crate::compositor::surface::active_stacking_visible_members_for_monitor(st, monitor);
+    let duration_ms = st.runtime.tuning.stack_animation_duration_ms();
+    if st.runtime.tuning.stack_animation_enabled() {
+        for node_id in old_visible.iter().chain(new_visible.iter()).copied() {
+            st.request_window_animation_prewarm(node_id, now);
+        }
+        st.ui.render_state.start_stack_cycle_transition(
+            monitor,
+            direction,
+            old_visible,
+            new_visible,
+            now,
+            duration_ms,
         );
+        st.request_maintenance();
+    }
+    st.set_recent_top_node(front, now + std::time::Duration::from_millis(1200));
+    st.set_interaction_focus(Some(front), 30_000, now);
+    st.update_focus_tracking_for_surface(front, now_ms);
+    true
+}
 
-        if is_tiling {
-            let members = self
+pub(crate) fn cycle_active_cluster_layout_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    now: Instant,
+) -> bool {
+    let Some(cid) = active_cluster_workspace_for_monitor(st, monitor) else {
+        return false;
+    };
+    let current_focus = st
+        .model
+        .focus_state
+        .primary_interaction_focus
+        .filter(|id| st.model.field.cluster_id_for_member_public(*id) == Some(cid));
+    let previous_layout_kind = active_cluster_layout_kind(st);
+    let tile_to_stack_transition =
+        if matches!(previous_layout_kind, ClusterWorkspaceLayoutKind::Tiling) {
+            crate::compositor::clusters::read::plan_active_cluster_layout(st, monitor)
+                .map(|plan| {
+                    let source_rects = plan
+                        .tiles
+                        .iter()
+                        .map(|tile| (tile.node_id, tile.rect))
+                        .collect::<HashMap<_, _>>();
+                    let old_visible = plan
+                        .tiles
+                        .into_iter()
+                        .map(|tile| tile.node_id)
+                        .collect::<Vec<_>>();
+                    (!source_rects.is_empty()).then_some((old_visible, source_rects))
+                })
+                .flatten()
+        } else {
+            None
+        };
+
+    st.runtime.tuning.cluster_default_layout = match st.runtime.tuning.cluster_default_layout {
+        ClusterDefaultLayout::Tiling => ClusterDefaultLayout::Stacking,
+        ClusterDefaultLayout::Stacking => ClusterDefaultLayout::Tiling,
+    };
+
+    let is_tiling = matches!(
+        st.runtime.tuning.cluster_layout_kind(),
+        ClusterWorkspaceLayoutKind::Tiling
+    );
+
+    if is_tiling {
+        let members = st
+            .model
+            .field
+            .cluster(cid)
+            .map(|c| c.members().iter().copied().collect::<Vec<_>>())
+            .unwrap_or_default();
+        for member in members {
+            let should_float = st
                 .model
-                .field
-                .cluster(cid)
-                .map(|c| c.members().iter().copied().collect::<Vec<_>>())
-                .unwrap_or_default();
-            for member in members {
-                let should_float = self
+                .spawn_state
+                .applied_window_rules
+                .get(&member)
+                .is_some_and(|rule| {
+                    rule.cluster_participation
+                        == halley_config::InitialWindowClusterParticipation::Float
+                        || rule.overlap_policy != halley_config::InitialWindowOverlapPolicy::None
+                });
+            if should_float {
+                let pos = st
+                    .model
+                    .field
+                    .node(member)
+                    .map(|n| n.pos)
+                    .unwrap_or(halley_core::field::Vec2 { x: 0.0, y: 0.0 });
+                let _ = detach_member_from_cluster(st, cid, member, pos, now);
+            }
+        }
+    } else {
+        let monitor_nodes: Vec<_> = st
+            .model
+            .monitor_state
+            .node_monitor
+            .iter()
+            .filter_map(|(&id, m)| if m == monitor { Some(id) } else { None })
+            .collect();
+        for node in monitor_nodes {
+            if st.model.field.cluster_id_for_member_public(node).is_none() {
+                let should_be_in_cluster = st
                     .model
                     .spawn_state
                     .applied_window_rules
-                    .get(&member)
+                    .get(&node)
                     .is_some_and(|rule| {
                         rule.cluster_participation
                             == halley_config::InitialWindowClusterParticipation::Float
                             || rule.overlap_policy
                                 != halley_config::InitialWindowOverlapPolicy::None
                     });
-                if should_float {
-                    let pos = self
-                        .model
-                        .field
-                        .node(member)
-                        .map(|n| n.pos)
-                        .unwrap_or(halley_core::field::Vec2 { x: 0.0, y: 0.0 });
-                    let _ = self.detach_member_from_cluster(cid, member, pos, now);
-                }
-            }
-        } else {
-            let monitor_nodes: Vec<_> = self
-                .model
-                .monitor_state
-                .node_monitor
-                .iter()
-                .filter_map(|(&id, m)| if m == monitor { Some(id) } else { None })
-                .collect();
-            for node in monitor_nodes {
-                if self
-                    .model
-                    .field
-                    .cluster_id_for_member_public(node)
-                    .is_none()
-                {
-                    let should_be_in_cluster = self
-                        .model
-                        .spawn_state
-                        .applied_window_rules
-                        .get(&node)
-                        .is_some_and(|rule| {
-                            rule.cluster_participation
-                                == halley_config::InitialWindowClusterParticipation::Float
-                                || rule.overlap_policy
-                                    != halley_config::InitialWindowOverlapPolicy::None
-                        });
-                    if should_be_in_cluster {
-                        let _ = self.absorb_node_into_cluster(cid, node, now);
-                    }
+                if should_be_in_cluster {
+                    let _ = absorb_node_into_cluster(st, cid, node, now);
                 }
             }
         }
-
-        let now_ms = self.now_ms(now);
-        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(self);
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
-
-        match self.runtime.tuning.cluster_layout_kind() {
-            ClusterWorkspaceLayoutKind::Tiling => {
-                let preferred_index = current_focus.and_then(|id| {
-                    self.model.field.cluster(cid).and_then(|cluster| {
-                        cluster.members().iter().position(|member| *member == id)
-                    })
-                });
-                let _ = self.focus_active_tiled_cluster_member_for_monitor(
-                    monitor,
-                    preferred_index,
-                    now,
-                );
-            }
-            ClusterWorkspaceLayoutKind::Stacking => {
-                let visible =
-                    crate::compositor::surface::active_stacking_visible_members_for_monitor(
-                        self, monitor,
-                    );
-                if let Some((old_visible, source_rects)) = tile_to_stack_transition {
-                    for node_id in old_visible.iter().chain(visible.iter()).copied() {
-                        self.request_window_animation_prewarm(node_id, now);
-                    }
-                    self.ui
-                        .render_state
-                        .start_stack_cycle_transition_from_rects(
-                            monitor,
-                            ClusterCycleDirection::Prev,
-                            old_visible,
-                            visible.clone(),
-                            source_rects,
-                            now,
-                            240,
-                        );
-                    self.request_maintenance();
-                }
-                if let Some(target) =
-                    crate::compositor::surface::active_stacking_front_member_for_monitor(
-                        self, monitor,
-                    )
-                    .or_else(|| visible.first().copied())
-                {
-                    self.set_recent_top_node(target, now + std::time::Duration::from_millis(1200));
-                    self.set_interaction_focus(Some(target), 30_000, now);
-                    self.update_focus_tracking_for_surface(target, now_ms);
-                }
-            }
-        }
-        self.refresh_cluster_overflow_for_monitor(monitor, now_ms, true);
-        true
     }
+
+    let now_ms = st.now_ms(now);
+    crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(st);
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+
+    match st.runtime.tuning.cluster_layout_kind() {
+        ClusterWorkspaceLayoutKind::Tiling => {
+            let preferred_index = current_focus.and_then(|id| {
+                st.model
+                    .field
+                    .cluster(cid)
+                    .and_then(|cluster| cluster.members().iter().position(|member| *member == id))
+            });
+            let _ =
+                focus_active_tiled_cluster_member_for_monitor(st, monitor, preferred_index, now);
+        }
+        ClusterWorkspaceLayoutKind::Stacking => {
+            let visible = crate::compositor::surface::active_stacking_visible_members_for_monitor(
+                st, monitor,
+            );
+            if let Some((old_visible, source_rects)) = tile_to_stack_transition {
+                for node_id in old_visible.iter().chain(visible.iter()).copied() {
+                    st.request_window_animation_prewarm(node_id, now);
+                }
+                st.ui.render_state.start_stack_cycle_transition_from_rects(
+                    monitor,
+                    ClusterCycleDirection::Prev,
+                    old_visible,
+                    visible.clone(),
+                    source_rects,
+                    now,
+                    240,
+                );
+                st.request_maintenance();
+            }
+            if let Some(target) =
+                crate::compositor::surface::active_stacking_front_member_for_monitor(st, monitor)
+                    .or_else(|| visible.first().copied())
+            {
+                st.set_recent_top_node(target, now + std::time::Duration::from_millis(1200));
+                st.set_interaction_focus(Some(target), 30_000, now);
+                st.update_focus_tracking_for_surface(target, now_ms);
+            }
+        }
+    }
+    refresh_cluster_overflow_for_monitor(st, monitor, now_ms, true);
+    true
 }

--- a/crates/halley-wl/src/compositor/clusters/system/overflow.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/overflow.rs
@@ -74,9 +74,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
             self.clear_cluster_overflow_for_monitor(monitor);
             return;
         };
-        let Some(plan) = self
-            .cluster_read_controller()
-            .plan_active_cluster_layout(monitor)
+        let Some(plan) =
+            crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
         else {
             self.clear_cluster_overflow_for_monitor(monitor);
             return;
@@ -120,10 +119,11 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
                 .cluster_overflow_scroll_offsets
                 .insert(monitor.to_string(), next);
         }
-        if let Some(rect) = self
-            .cluster_read_controller()
-            .overflow_strip_rect_for_monitor(monitor, overflow.len())
-        {
+        if let Some(rect) = crate::compositor::clusters::read::overflow_strip_rect_for_monitor(
+            self,
+            monitor,
+            overflow.len(),
+        ) {
             self.model
                 .cluster_state
                 .cluster_overflow_rects

--- a/crates/halley-wl/src/compositor/clusters/system/overflow.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/overflow.rs
@@ -1,229 +1,226 @@
 use super::*;
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    const CLUSTER_OVERFLOW_REVEAL_MS: u64 = 2200;
+const CLUSTER_OVERFLOW_REVEAL_MS: u64 = 2200;
 
-    pub(crate) fn adjust_cluster_overflow_scroll_for_monitor(
-        &mut self,
-        monitor: &str,
-        delta: i32,
-    ) -> bool {
-        let overflow_len = self
-            .model
+pub(crate) fn adjust_cluster_overflow_scroll_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    delta: i32,
+) -> bool {
+    let overflow_len = st
+        .model
+        .cluster_state
+        .cluster_overflow_members
+        .get(monitor)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let max_offset = overflow_len.saturating_sub(CLUSTER_OVERFLOW_VISIBLE_SLOTS);
+    if max_offset == 0 {
+        st.model
             .cluster_state
-            .cluster_overflow_members
-            .get(monitor)
-            .map(Vec::len)
-            .unwrap_or(0);
-        let max_offset = overflow_len.saturating_sub(Self::CLUSTER_OVERFLOW_VISIBLE_SLOTS);
-        if max_offset == 0 {
-            self.model
-                .cluster_state
-                .cluster_overflow_scroll_offsets
-                .remove(monitor);
-            return false;
-        }
-        let current = self
+            .cluster_overflow_scroll_offsets
+            .remove(monitor);
+        return false;
+    }
+    let current = st
+        .model
+        .cluster_state
+        .cluster_overflow_scroll_offsets
+        .get(monitor)
+        .copied()
+        .unwrap_or(0) as i32;
+    let next = (current + delta).clamp(0, max_offset as i32) as usize;
+    if next == current as usize {
+        return false;
+    }
+    st.model
+        .cluster_state
+        .cluster_overflow_scroll_offsets
+        .insert(monitor.to_string(), next);
+    true
+}
+
+pub(super) fn clear_cluster_overflow_for_monitor(st: &mut Halley, monitor: &str) {
+    st.model
+        .cluster_state
+        .cluster_overflow_members
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_rects
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_scroll_offsets
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_reveal_started_at_ms
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_visible_until_ms
+        .remove(monitor);
+}
+
+pub(super) fn refresh_cluster_overflow_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    now_ms: u64,
+    reveal: bool,
+) {
+    let Some(_cid) = active_cluster_workspace_for_monitor(st, monitor) else {
+        clear_cluster_overflow_for_monitor(st, monitor);
+        return;
+    };
+    let Some(plan) = crate::compositor::clusters::read::plan_active_cluster_layout(st, monitor)
+    else {
+        clear_cluster_overflow_for_monitor(st, monitor);
+        return;
+    };
+    let overflow = plan.overflow_members;
+    if overflow.is_empty() {
+        clear_cluster_overflow_for_monitor(st, monitor);
+        return;
+    }
+
+    let was_visible = st
+        .model
+        .cluster_state
+        .cluster_overflow_visible_until_ms
+        .get(monitor)
+        .is_some_and(|visible_until_ms| *visible_until_ms > now_ms);
+
+    st.model
+        .cluster_state
+        .cluster_overflow_members
+        .insert(monitor.to_string(), overflow.clone());
+    let max_offset = overflow
+        .len()
+        .saturating_sub(CLUSTER_OVERFLOW_VISIBLE_SLOTS);
+    if max_offset == 0 {
+        st.model
+            .cluster_state
+            .cluster_overflow_scroll_offsets
+            .remove(monitor);
+    } else {
+        let next = st
             .model
             .cluster_state
             .cluster_overflow_scroll_offsets
             .get(monitor)
             .copied()
-            .unwrap_or(0) as i32;
-        let next = (current + delta).clamp(0, max_offset as i32) as usize;
-        if next == current as usize {
-            return false;
-        }
-        self.model
+            .unwrap_or(0)
+            .min(max_offset);
+        st.model
             .cluster_state
             .cluster_overflow_scroll_offsets
             .insert(monitor.to_string(), next);
-        true
     }
-
-    pub(super) fn clear_cluster_overflow_for_monitor(&mut self, monitor: &str) {
-        self.model
-            .cluster_state
-            .cluster_overflow_members
-            .remove(monitor);
-        self.model
+    if let Some(rect) = crate::compositor::clusters::read::overflow_strip_rect_for_monitor(
+        st,
+        monitor,
+        overflow.len(),
+    ) {
+        st.model
             .cluster_state
             .cluster_overflow_rects
-            .remove(monitor);
-        self.model
-            .cluster_state
-            .cluster_overflow_scroll_offsets
-            .remove(monitor);
-        self.model
-            .cluster_state
-            .cluster_overflow_reveal_started_at_ms
-            .remove(monitor);
-        self.model
+            .insert(monitor.to_string(), rect);
+    }
+    if reveal {
+        if !was_visible {
+            st.model
+                .cluster_state
+                .cluster_overflow_reveal_started_at_ms
+                .insert(monitor.to_string(), now_ms);
+        }
+        st.model
             .cluster_state
             .cluster_overflow_visible_until_ms
-            .remove(monitor);
+            .insert(
+                monitor.to_string(),
+                now_ms.saturating_add(CLUSTER_OVERFLOW_REVEAL_MS),
+            );
+        st.request_maintenance();
     }
+}
 
-    pub(super) fn refresh_cluster_overflow_for_monitor(
-        &mut self,
-        monitor: &str,
-        now_ms: u64,
-        reveal: bool,
+pub(crate) fn reveal_cluster_overflow_for_monitor(st: &mut Halley, monitor: &str, now_ms: u64) {
+    refresh_cluster_overflow_for_monitor(st, monitor, now_ms, true);
+}
+
+pub(crate) fn hide_cluster_overflow_for_monitor(st: &mut Halley, monitor: &str) {
+    st.model
+        .cluster_state
+        .cluster_overflow_scroll_offsets
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_reveal_started_at_ms
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .cluster_overflow_visible_until_ms
+        .remove(monitor);
+}
+
+pub(crate) fn swap_cluster_overflow_member_with_visible(
+    st: &mut Halley,
+    monitor: &str,
+    cid: ClusterId,
+    overflow_member: NodeId,
+    visible_member: NodeId,
+    now_ms: u64,
+) -> bool {
+    if active_cluster_workspace_for_monitor(st, monitor) != Some(cid) {
+        return false;
+    }
+    if !matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Tiling
     ) {
-        let Some(_cid) = self.active_cluster_workspace_for_monitor(monitor) else {
-            self.clear_cluster_overflow_for_monitor(monitor);
-            return;
-        };
-        let Some(plan) =
-            crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
-        else {
-            self.clear_cluster_overflow_for_monitor(monitor);
-            return;
-        };
-        let overflow = plan.overflow_members;
-        if overflow.is_empty() {
-            self.clear_cluster_overflow_for_monitor(monitor);
-            return;
-        }
-
-        let was_visible = self
-            .model
-            .cluster_state
-            .cluster_overflow_visible_until_ms
-            .get(monitor)
-            .is_some_and(|visible_until_ms| *visible_until_ms > now_ms);
-
-        self.model
-            .cluster_state
-            .cluster_overflow_members
-            .insert(monitor.to_string(), overflow.clone());
-        let max_offset = overflow
-            .len()
-            .saturating_sub(Self::CLUSTER_OVERFLOW_VISIBLE_SLOTS);
-        if max_offset == 0 {
-            self.model
-                .cluster_state
-                .cluster_overflow_scroll_offsets
-                .remove(monitor);
-        } else {
-            let next = self
-                .model
-                .cluster_state
-                .cluster_overflow_scroll_offsets
-                .get(monitor)
-                .copied()
-                .unwrap_or(0)
-                .min(max_offset);
-            self.model
-                .cluster_state
-                .cluster_overflow_scroll_offsets
-                .insert(monitor.to_string(), next);
-        }
-        if let Some(rect) = crate::compositor::clusters::read::overflow_strip_rect_for_monitor(
-            self,
-            monitor,
-            overflow.len(),
-        ) {
-            self.model
-                .cluster_state
-                .cluster_overflow_rects
-                .insert(monitor.to_string(), rect);
-        }
-        if reveal {
-            if !was_visible {
-                self.model
-                    .cluster_state
-                    .cluster_overflow_reveal_started_at_ms
-                    .insert(monitor.to_string(), now_ms);
-            }
-            self.model
-                .cluster_state
-                .cluster_overflow_visible_until_ms
-                .insert(
-                    monitor.to_string(),
-                    now_ms.saturating_add(Self::CLUSTER_OVERFLOW_REVEAL_MS),
-                );
-            self.request_maintenance();
-        }
+        return false;
     }
-
-    pub(crate) fn reveal_cluster_overflow_for_monitor(&mut self, monitor: &str, now_ms: u64) {
-        self.refresh_cluster_overflow_for_monitor(monitor, now_ms, true);
+    let max_stack = st.runtime.tuning.tile_max_stack;
+    if !st.model.field.swap_cluster_overflow_member_with_visible(
+        cid,
+        overflow_member,
+        visible_member,
+        max_stack,
+    ) {
+        return false;
     }
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+    reveal_cluster_overflow_for_monitor(st, monitor, now_ms);
+    true
+}
 
-    pub(crate) fn hide_cluster_overflow_for_monitor(&mut self, monitor: &str) {
-        self.model
-            .cluster_state
-            .cluster_overflow_scroll_offsets
-            .remove(monitor);
-        self.model
-            .cluster_state
-            .cluster_overflow_reveal_started_at_ms
-            .remove(monitor);
-        self.model
-            .cluster_state
-            .cluster_overflow_visible_until_ms
-            .remove(monitor);
+pub(crate) fn reorder_cluster_overflow_member(
+    st: &mut Halley,
+    monitor: &str,
+    cid: ClusterId,
+    member: NodeId,
+    target_overflow_index: usize,
+    now_ms: u64,
+) -> bool {
+    if active_cluster_workspace_for_monitor(st, monitor) != Some(cid) {
+        return false;
     }
-
-    pub(crate) fn swap_cluster_overflow_member_with_visible(
-        &mut self,
-        monitor: &str,
-        cid: ClusterId,
-        overflow_member: NodeId,
-        visible_member: NodeId,
-        now_ms: u64,
-    ) -> bool {
-        if self.active_cluster_workspace_for_monitor(monitor) != Some(cid) {
-            return false;
-        }
-        if !matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Tiling
-        ) {
-            return false;
-        }
-        let max_stack = self.runtime.tuning.tile_max_stack;
-        if !self.model.field.swap_cluster_overflow_member_with_visible(
-            cid,
-            overflow_member,
-            visible_member,
-            max_stack,
-        ) {
-            return false;
-        }
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
-        self.reveal_cluster_overflow_for_monitor(monitor, now_ms);
-        true
+    if !matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Tiling
+    ) {
+        return false;
     }
-
-    pub(crate) fn reorder_cluster_overflow_member(
-        &mut self,
-        monitor: &str,
-        cid: ClusterId,
-        member: NodeId,
-        target_overflow_index: usize,
-        now_ms: u64,
-    ) -> bool {
-        if self.active_cluster_workspace_for_monitor(monitor) != Some(cid) {
-            return false;
-        }
-        if !matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Tiling
-        ) {
-            return false;
-        }
-        let max_stack = self.runtime.tuning.tile_max_stack;
-        if !self.model.field.reorder_cluster_overflow_member(
-            cid,
-            member,
-            target_overflow_index,
-            max_stack,
-        ) {
-            return false;
-        }
-        self.refresh_cluster_overflow_for_monitor(monitor, now_ms, true);
-        true
+    let max_stack = st.runtime.tuning.tile_max_stack;
+    if !st.model.field.reorder_cluster_overflow_member(
+        cid,
+        member,
+        target_overflow_index,
+        max_stack,
+    ) {
+        return false;
     }
+    refresh_cluster_overflow_for_monitor(st, monitor, now_ms, true);
+    true
 }

--- a/crates/halley-wl/src/compositor/clusters/system/tests.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/tests.rs
@@ -97,8 +97,7 @@ fn create_named_test_cluster(
     let cid = st.create_cluster(vec![a, b]).expect("cluster");
     let core = st.collapse_cluster(cid).expect("core");
     st.assign_node_to_monitor(core, monitor);
-    let _ =
-        cluster_system_controller(&mut *st).ensure_cluster_name_record_for_monitor(cid, monitor);
+    let _ = super::ensure_cluster_name_record_for_monitor(&mut *st, cid, monitor);
     (cid, core)
 }
 
@@ -178,11 +177,11 @@ fn cluster_slot_order_is_creation_order_per_monitor() {
     let (cid_b1, _core_b1) = create_named_test_cluster(&mut st, "monitor_b", ["b1", "b2"], 920.0);
 
     assert_eq!(
-        cluster_system_controller(&st).cluster_slot_order_for_monitor("monitor_a"),
+        super::cluster_slot_order_for_monitor(&st, "monitor_a"),
         vec![cid_a1, cid_a2]
     );
     assert_eq!(
-        cluster_system_controller(&st).cluster_slot_order_for_monitor("monitor_b"),
+        super::cluster_slot_order_for_monitor(&st, "monitor_b"),
         vec![cid_b1]
     );
 }
@@ -307,7 +306,10 @@ fn cluster_mode_confirm_opens_name_prompt_before_creating() {
             .is_none()
     );
 
-    assert!(cluster_system_controller(&mut st).cancel_cluster_name_prompt_for_monitor("monitor_a"));
+    assert!(super::cancel_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_a"
+    ));
     assert!(
         !st.model
             .cluster_state
@@ -351,16 +353,15 @@ fn lift_finalize_prompt_selects_existing_matching_apps_without_banner() {
         .node_app_ids
         .insert(second, "org.mozilla.firefox".to_string());
 
-    assert!(
-        cluster_system_controller(&mut st).open_lift_cluster_finalize_draft(
-            "monitor_a",
-            Some("Browser".to_string()),
-            vec!["org.mozilla.firefox.desktop".to_string()],
-            Vec::new(),
-            Vec::new(),
-            now,
-        )
-    );
+    assert!(super::open_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        Some("Browser".to_string()),
+        vec!["org.mozilla.firefox.desktop".to_string()],
+        Vec::new(),
+        Vec::new(),
+        now,
+    ));
     assert!(
         !st.ui
             .render_state
@@ -377,10 +378,11 @@ fn lift_finalize_prompt_selects_existing_matching_apps_without_banner() {
         Some(2)
     );
 
-    assert!(
-        cluster_system_controller(&mut st)
-            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
-    );
+    assert!(super::confirm_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_a",
+        now,
+    ));
     assert_eq!(st.model.field.cluster_ids().len(), 1);
     assert!(
         !st.model
@@ -409,20 +411,20 @@ fn lift_finalize_cross_monitor_selection_centers_core_on_target_monitor() {
     st.assign_node_to_monitor(first, "monitor_a");
     st.assign_node_to_monitor(second, "monitor_a");
 
-    assert!(
-        cluster_system_controller(&mut st).open_lift_cluster_finalize_draft(
-            "monitor_b",
-            Some("Cross".to_string()),
-            Vec::new(),
-            Vec::new(),
-            vec![first, second],
-            now,
-        )
-    );
-    assert!(
-        cluster_system_controller(&mut st)
-            .confirm_cluster_name_prompt_for_monitor("monitor_b", now,)
-    );
+    assert!(super::open_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_b",
+        Some("Cross".to_string()),
+        Vec::new(),
+        Vec::new(),
+        vec![first, second],
+        now,
+    ));
+    assert!(super::confirm_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_b",
+        now,
+    ));
 
     let cid = st
         .model
@@ -474,29 +476,29 @@ fn lift_finalize_launches_after_confirm_and_absorbs_matching_windows() {
     let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
     let now = Instant::now();
 
-    assert!(
-        cluster_system_controller(&mut st).open_lift_cluster_finalize_draft(
-            "monitor_a",
-            Some("Work".to_string()),
-            vec!["alpha.desktop".to_string(), "beta.desktop".to_string()],
-            vec![
-                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
-                    app_id: "alpha.desktop".to_string(),
-                    command: "true".to_string(),
-                },
-                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
-                    app_id: "beta.desktop".to_string(),
-                    command: "true".to_string(),
-                },
-            ],
-            Vec::new(),
-            now,
-        )
-    );
-    assert!(
-        cluster_system_controller(&mut st)
-            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
-    );
+    assert!(super::open_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        Some("Work".to_string()),
+        vec!["alpha.desktop".to_string(), "beta.desktop".to_string()],
+        vec![
+            crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: "alpha.desktop".to_string(),
+                command: "true".to_string(),
+            },
+            crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: "beta.desktop".to_string(),
+                command: "true".to_string(),
+            },
+        ],
+        Vec::new(),
+        now,
+    ));
+    assert!(super::confirm_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_a",
+        now,
+    ));
     assert!(
         st.model
             .cluster_state
@@ -518,19 +520,19 @@ fn lift_finalize_launches_after_confirm_and_absorbs_matching_windows() {
     st.assign_node_to_monitor(alpha, "monitor_a");
     st.assign_node_to_monitor(beta, "monitor_a");
 
-    assert!(
-        cluster_system_controller(&mut st)
-            .note_pending_lift_cluster_candidate_node("monitor_a", alpha)
-    );
-    assert!(cluster_system_controller(&st).pending_lift_cluster_node_staged(alpha));
+    assert!(super::note_pending_lift_cluster_candidate_node(
+        &mut st,
+        "monitor_a",
+        alpha
+    ));
+    assert!(super::pending_lift_cluster_node_staged(&st, alpha));
     st.model.spawn_state.pending_initial_reveal.insert(alpha);
-    assert!(
-        cluster_system_controller(&mut st).maybe_add_node_to_lift_cluster_finalize_draft(
-            "monitor_a",
-            alpha,
-            "alpha",
-        )
-    );
+    assert!(super::maybe_add_node_to_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        alpha,
+        "alpha",
+    ));
     assert_eq!(st.model.field.cluster_ids().len(), 0);
     assert!(
         st.model
@@ -539,19 +541,19 @@ fn lift_finalize_launches_after_confirm_and_absorbs_matching_windows() {
             .is_some_and(|node| node.visibility.has(Visibility::DETACHED))
     );
     assert!(!st.model.spawn_state.pending_initial_reveal.contains(&alpha));
-    assert!(
-        cluster_system_controller(&mut st)
-            .note_pending_lift_cluster_candidate_node("monitor_a", beta)
-    );
-    assert!(cluster_system_controller(&st).pending_lift_cluster_node_staged(beta));
+    assert!(super::note_pending_lift_cluster_candidate_node(
+        &mut st,
+        "monitor_a",
+        beta
+    ));
+    assert!(super::pending_lift_cluster_node_staged(&st, beta));
     st.model.spawn_state.pending_initial_reveal.insert(beta);
-    assert!(
-        cluster_system_controller(&mut st).maybe_add_node_to_lift_cluster_finalize_draft(
-            "monitor_a",
-            beta,
-            "beta",
-        )
-    );
+    assert!(super::maybe_add_node_to_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        beta,
+        "beta",
+    ));
 
     assert_eq!(st.model.field.cluster_ids().len(), 1);
     assert!(
@@ -562,8 +564,8 @@ fn lift_finalize_launches_after_confirm_and_absorbs_matching_windows() {
     );
     assert!(st.model.field.cluster_id_for_member_public(alpha).is_some());
     assert!(st.model.field.cluster_id_for_member_public(beta).is_some());
-    assert!(!cluster_system_controller(&st).pending_lift_cluster_node_staged(alpha));
-    assert!(!cluster_system_controller(&st).pending_lift_cluster_node_staged(beta));
+    assert!(!super::pending_lift_cluster_node_staged(&st, alpha));
+    assert!(!super::pending_lift_cluster_node_staged(&st, beta));
     assert!(!st.model.spawn_state.pending_initial_reveal.contains(&beta));
     for member in [alpha, beta] {
         assert!(st.model.field.node(member).is_some_and(|node| {
@@ -598,29 +600,29 @@ fn lift_finalize_app_launches_do_not_select_existing_matching_windows() {
     st.model.node_app_ids.insert(alpha, "alpha".to_string());
     st.model.node_app_ids.insert(beta, "beta".to_string());
 
-    assert!(
-        cluster_system_controller(&mut st).open_lift_cluster_finalize_draft(
-            "monitor_a",
-            Some("Work".to_string()),
-            Vec::new(),
-            vec![
-                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
-                    app_id: "alpha.desktop".to_string(),
-                    command: "true".to_string(),
-                },
-                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
-                    app_id: "beta.desktop".to_string(),
-                    command: "true".to_string(),
-                },
-            ],
-            Vec::new(),
-            now,
-        )
-    );
-    assert!(
-        cluster_system_controller(&mut st)
-            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
-    );
+    assert!(super::open_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        Some("Work".to_string()),
+        Vec::new(),
+        vec![
+            crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: "alpha.desktop".to_string(),
+                command: "true".to_string(),
+            },
+            crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: "beta.desktop".to_string(),
+                command: "true".to_string(),
+            },
+        ],
+        Vec::new(),
+        now,
+    ));
+    assert!(super::confirm_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_a",
+        now,
+    ));
     assert_eq!(st.model.field.cluster_ids().len(), 0);
     assert!(
         st.model
@@ -630,13 +632,12 @@ fn lift_finalize_app_launches_do_not_select_existing_matching_windows() {
     );
     assert!(st.model.field.cluster_id_for_member_public(alpha).is_none());
     assert!(st.model.field.cluster_id_for_member_public(beta).is_none());
-    assert!(
-        !cluster_system_controller(&mut st).maybe_add_node_to_lift_cluster_finalize_draft(
-            "monitor_a",
-            alpha,
-            "alpha",
-        )
-    );
+    assert!(!super::maybe_add_node_to_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        alpha,
+        "alpha",
+    ));
     assert!(st.model.field.cluster_id_for_member_public(alpha).is_none());
     assert_eq!(
         st.ui
@@ -655,25 +656,25 @@ fn lift_finalize_releases_non_matching_staged_candidate() {
     let mut st = Halley::new_for_test(&dh, single_monitor_tuning());
     let now = Instant::now();
 
-    assert!(
-        cluster_system_controller(&mut st).open_lift_cluster_finalize_draft(
-            "monitor_a",
-            Some("Work".to_string()),
-            Vec::new(),
-            vec![
-                crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
-                    app_id: "alpha.desktop".to_string(),
-                    command: "true".to_string(),
-                },
-            ],
-            Vec::new(),
-            now,
-        )
-    );
-    assert!(
-        cluster_system_controller(&mut st)
-            .confirm_cluster_name_prompt_for_monitor("monitor_a", now,)
-    );
+    assert!(super::open_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        Some("Work".to_string()),
+        Vec::new(),
+        vec![
+            crate::compositor::clusters::state::ClusterFinalizeAppLaunch {
+                app_id: "alpha.desktop".to_string(),
+                command: "true".to_string(),
+            },
+        ],
+        Vec::new(),
+        now,
+    ));
+    assert!(super::confirm_cluster_name_prompt_for_monitor(
+        &mut st,
+        "monitor_a",
+        now,
+    ));
 
     let candidate = st.model.field.spawn_surface(
         "Gamma",
@@ -681,20 +682,20 @@ fn lift_finalize_releases_non_matching_staged_candidate() {
         Vec2 { x: 220.0, y: 160.0 },
     );
     st.assign_node_to_monitor(candidate, "monitor_a");
-    assert!(
-        cluster_system_controller(&mut st)
-            .note_pending_lift_cluster_candidate_node("monitor_a", candidate)
-    );
-    assert!(cluster_system_controller(&st).pending_lift_cluster_node_staged(candidate));
+    assert!(super::note_pending_lift_cluster_candidate_node(
+        &mut st,
+        "monitor_a",
+        candidate
+    ));
+    assert!(super::pending_lift_cluster_node_staged(&st, candidate));
 
-    assert!(
-        !cluster_system_controller(&mut st).maybe_add_node_to_lift_cluster_finalize_draft(
-            "monitor_a",
-            candidate,
-            "gamma",
-        )
-    );
-    assert!(!cluster_system_controller(&st).pending_lift_cluster_node_staged(candidate));
+    assert!(!super::maybe_add_node_to_lift_cluster_finalize_draft(
+        &mut st,
+        "monitor_a",
+        candidate,
+        "gamma",
+    ));
+    assert!(!super::pending_lift_cluster_node_staged(&st, candidate));
     assert!(
         st.model
             .field
@@ -714,7 +715,7 @@ fn custom_cluster_name_stays_unique_and_survives_monitor_move() {
             name: "Studio".to_string(),
         },
     );
-    let _ = cluster_system_controller(&mut st).relabel_cluster_core(cid);
+    let _ = super::relabel_cluster_core(&mut st, cid);
     st.assign_node_to_monitor(core, "monitor_b");
     let _ = st.sync_cluster_monitor(cid, Some("monitor_b"));
     assert_eq!(
@@ -1073,12 +1074,8 @@ fn tiled_cluster_focus_retargets_replacement_tile_by_index() {
     let now = Instant::now();
     assert!(st.enter_cluster_workspace_by_core(core, "monitor_a", now));
 
-    let removed = cluster_system_controller(&mut st).detach_member_from_cluster(
-        cid,
-        stack_a,
-        Vec2 { x: 0.0, y: 0.0 },
-        now,
-    );
+    let removed =
+        super::detach_member_from_cluster(&mut st, cid, stack_a, Vec2 { x: 0.0, y: 0.0 }, now);
     assert!(removed);
     st.layout_active_cluster_workspace_for_monitor("monitor_a", st.now_ms(now));
     assert!(st.focus_active_tiled_cluster_member_for_monitor("monitor_a", Some(1), now));

--- a/crates/halley-wl/src/compositor/clusters/system/tests.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/tests.rs
@@ -291,7 +291,9 @@ fn cluster_mode_confirm_opens_name_prompt_before_creating() {
     assert!(st.enter_cluster_mode());
     assert!(st.toggle_cluster_mode_selection(first));
     assert!(st.toggle_cluster_mode_selection(second));
-    assert!(st.confirm_cluster_mode(now));
+    assert!(crate::compositor::clusters::system::confirm_cluster_mode(
+        &mut st, now
+    ));
     assert!(
         st.model
             .cluster_state
@@ -1312,7 +1314,13 @@ fn closing_cluster_bloom_refocuses_core() {
     let core = st.collapse_cluster(cid).expect("core");
     st.assign_node_to_monitor(core, "monitor_a");
 
-    assert!(st.open_cluster_bloom_for_monitor("monitor_a", cid));
+    assert!(
+        crate::compositor::clusters::system::open_cluster_bloom_for_monitor(
+            &mut st,
+            "monitor_a",
+            cid
+        )
+    );
     st.set_interaction_focus(Some(master), 30_000, Instant::now());
 
     assert!(st.close_cluster_bloom_for_monitor("monitor_a"));

--- a/crates/halley-wl/src/compositor/clusters/system/workspace.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/workspace.rs
@@ -118,9 +118,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         }
         let perf_start = crate::perf::start();
         let plan_start = crate::perf::start();
-        let Some(plan) = self
-            .cluster_read_controller()
-            .plan_enter_cluster_workspace(core_id, monitor)
+        let Some(plan) =
+            crate::compositor::clusters::read::plan_enter_cluster_workspace(self, core_id, monitor)
         else {
             return false;
         };
@@ -239,9 +238,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         monitor: &str,
         now: Instant,
     ) -> bool {
-        let Some(plan) = self
-            .cluster_read_controller()
-            .plan_exit_cluster_workspace(monitor)
+        let Some(plan) =
+            crate::compositor::clusters::read::plan_exit_cluster_workspace(self, monitor)
         else {
             return false;
         };
@@ -473,9 +471,8 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         {
             return;
         }
-        let Some(plan) = self
-            .cluster_read_controller()
-            .plan_active_cluster_layout(monitor)
+        let Some(plan) =
+            crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
         else {
             return;
         };

--- a/crates/halley-wl/src/compositor/clusters/system/workspace.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/workspace.rs
@@ -4,553 +4,546 @@ use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use super::*;
 
-impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
-    fn restore_cluster_workspace_monitor(&mut self, monitor: &str) {
-        let Some(vp) = self
+pub(crate) fn restore_cluster_workspace_monitor(st: &mut Halley, monitor: &str) {
+    let Some(vp) = st
+        .model
+        .cluster_state
+        .workspace_prev_viewports
+        .remove(monitor)
+    else {
+        return;
+    };
+    if st.model.monitor_state.current_monitor == monitor {
+        st.model.viewport = vp;
+        st.model.zoom_ref_size = st.model.viewport.size;
+        crate::compositor::monitor::camera::snap_camera_targets_to_live(&mut *st);
+        st.runtime.tuning.viewport_center = st.model.viewport.center;
+        st.runtime.tuning.viewport_size = st.model.viewport.size;
+    }
+    if let Some(space) = st.model.monitor_state.monitors.get_mut(monitor) {
+        space.viewport = vp;
+        space.zoom_ref_size = vp.size;
+        space.camera_target_center = vp.center;
+        space.camera_target_view_size = vp.size;
+    }
+}
+
+pub(super) fn clear_cluster_shell_state(st: &mut Halley, cid: ClusterId) {
+    let active_monitors = st
+        .model
+        .cluster_state
+        .active_cluster_workspaces
+        .iter()
+        .filter_map(|(monitor, active_cid)| (*active_cid == cid).then(|| monitor.clone()))
+        .collect::<Vec<_>>();
+    for monitor in &active_monitors {
+        for id in st
             .model
             .cluster_state
-            .workspace_prev_viewports
-            .remove(monitor)
-        else {
-            return;
-        };
-        if self.model.monitor_state.current_monitor == monitor {
-            self.model.viewport = vp;
-            self.model.zoom_ref_size = self.model.viewport.size;
-            crate::compositor::monitor::camera::snap_camera_targets_to_live(&mut **self);
-            self.runtime.tuning.viewport_center = self.model.viewport.center;
-            self.runtime.tuning.viewport_size = self.model.viewport.size;
-        }
-        if let Some(space) = self.model.monitor_state.monitors.get_mut(monitor) {
-            space.viewport = vp;
-            space.zoom_ref_size = vp.size;
-            space.camera_target_center = vp.center;
-            space.camera_target_view_size = vp.size;
-        }
-    }
-
-    pub(super) fn clear_cluster_shell_state(&mut self, cid: ClusterId) {
-        let active_monitors = self
-            .model
-            .cluster_state
-            .active_cluster_workspaces
-            .iter()
-            .filter_map(|(monitor, active_cid)| (*active_cid == cid).then(|| monitor.clone()))
-            .collect::<Vec<_>>();
-        for monitor in &active_monitors {
-            for id in self
-                .model
-                .cluster_state
-                .workspace_hidden_nodes
-                .remove(monitor.as_str())
-                .unwrap_or_default()
-            {
-                if self.model.field.node(id).is_some() {
-                    let _ = self.model.field.set_detached(id, false);
-                }
-            }
-            self.model
-                .cluster_state
-                .workspace_core_positions
-                .remove(monitor.as_str());
-            self.clear_cluster_overflow_for_monitor(monitor.as_str());
-            if self
-                .input
-                .interaction_state
-                .cluster_overflow_drag_preview
-                .as_ref()
-                .is_some_and(|preview| preview.monitor == *monitor)
-            {
-                self.input.interaction_state.cluster_overflow_drag_preview = None;
-                crate::compositor::interaction::pointer::set_cursor_override_icon(self, None);
-            }
-            self.restore_cluster_workspace_monitor(monitor.as_str());
-        }
-        self.model
-            .cluster_state
-            .active_cluster_workspaces
-            .retain(|_, active_cid| *active_cid != cid);
-        self.model
-            .cluster_state
-            .cluster_bloom_open
-            .retain(|_, open_cid| *open_cid != cid);
-        if self
-            .input
-            .interaction_state
-            .cluster_join_candidate
-            .as_ref()
-            .is_some_and(|candidate| candidate.cluster_id == cid)
+            .workspace_hidden_nodes
+            .remove(monitor.as_str())
+            .unwrap_or_default()
         {
-            self.input.interaction_state.cluster_join_candidate = None;
+            if st.model.field.node(id).is_some() {
+                let _ = st.model.field.set_detached(id, false);
+            }
         }
-    }
-
-    pub fn collapse_active_cluster_workspace(&mut self, now: Instant) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        self.exit_cluster_workspace_for_monitor(monitor.as_str(), now)
-    }
-
-    pub fn toggle_cluster_workspace_by_core(&mut self, core_id: NodeId, now: Instant) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        if let Some(cid) = self.active_cluster_workspace_for_monitor(monitor.as_str())
-            && self.model.field.cluster_id_for_core_public(core_id) == Some(cid)
-        {
-            return self.exit_cluster_workspace_for_monitor(monitor.as_str(), now);
-        }
-        self.enter_cluster_workspace_by_core(core_id, monitor.as_str(), now)
-    }
-
-    pub(crate) fn enter_cluster_workspace_by_core(
-        &mut self,
-        core_id: NodeId,
-        monitor: &str,
-        now: Instant,
-    ) -> bool {
-        let Some(cid) = self.model.field.cluster_id_for_core_public(core_id) else {
-            return false;
-        };
-        if self.active_cluster_workspace_for_monitor(monitor) == Some(cid) {
-            return true;
-        }
-        if self.active_cluster_workspace_for_monitor(monitor).is_some() {
-            let _ = self.exit_cluster_workspace_for_monitor(monitor, now);
-        }
-        let perf_start = crate::perf::start();
-        let plan_start = crate::perf::start();
-        let Some(plan) =
-            crate::compositor::clusters::read::plan_enter_cluster_workspace(self, core_id, monitor)
-        else {
-            return false;
-        };
-        let plan_ms = plan_start.map(crate::perf::elapsed_ms);
-        let _ = self.sync_cluster_monitor(cid, Some(monitor));
-        let previous_full_viewport = if self.model.monitor_state.current_monitor == monitor {
-            self.model.viewport
-        } else {
-            self.model
-                .monitor_state
-                .monitors
-                .get(monitor)
-                .map(|space| space.viewport)
-                .unwrap_or(plan.current_viewport)
-        };
-        self.model
-            .cluster_state
-            .workspace_prev_viewports
-            .insert(monitor.to_string(), previous_full_viewport);
-        self.model
+        st.model
             .cluster_state
             .workspace_core_positions
-            .insert(monitor.to_string(), plan.core_pos);
-        if self.model.monitor_state.current_monitor == monitor {
-            let live_viewport = self
-                .model
-                .monitor_state
-                .monitors
-                .get(monitor)
-                .map(|space| space.viewport)
-                .unwrap_or(plan.current_viewport);
-            self.input.interaction_state.viewport_pan_anim = None;
-            self.model.viewport = live_viewport;
-            self.model.zoom_ref_size = live_viewport.size;
-            self.model.camera_target_center = live_viewport.center;
-            self.model.camera_target_view_size = live_viewport.size;
-            self.runtime.tuning.viewport_center = live_viewport.center;
-            self.runtime.tuning.viewport_size = live_viewport.size;
-        }
-        self.model.spawn_state.pending_spawn_pan_queue.clear();
-        self.model.spawn_state.active_spawn_pan = None;
-        self.input.interaction_state.viewport_pan_anim = None;
-        self.model.spawn_state.pending_spawn_monitor = None;
-        let spawn = self.spawn_monitor_state_mut(monitor);
-        spawn.spawn_pan_start_center = None;
-        for id in &plan.hidden_ids {
-            let _ = self.model.field.set_detached(*id, true);
-        }
-        let _ = self.model.field.set_detached(plan.core_id, true);
-        let _ = self.model.field.activate_cluster_workspace(plan.cid);
-
-        self.model
-            .cluster_state
-            .workspace_hidden_nodes
-            .insert(monitor.to_string(), plan.hidden_ids);
-        self.model
-            .cluster_state
-            .active_cluster_workspaces
-            .retain(|name, active_cid| *active_cid != cid || name == monitor);
-        self.model
-            .cluster_state
-            .active_cluster_workspaces
-            .insert(monitor.to_string(), cid);
-        self.model.cluster_state.cluster_bloom_open.remove(monitor);
-        self.set_interaction_focus(None, 0, now);
-        let now_ms = self.now_ms(now);
-        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewport_forced(
-            self, monitor,
-        );
-        let layout_start = crate::perf::start();
-        self.layout_active_cluster_workspace_for_monitor(monitor, now_ms);
-        let layout_ms = layout_start.map(crate::perf::elapsed_ms);
-        if matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Stacking
-        ) && let Some(front) = self
-            .model
-            .field
-            .cluster(plan.cid)
-            .and_then(|cluster| cluster.members().first().copied())
-        {
-            self.set_recent_top_node(front, now + std::time::Duration::from_millis(1200));
-            self.set_interaction_focus(Some(front), 30_000, now);
-            self.update_focus_tracking_for_surface(front, now_ms);
-        } else if matches!(
-            self.active_cluster_layout_kind(),
-            ClusterWorkspaceLayoutKind::Tiling
-        ) {
-            let _ = self.focus_active_tiled_cluster_member_for_monitor(monitor, Some(0), now);
-        }
-        let overflow_start = crate::perf::start();
-        self.refresh_cluster_overflow_for_monitor(monitor, now_ms, false);
-        if let Some(start) = perf_start {
-            let members = self
-                .model
-                .field
-                .cluster(cid)
-                .map_or(0, |cluster| cluster.members().len());
-            eventline::info!(
-                "perf enter_cluster_workspace monitor={} members={} took={:.2}ms (plan={:.2} layout={:.2} overflow={:.2})",
-                monitor,
-                members,
-                crate::perf::elapsed_ms(start),
-                plan_ms.unwrap_or_default(),
-                layout_ms.unwrap_or_default(),
-                overflow_start
-                    .map(crate::perf::elapsed_ms)
-                    .unwrap_or_default(),
-            );
-        }
-        true
-    }
-
-    pub(crate) fn exit_cluster_workspace_for_monitor(
-        &mut self,
-        monitor: &str,
-        now: Instant,
-    ) -> bool {
-        let Some(plan) =
-            crate::compositor::clusters::read::plan_exit_cluster_workspace(self, monitor)
-        else {
-            return false;
-        };
-
-        for id in &plan.hidden_ids {
-            let _ = self.model.field.set_detached(*id, false);
-        }
-
-        let _ = self.model.field.deactivate_cluster_workspace(plan.cid);
-        let core = self.collapse_cluster(plan.cid).or(plan.core_id);
-        if let Some(core_id) = core {
-            let _ = self.ensure_cluster_name_record_for_monitor(plan.cid, monitor);
-            let _ = self.relabel_cluster_core(plan.cid);
-            let preserved_core_pos = self
-                .model
-                .cluster_state
-                .workspace_core_positions
-                .remove(monitor)
-                .or(plan.core_pos);
-            if let Some(core_pos) = preserved_core_pos {
-                let _ = self.model.field.carry(core_id, core_pos);
-            }
-            let _ = self.model.field.set_detached(core_id, false);
-            self.assign_node_to_monitor(core_id, monitor);
-            let now_ms = self.now_ms(now);
-            let _ = self.model.field.touch(core_id, now_ms);
-        }
-
-        self.restore_cluster_workspace_monitor(monitor);
-        self.model
-            .cluster_state
-            .active_cluster_workspaces
-            .remove(monitor);
-        self.model
-            .cluster_state
-            .workspace_hidden_nodes
-            .remove(monitor);
-        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(self);
-        self.clear_cluster_overflow_for_monitor(monitor);
-        if self
+            .remove(monitor.as_str());
+        clear_cluster_overflow_for_monitor(st, monitor.as_str());
+        if st
             .input
             .interaction_state
             .cluster_overflow_drag_preview
             .as_ref()
-            .is_some_and(|preview| preview.monitor == monitor)
+            .is_some_and(|preview| preview.monitor == *monitor)
         {
-            self.input.interaction_state.cluster_overflow_drag_preview = None;
-            crate::compositor::interaction::pointer::set_cursor_override_icon(self, None);
+            st.input.interaction_state.cluster_overflow_drag_preview = None;
+            crate::compositor::interaction::pointer::set_cursor_override_icon(st, None);
         }
-        if let Some(core_id) = core {
-            self.set_recent_top_node(core_id, now + std::time::Duration::from_millis(1200));
-            self.set_interaction_focus(Some(core_id), 30_000, now);
-        }
-        true
+        restore_cluster_workspace_monitor(st, monitor.as_str());
     }
-
-    fn clear_cluster_tile_animation_for_node(&mut self, node_id: NodeId) {
-        self.ui
-            .render_state
-            .clear_cluster_tile_animation_for_node(node_id);
+    st.model
+        .cluster_state
+        .active_cluster_workspaces
+        .retain(|_, active_cid| *active_cid != cid);
+    st.model
+        .cluster_state
+        .cluster_bloom_open
+        .retain(|_, open_cid| *open_cid != cid);
+    if st
+        .input
+        .interaction_state
+        .cluster_join_candidate
+        .as_ref()
+        .is_some_and(|candidate| candidate.cluster_id == cid)
+    {
+        st.input.interaction_state.cluster_join_candidate = None;
     }
+}
 
-    fn update_tiled_cluster_animation_targets(
-        &mut self,
-        plan: &ClusterLayoutPlan,
-        dragged_member: Option<NodeId>,
-        now: Instant,
+pub fn collapse_active_cluster_workspace(st: &mut Halley, now: Instant) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    exit_cluster_workspace_for_monitor(st, monitor.as_str(), now)
+}
+
+pub fn toggle_cluster_workspace_by_core(st: &mut Halley, core_id: NodeId, now: Instant) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    if let Some(cid) = active_cluster_workspace_for_monitor(st, monitor.as_str())
+        && st.model.field.cluster_id_for_core_public(core_id) == Some(cid)
+    {
+        return exit_cluster_workspace_for_monitor(st, monitor.as_str(), now);
+    }
+    enter_cluster_workspace_by_core(st, core_id, monitor.as_str(), now)
+}
+
+pub(crate) fn enter_cluster_workspace_by_core(
+    st: &mut Halley,
+    core_id: NodeId,
+    monitor: &str,
+    now: Instant,
+) -> bool {
+    let Some(cid) = st.model.field.cluster_id_for_core_public(core_id) else {
+        return false;
+    };
+    if active_cluster_workspace_for_monitor(st, monitor) == Some(cid) {
+        return true;
+    }
+    if active_cluster_workspace_for_monitor(st, monitor).is_some() {
+        let _ = exit_cluster_workspace_for_monitor(st, monitor, now);
+    }
+    let perf_start = crate::perf::start();
+    let plan_start = crate::perf::start();
+    let Some(plan) =
+        crate::compositor::clusters::read::plan_enter_cluster_workspace(st, core_id, monitor)
+    else {
+        return false;
+    };
+    let plan_ms = plan_start.map(crate::perf::elapsed_ms);
+    let _ = sync_cluster_monitor(st, cid, Some(monitor));
+    let previous_full_viewport = if st.model.monitor_state.current_monitor == monitor {
+        st.model.viewport
+    } else {
+        st.model
+            .monitor_state
+            .monitors
+            .get(monitor)
+            .map(|space| space.viewport)
+            .unwrap_or(plan.current_viewport)
+    };
+    st.model
+        .cluster_state
+        .workspace_prev_viewports
+        .insert(monitor.to_string(), previous_full_viewport);
+    st.model
+        .cluster_state
+        .workspace_core_positions
+        .insert(monitor.to_string(), plan.core_pos);
+    if st.model.monitor_state.current_monitor == monitor {
+        let live_viewport = st
+            .model
+            .monitor_state
+            .monitors
+            .get(monitor)
+            .map(|space| space.viewport)
+            .unwrap_or(plan.current_viewport);
+        st.input.interaction_state.viewport_pan_anim = None;
+        st.model.viewport = live_viewport;
+        st.model.zoom_ref_size = live_viewport.size;
+        st.model.camera_target_center = live_viewport.center;
+        st.model.camera_target_view_size = live_viewport.size;
+        st.runtime.tuning.viewport_center = live_viewport.center;
+        st.runtime.tuning.viewport_size = live_viewport.size;
+    }
+    st.model.spawn_state.pending_spawn_pan_queue.clear();
+    st.model.spawn_state.active_spawn_pan = None;
+    st.input.interaction_state.viewport_pan_anim = None;
+    st.model.spawn_state.pending_spawn_monitor = None;
+    let spawn = st.spawn_monitor_state_mut(monitor);
+    spawn.spawn_pan_start_center = None;
+    for id in &plan.hidden_ids {
+        let _ = st.model.field.set_detached(*id, true);
+    }
+    let _ = st.model.field.set_detached(plan.core_id, true);
+    let _ = st.model.field.activate_cluster_workspace(plan.cid);
+
+    st.model
+        .cluster_state
+        .workspace_hidden_nodes
+        .insert(monitor.to_string(), plan.hidden_ids);
+    st.model
+        .cluster_state
+        .active_cluster_workspaces
+        .retain(|name, active_cid| *active_cid != cid || name == monitor);
+    st.model
+        .cluster_state
+        .active_cluster_workspaces
+        .insert(monitor.to_string(), cid);
+    st.model.cluster_state.cluster_bloom_open.remove(monitor);
+    st.set_interaction_focus(None, 0, now);
+    let now_ms = st.now_ms(now);
+    crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewport_forced(st, monitor);
+    let layout_start = crate::perf::start();
+    layout_active_cluster_workspace_for_monitor(st, monitor, now_ms);
+    let layout_ms = layout_start.map(crate::perf::elapsed_ms);
+    if matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Stacking
+    ) && let Some(front) = st
+        .model
+        .field
+        .cluster(plan.cid)
+        .and_then(|cluster| cluster.members().first().copied())
+    {
+        st.set_recent_top_node(front, now + std::time::Duration::from_millis(1200));
+        st.set_interaction_focus(Some(front), 30_000, now);
+        st.update_focus_tracking_for_surface(front, now_ms);
+    } else if matches!(
+        active_cluster_layout_kind(st),
+        ClusterWorkspaceLayoutKind::Tiling
     ) {
-        for placement in &plan.tiles {
-            if self
+        let _ = focus_active_tiled_cluster_member_for_monitor(st, monitor, Some(0), now);
+    }
+    let overflow_start = crate::perf::start();
+    refresh_cluster_overflow_for_monitor(st, monitor, now_ms, false);
+    if let Some(start) = perf_start {
+        let members = st
+            .model
+            .field
+            .cluster(cid)
+            .map_or(0, |cluster| cluster.members().len());
+        eventline::info!(
+            "perf enter_cluster_workspace monitor={} members={} took={:.2}ms (plan={:.2} layout={:.2} overflow={:.2})",
+            monitor,
+            members,
+            crate::perf::elapsed_ms(start),
+            plan_ms.unwrap_or_default(),
+            layout_ms.unwrap_or_default(),
+            overflow_start
+                .map(crate::perf::elapsed_ms)
+                .unwrap_or_default(),
+        );
+    }
+    true
+}
+
+pub(crate) fn exit_cluster_workspace_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    now: Instant,
+) -> bool {
+    let Some(plan) = crate::compositor::clusters::read::plan_exit_cluster_workspace(st, monitor)
+    else {
+        return false;
+    };
+
+    for id in &plan.hidden_ids {
+        let _ = st.model.field.set_detached(*id, false);
+    }
+
+    let _ = st.model.field.deactivate_cluster_workspace(plan.cid);
+    let core = st.collapse_cluster(plan.cid).or(plan.core_id);
+    if let Some(core_id) = core {
+        let _ = ensure_cluster_name_record_for_monitor(st, plan.cid, monitor);
+        let _ = relabel_cluster_core(st, plan.cid);
+        let preserved_core_pos = st
+            .model
+            .cluster_state
+            .workspace_core_positions
+            .remove(monitor)
+            .or(plan.core_pos);
+        if let Some(core_pos) = preserved_core_pos {
+            let _ = st.model.field.carry(core_id, core_pos);
+        }
+        let _ = st.model.field.set_detached(core_id, false);
+        st.assign_node_to_monitor(core_id, monitor);
+        let now_ms = st.now_ms(now);
+        let _ = st.model.field.touch(core_id, now_ms);
+    }
+
+    restore_cluster_workspace_monitor(st, monitor);
+    st.model
+        .cluster_state
+        .active_cluster_workspaces
+        .remove(monitor);
+    st.model
+        .cluster_state
+        .workspace_hidden_nodes
+        .remove(monitor);
+    crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(st);
+    clear_cluster_overflow_for_monitor(st, monitor);
+    if st
+        .input
+        .interaction_state
+        .cluster_overflow_drag_preview
+        .as_ref()
+        .is_some_and(|preview| preview.monitor == monitor)
+    {
+        st.input.interaction_state.cluster_overflow_drag_preview = None;
+        crate::compositor::interaction::pointer::set_cursor_override_icon(st, None);
+    }
+    if let Some(core_id) = core {
+        st.set_recent_top_node(core_id, now + std::time::Duration::from_millis(1200));
+        st.set_interaction_focus(Some(core_id), 30_000, now);
+    }
+    true
+}
+
+pub(crate) fn clear_cluster_tile_animation_for_node(st: &mut Halley, node_id: NodeId) {
+    st.ui
+        .render_state
+        .clear_cluster_tile_animation_for_node(node_id);
+}
+
+pub(crate) fn update_tiled_cluster_animation_targets(
+    st: &mut Halley,
+    plan: &ClusterLayoutPlan,
+    dragged_member: Option<NodeId>,
+    now: Instant,
+) {
+    for placement in &plan.tiles {
+        if st
+            .model
+            .spawn_state
+            .pending_tiled_insert_reveal_at_ms
+            .contains_key(&placement.node_id)
+            || Some(placement.node_id) == dragged_member
+        {
+            clear_cluster_tile_animation_for_node(st, placement.node_id);
+            continue;
+        }
+
+        let current_rect = if st
+            .ui
+            .render_state
+            .remove_cluster_tile_entry_pending(placement.node_id)
+        {
+            None
+        } else {
+            crate::animation::cluster_tile_rect_from_field(&st.model.field, placement.node_id)
+        };
+        let frozen_geo = st
+            .ui
+            .render_state
+            .cache
+            .window_geometry
+            .get(&placement.node_id)
+            .copied();
+        if current_rect.is_some_and(|rect| rect.alpha > 0.01)
+            && let Some(geo) = frozen_geo
+        {
+            st.ui
+                .render_state
+                .remember_cluster_tile_frozen_geometry(placement.node_id, geo);
+        }
+        let duration_ms = st.runtime.tuning.tile_animation_duration_ms();
+        if st.runtime.tuning.tile_animation_enabled() {
+            crate::animation::set_cluster_tile_target(
+                st.ui.render_state.cluster_tile_tracks_mut(),
+                current_rect,
+                placement.node_id,
+                placement.rect,
+                now,
+                duration_ms,
+            );
+            st.request_window_animation_prewarm(placement.node_id, now);
+        } else {
+            st.ui
+                .render_state
+                .remove_cluster_tile_track(placement.node_id);
+        }
+    }
+}
+
+pub(crate) fn current_surface_size_map_for_members(
+    st: &Halley,
+    members: &HashSet<NodeId>,
+) -> HashMap<NodeId, Vec2> {
+    let mut sizes = HashMap::with_capacity(members.len());
+    for (&node_id, &(_, _, w, h)) in &st.ui.render_state.cache.window_geometry {
+        if members.contains(&node_id) {
+            sizes.insert(
+                node_id,
+                Vec2 {
+                    x: w.max(1.0),
+                    y: h.max(1.0),
+                },
+            );
+        }
+    }
+
+    for top in st.platform.xdg_shell_state.toplevel_surfaces() {
+        let wl = top.wl_surface();
+        let key = wl.id();
+        let Some(node_id) = st.model.surface_to_node.get(&key).copied() else {
+            continue;
+        };
+        if sizes.contains_key(&node_id) || !members.contains(&node_id) {
+            continue;
+        }
+
+        let size = with_states(wl, |states| {
+            states
+                .cached_state
+                .get::<SurfaceCachedState>()
+                .current()
+                .geometry
+        })
+        .map(|g| Vec2 {
+            x: g.size.w.max(1) as f32,
+            y: g.size.h.max(1) as f32,
+        })
+        .or_else(|| {
+            top.with_committed_state(|state| state.and_then(|state| state.size))
+                .map(|sz| Vec2 {
+                    x: sz.w.max(1) as f32,
+                    y: sz.h.max(1) as f32,
+                })
+        })
+        .unwrap_or_else(|| {
+            let bbox = bbox_from_surface_tree(wl, (0, 0));
+            Vec2 {
+                x: bbox.size.w.max(1) as f32,
+                y: bbox.size.h.max(1) as f32,
+            }
+        });
+        sizes.insert(node_id, size);
+    }
+
+    for &node_id in members {
+        sizes.entry(node_id).or_insert_with(|| {
+            st.model
+                .field
+                .node(node_id)
+                .map_or(Vec2 { x: 1.0, y: 1.0 }, |node| Vec2 {
+                    x: node.intrinsic_size.x.max(1.0),
+                    y: node.intrinsic_size.y.max(1.0),
+                })
+        });
+    }
+
+    sizes
+}
+
+pub(crate) fn layout_active_cluster_workspace_for_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    now_ms: u64,
+) {
+    let Some(cid) = active_cluster_workspace_for_monitor(st, monitor) else {
+        return;
+    };
+    let Some(cluster) = st.model.field.cluster(cid) else {
+        // The cluster dissolved (e.g. its last window closed) while its
+        // workspace was still active. Drop the stale workspace entry and
+        // recompute the work area: with no active cluster the aperture
+        // reservation falls to zero, so the frozen top gap is released
+        // immediately instead of lingering (`refresh` re-checks the now-
+        // unlocked monitor). The explicit exit path already refreshes; this
+        // covers the implicit-dissolve path.
+        st.model
+            .cluster_state
+            .active_cluster_workspaces
+            .remove(monitor);
+        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(st);
+        return;
+    };
+    let members = cluster.members().to_vec();
+    let member_set = members.iter().copied().collect::<HashSet<_>>();
+    let dragged_member = st
+        .input
+        .interaction_state
+        .drag_authority_node
+        .filter(|id| member_set.contains(id));
+    if st
+        .model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(monitor)
+        .is_some_and(|fullscreen_id| member_set.contains(fullscreen_id))
+    {
+        return;
+    }
+    let Some(plan) = crate::compositor::clusters::read::plan_active_cluster_layout(st, monitor)
+    else {
+        return;
+    };
+    let now = Instant::now();
+    if matches!(plan.kind, ClusterWorkspaceLayoutKind::Tiling) {
+        update_tiled_cluster_animation_targets(st, &plan, dragged_member, now);
+    }
+    let visible_members = plan
+        .tiles
+        .iter()
+        .map(|tile| tile.node_id)
+        .filter(|id| {
+            !st.model
+                .spawn_state
+                .pending_tiled_insert_reveal_at_ms
+                .contains_key(id)
+        })
+        .collect::<HashSet<_>>();
+    let visible_surface_sizes = current_surface_size_map_for_members(st, &visible_members);
+    if let Some(cluster) = st.model.field.cluster_mut(cid) {
+        for member_id in &members {
+            if let Some(node) = cluster.workspace_member_mut(*member_id) {
+                let visible = visible_members.contains(member_id);
+                node.visibility.set(Visibility::DETACHED, !visible);
+                node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, !visible);
+            }
+        }
+    }
+    for placement in plan.tiles {
+        let nid = placement.node_id;
+        if Some(nid) == dragged_member
+            || st
                 .model
                 .spawn_state
                 .pending_tiled_insert_reveal_at_ms
-                .contains_key(&placement.node_id)
-                || Some(placement.node_id) == dragged_member
-            {
-                self.clear_cluster_tile_animation_for_node(placement.node_id);
-                continue;
-            }
-
-            let current_rect = if self
-                .ui
-                .render_state
-                .remove_cluster_tile_entry_pending(placement.node_id)
-            {
-                None
-            } else {
-                crate::animation::cluster_tile_rect_from_field(&self.model.field, placement.node_id)
-            };
-            let frozen_geo = self
-                .ui
-                .render_state
-                .cache
-                .window_geometry
-                .get(&placement.node_id)
-                .copied();
-            if current_rect.is_some_and(|rect| rect.alpha > 0.01)
-                && let Some(geo) = frozen_geo
-            {
-                self.ui
-                    .render_state
-                    .remember_cluster_tile_frozen_geometry(placement.node_id, geo);
-            }
-            let duration_ms = self.runtime.tuning.tile_animation_duration_ms();
-            if self.runtime.tuning.tile_animation_enabled() {
-                crate::animation::set_cluster_tile_target(
-                    self.ui.render_state.cluster_tile_tracks_mut(),
-                    current_rect,
-                    placement.node_id,
-                    placement.rect,
-                    now,
-                    duration_ms,
-                );
-                self.request_window_animation_prewarm(placement.node_id, now);
-            } else {
-                self.ui
-                    .render_state
-                    .remove_cluster_tile_track(placement.node_id);
-            }
-        }
-    }
-
-    fn current_surface_size_map_for_members(
-        &self,
-        members: &HashSet<NodeId>,
-    ) -> HashMap<NodeId, Vec2> {
-        let mut sizes = HashMap::with_capacity(members.len());
-        for (&node_id, &(_, _, w, h)) in &self.ui.render_state.cache.window_geometry {
-            if members.contains(&node_id) {
-                sizes.insert(
-                    node_id,
-                    Vec2 {
-                        x: w.max(1.0),
-                        y: h.max(1.0),
-                    },
-                );
-            }
-        }
-
-        for top in self.platform.xdg_shell_state.toplevel_surfaces() {
-            let wl = top.wl_surface();
-            let key = wl.id();
-            let Some(node_id) = self.model.surface_to_node.get(&key).copied() else {
-                continue;
-            };
-            if sizes.contains_key(&node_id) || !members.contains(&node_id) {
-                continue;
-            }
-
-            let size = with_states(wl, |states| {
-                states
-                    .cached_state
-                    .get::<SurfaceCachedState>()
-                    .current()
-                    .geometry
-            })
-            .map(|g| Vec2 {
-                x: g.size.w.max(1) as f32,
-                y: g.size.h.max(1) as f32,
-            })
-            .or_else(|| {
-                top.with_committed_state(|state| state.and_then(|state| state.size))
-                    .map(|sz| Vec2 {
-                        x: sz.w.max(1) as f32,
-                        y: sz.h.max(1) as f32,
-                    })
-            })
-            .unwrap_or_else(|| {
-                let bbox = bbox_from_surface_tree(wl, (0, 0));
-                Vec2 {
-                    x: bbox.size.w.max(1) as f32,
-                    y: bbox.size.h.max(1) as f32,
-                }
-            });
-            sizes.insert(node_id, size);
-        }
-
-        for &node_id in members {
-            sizes.entry(node_id).or_insert_with(|| {
-                self.model
-                    .field
-                    .node(node_id)
-                    .map_or(Vec2 { x: 1.0, y: 1.0 }, |node| Vec2 {
-                        x: node.intrinsic_size.x.max(1.0),
-                        y: node.intrinsic_size.y.max(1.0),
-                    })
-            });
-        }
-
-        sizes
-    }
-
-    pub(crate) fn layout_active_cluster_workspace_for_monitor(
-        &mut self,
-        monitor: &str,
-        now_ms: u64,
-    ) {
-        let Some(cid) = self.active_cluster_workspace_for_monitor(monitor) else {
-            return;
-        };
-        let Some(cluster) = self.model.field.cluster(cid) else {
-            // The cluster dissolved (e.g. its last window closed) while its
-            // workspace was still active. Drop the stale workspace entry and
-            // recompute the work area: with no active cluster the aperture
-            // reservation falls to zero, so the frozen top gap is released
-            // immediately instead of lingering (`refresh` re-checks the now-
-            // unlocked monitor). The explicit exit path already refreshes; this
-            // covers the implicit-dissolve path.
-            self.model
-                .cluster_state
-                .active_cluster_workspaces
-                .remove(monitor);
-            crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(self);
-            return;
-        };
-        let members = cluster.members().to_vec();
-        let member_set = members.iter().copied().collect::<HashSet<_>>();
-        let dragged_member = self
-            .input
-            .interaction_state
-            .drag_authority_node
-            .filter(|id| member_set.contains(id));
-        if self
-            .model
-            .fullscreen_state
-            .fullscreen_active_node
-            .get(monitor)
-            .is_some_and(|fullscreen_id| member_set.contains(fullscreen_id))
+                .contains_key(&nid)
         {
-            return;
+            continue;
         }
-        let Some(plan) =
-            crate::compositor::clusters::read::plan_active_cluster_layout(self, monitor)
-        else {
-            return;
+        let rect = placement.rect;
+        let target_size = Vec2 {
+            x: rect.w.max(64.0),
+            y: rect.h.max(64.0),
         };
-        let now = Instant::now();
-        if matches!(plan.kind, ClusterWorkspaceLayoutKind::Tiling) {
-            self.update_tiled_cluster_animation_targets(&plan, dragged_member, now);
+        let target_pos = Vec2 {
+            x: rect.x + rect.w * 0.5,
+            y: rect.y + rect.h * 0.5,
+        };
+        let layout_changed = st.model.field.node(nid).is_none_or(|node| {
+            (node.intrinsic_size.x - target_size.x).abs() > 0.5
+                || (node.intrinsic_size.y - target_size.y).abs() > 0.5
+                || (node.pos.x - target_pos.x).abs() > 0.5
+                || (node.pos.y - target_pos.y).abs() > 0.5
+                || node.state != halley_core::field::NodeState::Active
+                || node.visibility.has(Visibility::DETACHED)
+                || node.visibility.has(Visibility::HIDDEN_BY_CLUSTER)
+        });
+        if let Some(cluster) = st.model.field.cluster_mut(cid)
+            && let Some(node) = cluster.workspace_member_mut(nid)
+            && layout_changed
+        {
+            node.visibility.set(Visibility::DETACHED, false);
+            node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
+            node.intrinsic_size = target_size;
+            node.state = halley_core::field::NodeState::Active;
+            node.footprint = node.resize_footprint.unwrap_or(node.intrinsic_size);
+            node.pos = target_pos;
         }
-        let visible_members = plan
-            .tiles
-            .iter()
-            .map(|tile| tile.node_id)
-            .filter(|id| {
-                !self
-                    .model
-                    .spawn_state
-                    .pending_tiled_insert_reveal_at_ms
-                    .contains_key(id)
-            })
-            .collect::<HashSet<_>>();
-        let visible_surface_sizes = self.current_surface_size_map_for_members(&visible_members);
-        if let Some(cluster) = self.model.field.cluster_mut(cid) {
-            for member_id in &members {
-                if let Some(node) = cluster.workspace_member_mut(*member_id) {
-                    let visible = visible_members.contains(member_id);
-                    node.visibility.set(Visibility::DETACHED, !visible);
-                    node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, !visible);
-                }
-            }
+        if layout_changed {
+            st.set_last_active_size_now(nid, target_size);
         }
-        for placement in plan.tiles {
-            let nid = placement.node_id;
-            if Some(nid) == dragged_member
-                || self
-                    .model
-                    .spawn_state
-                    .pending_tiled_insert_reveal_at_ms
-                    .contains_key(&nid)
-            {
-                continue;
-            }
-            let rect = placement.rect;
-            let target_size = Vec2 {
-                x: rect.w.max(64.0),
-                y: rect.h.max(64.0),
-            };
-            let target_pos = Vec2 {
-                x: rect.x + rect.w * 0.5,
-                y: rect.y + rect.h * 0.5,
-            };
-            let layout_changed = self.model.field.node(nid).is_none_or(|node| {
-                (node.intrinsic_size.x - target_size.x).abs() > 0.5
-                    || (node.intrinsic_size.y - target_size.y).abs() > 0.5
-                    || (node.pos.x - target_pos.x).abs() > 0.5
-                    || (node.pos.y - target_pos.y).abs() > 0.5
-                    || node.state != halley_core::field::NodeState::Active
-                    || node.visibility.has(Visibility::DETACHED)
-                    || node.visibility.has(Visibility::HIDDEN_BY_CLUSTER)
-            });
-            if let Some(cluster) = self.model.field.cluster_mut(cid)
-                && let Some(node) = cluster.workspace_member_mut(nid)
-                && layout_changed
-            {
-                node.visibility.set(Visibility::DETACHED, false);
-                node.visibility.set(Visibility::HIDDEN_BY_CLUSTER, false);
-                node.intrinsic_size = target_size;
-                node.state = halley_core::field::NodeState::Active;
-                node.footprint = node.resize_footprint.unwrap_or(node.intrinsic_size);
-                node.pos = target_pos;
-            }
-            if layout_changed {
-                self.set_last_active_size_now(nid, target_size);
-            }
-            let surface_size_changed = visible_surface_sizes.get(&nid).is_none_or(|size| {
-                (size.x - target_size.x).abs() > 0.5 || (size.y - target_size.y).abs() > 0.5
-            });
-            if surface_size_changed {
-                self.request_toplevel_resize(nid, rect.w.round() as i32, rect.h.round() as i32);
-            }
+        let surface_size_changed = visible_surface_sizes.get(&nid).is_none_or(|size| {
+            (size.x - target_size.x).abs() > 0.5 || (size.y - target_size.y).abs() > 0.5
+        });
+        if surface_size_changed {
+            st.request_toplevel_resize(nid, rect.w.round() as i32, rect.h.round() as i32);
         }
-        self.refresh_cluster_overflow_for_monitor(monitor, now_ms, false);
     }
+    refresh_cluster_overflow_for_monitor(st, monitor, now_ms, false);
 }

--- a/crates/halley-wl/src/compositor/clusters/system/workspace.rs
+++ b/crates/halley-wl/src/compositor/clusters/system/workspace.rs
@@ -3,7 +3,6 @@ use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::SurfaceCachedState;
 
 use super::*;
-use crate::compositor::monitor::camera::camera_controller;
 
 impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
     fn restore_cluster_workspace_monitor(&mut self, monitor: &str) {
@@ -18,7 +17,7 @@ impl<T: DerefMut<Target = Halley>> ClusterSystemController<T> {
         if self.model.monitor_state.current_monitor == monitor {
             self.model.viewport = vp;
             self.model.zoom_ref_size = self.model.viewport.size;
-            camera_controller(&mut **self).snap_targets_to_live();
+            crate::compositor::monitor::camera::snap_camera_targets_to_live(&mut **self);
             self.runtime.tuning.viewport_center = self.model.viewport.center;
             self.runtime.tuning.viewport_size = self.model.viewport.size;
         }

--- a/crates/halley-wl/src/compositor/ctx.rs
+++ b/crates/halley-wl/src/compositor/ctx.rs
@@ -21,10 +21,6 @@ pub(crate) struct PointerCtx<'a> {
     pub(in crate::compositor) st: &'a mut Halley,
 }
 
-pub(crate) struct FullscreenCtx<'a> {
-    pub(in crate::compositor) st: &'a mut Halley,
-}
-
 pub(crate) fn focus_ctx(st: &Halley) -> FocusCtx<'_> {
     FocusCtx {
         display_handle: &st.platform.display_handle,
@@ -45,8 +41,4 @@ pub(crate) fn layer_shell_ctx(st: &mut Halley) -> LayerShellCtx<'_> {
 
 pub(crate) fn pointer_ctx(st: &mut Halley) -> PointerCtx<'_> {
     PointerCtx { st }
-}
-
-pub(crate) fn fullscreen_ctx(st: &mut Halley) -> FullscreenCtx<'_> {
-    FullscreenCtx { st }
 }

--- a/crates/halley-wl/src/compositor/exit_confirm.rs
+++ b/crates/halley-wl/src/compositor/exit_confirm.rs
@@ -1,66 +1,39 @@
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use super::root::Halley;
 
-pub(crate) struct ExitConfirmController<T> {
-    st: T,
+pub(crate) fn active(st: &Halley) -> bool {
+    st.ui.render_state.exit_confirm_visible()
 }
 
-pub(crate) fn exit_confirm_controller<T>(st: T) -> ExitConfirmController<T> {
-    ExitConfirmController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for ExitConfirmController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
+pub(crate) fn show(st: &mut Halley) {
+    st.begin_modal_keyboard_capture();
+    let mut monitors: Vec<String> = st.model.monitor_state.monitors.keys().cloned().collect();
+    if monitors.is_empty() {
+        monitors.push(st.model.monitor_state.current_monitor.clone());
+    }
+    for monitor in monitors {
+        st.ui.render_state.show_exit_confirm(monitor.as_str());
     }
 }
 
-impl<T: DerefMut<Target = Halley>> DerefMut for ExitConfirmController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
+pub(crate) fn clear(st: &mut Halley) {
+    let mut monitors: Vec<String> = st
+        .ui
+        .render_state
+        .overlays
+        .overlay_exit_confirm
+        .keys()
+        .cloned()
+        .collect();
+    if monitors.is_empty() {
+        monitors.push(st.model.monitor_state.current_monitor.clone());
     }
-}
-
-impl<T: Deref<Target = Halley>> ExitConfirmController<T> {
-    pub(crate) fn active(&self) -> bool {
-        self.ui.render_state.exit_confirm_visible()
+    for monitor in monitors {
+        st.ui.render_state.clear_exit_confirm(monitor.as_str());
     }
-}
-
-impl<T: DerefMut<Target = Halley>> ExitConfirmController<T> {
-    pub(crate) fn show(&mut self) {
-        self.begin_modal_keyboard_capture();
-        let mut monitors: Vec<String> = self.model.monitor_state.monitors.keys().cloned().collect();
-        if monitors.is_empty() {
-            monitors.push(self.model.monitor_state.current_monitor.clone());
-        }
-        for monitor in monitors {
-            self.ui.render_state.show_exit_confirm(monitor.as_str());
-        }
-    }
-
-    pub(crate) fn clear(&mut self) {
-        let mut monitors: Vec<String> = self
-            .ui
-            .render_state
-            .overlays
-            .overlay_exit_confirm
-            .keys()
-            .cloned()
-            .collect();
-        if monitors.is_empty() {
-            monitors.push(self.model.monitor_state.current_monitor.clone());
-        }
-        for monitor in monitors {
-            self.ui.render_state.clear_exit_confirm(monitor.as_str());
-        }
-        let restore_focus = self
-            .last_input_surface_node_for_monitor(self.model.monitor_state.current_monitor.as_str())
-            .or(self.last_input_surface_node());
-        self.schedule_modal_focus_restore(restore_focus, Instant::now());
-    }
+    let restore_focus = st
+        .last_input_surface_node_for_monitor(st.model.monitor_state.current_monitor.as_str())
+        .or(st.last_input_surface_node());
+    st.schedule_modal_focus_restore(restore_focus, Instant::now());
 }

--- a/crates/halley-wl/src/compositor/focus/cycle.rs
+++ b/crates/halley-wl/src/compositor/focus/cycle.rs
@@ -1,4 +1,3 @@
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use halley_config::FocusCycleBindingAction;
@@ -8,28 +7,6 @@ use smithay::reexports::wayland_server::Resource;
 
 use crate::compositor::interaction::state::{FocusCycleImmersiveOrigin, FocusCycleSession};
 use crate::compositor::root::Halley;
-
-pub(crate) struct FocusCycleController<T> {
-    st: T,
-}
-
-pub(crate) fn focus_cycle_controller<T>(st: T) -> FocusCycleController<T> {
-    FocusCycleController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for FocusCycleController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for FocusCycleController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
 
 fn is_focus_cycle_candidate(st: &Halley, id: NodeId) -> bool {
     st.model.field.node(id).is_some_and(|node| {
@@ -115,328 +92,315 @@ pub(crate) fn focus_cycle_releases_fullscreen_lock_for_monitor(st: &Halley, moni
         .is_some()
 }
 
-impl<T: Deref<Target = Halley>> FocusCycleController<T> {
-    fn build_candidates(&self, origin_focus: Option<NodeId>) -> Vec<NodeId> {
-        let mut candidates = self
+fn build_candidates(st: &Halley, origin_focus: Option<NodeId>) -> Vec<NodeId> {
+    let mut candidates = st
+        .model
+        .field
+        .node_ids_all()
+        .into_iter()
+        .filter(|&id| is_focus_cycle_candidate(st, id))
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|a, b| {
+        let a_at = st
             .model
-            .field
-            .node_ids_all()
-            .into_iter()
-            .filter(|&id| is_focus_cycle_candidate(self, id))
-            .collect::<Vec<_>>();
+            .focus_state
+            .last_surface_focus_ms
+            .get(a)
+            .copied()
+            .unwrap_or(0);
+        let b_at = st
+            .model
+            .focus_state
+            .last_surface_focus_ms
+            .get(b)
+            .copied()
+            .unwrap_or(0);
 
-        candidates.sort_by(|a, b| {
-            let a_at = self
-                .model
-                .focus_state
-                .last_surface_focus_ms
-                .get(a)
-                .copied()
-                .unwrap_or(0);
-            let b_at = self
-                .model
-                .focus_state
-                .last_surface_focus_ms
-                .get(b)
-                .copied()
-                .unwrap_or(0);
+        b_at.cmp(&a_at).then_with(|| b.as_u64().cmp(&a.as_u64()))
+    });
 
-            b_at.cmp(&a_at).then_with(|| b.as_u64().cmp(&a.as_u64()))
-        });
-
-        if let Some(origin_focus) = origin_focus
-            && let Some(index) = candidates.iter().position(|&id| id == origin_focus)
-        {
-            let origin = candidates.remove(index);
-            candidates.insert(0, origin);
-        }
-
-        candidates
+    if let Some(origin_focus) = origin_focus
+        && let Some(index) = candidates.iter().position(|&id| id == origin_focus)
+    {
+        let origin = candidates.remove(index);
+        candidates.insert(0, origin);
     }
+
+    candidates
 }
 
-impl<T: DerefMut<Target = Halley>> FocusCycleController<T> {
-    fn refresh_session_candidates(&mut self, now: Instant) -> bool {
-        let Some(session) = self.input.interaction_state.focus_cycle_session.as_ref() else {
-            return false;
-        };
+fn refresh_session_candidates(st: &mut Halley, now: Instant) -> bool {
+    let Some(session) = st.input.interaction_state.focus_cycle_session.as_ref() else {
+        return false;
+    };
 
-        let preview_index = session.preview_index;
-        let current_preview = session.candidates.get(preview_index).copied();
-        let filtered = session
-            .candidates
-            .iter()
-            .copied()
-            .filter(|&id| is_focus_cycle_candidate(self, id))
-            .collect::<Vec<_>>();
+    let preview_index = session.preview_index;
+    let current_preview = session.candidates.get(preview_index).copied();
+    let filtered = session
+        .candidates
+        .iter()
+        .copied()
+        .filter(|&id| is_focus_cycle_candidate(st, id))
+        .collect::<Vec<_>>();
 
-        let next_index = if filtered.is_empty() {
-            0
-        } else {
-            current_preview
-                .and_then(|current| filtered.iter().position(|&id| id == current))
-                .unwrap_or_else(|| preview_index.min(filtered.len().saturating_sub(1)))
-        };
+    let next_index = if filtered.is_empty() {
+        0
+    } else {
+        current_preview
+            .and_then(|current| filtered.iter().position(|&id| id == current))
+            .unwrap_or_else(|| preview_index.min(filtered.len().saturating_sub(1)))
+    };
 
-        let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() else {
-            return false;
-        };
-        session.candidates = filtered;
+    let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() else {
+        return false;
+    };
+    session.candidates = filtered;
 
-        if session.candidates.is_empty() {
-            self.input.interaction_state.focus_cycle_session = None;
-            self.ui.render_state.clear_focus_cycle_still();
-            return false;
-        }
-
-        session.preview_index = next_index;
-        session.step_from_visual_index = next_index as f32;
-        session.step_to_visual_index = next_index as f32;
-        session.step_started_at = now;
-        true
+    if session.candidates.is_empty() {
+        st.input.interaction_state.focus_cycle_session = None;
+        st.ui.render_state.clear_focus_cycle_still();
+        return false;
     }
 
-    fn preview_step(&mut self, direction: FocusCycleBindingAction, now: Instant) -> bool {
-        if !self.refresh_session_candidates(now) {
+    session.preview_index = next_index;
+    session.step_from_visual_index = next_index as f32;
+    session.step_to_visual_index = next_index as f32;
+    session.step_started_at = now;
+    true
+}
+
+fn preview_step(st: &mut Halley, direction: FocusCycleBindingAction, now: Instant) -> bool {
+    if !refresh_session_candidates(st, now) {
+        return false;
+    }
+
+    let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() else {
+        return false;
+    };
+    if session.candidates.len() < 2 {
+        return false;
+    }
+    if session.closing_started_at.is_some() {
+        return false;
+    }
+
+    let len = session.candidates.len();
+    let from_index = session.preview_index;
+    let to_index = match direction {
+        FocusCycleBindingAction::Forward => (from_index + 1) % len,
+        FocusCycleBindingAction::Backward => (from_index + len - 1) % len,
+    };
+    let to_visual = match direction {
+        FocusCycleBindingAction::Forward if from_index + 1 == len && to_index == 0 => len as f32,
+        FocusCycleBindingAction::Backward if from_index == 0 && to_index + 1 == len => -1.0,
+        _ => to_index as f32,
+    };
+    session.preview_index = to_index;
+    session.step_from_visual_index = from_index as f32;
+    session.step_to_visual_index = to_visual;
+    session.step_started_at = now;
+
+    let preview = session.candidates[session.preview_index];
+    if session
+        .immersive_origin
+        .as_ref()
+        .is_some_and(|origin| preview != origin.node_id)
+    {
+        session.immersive_lock_released = true;
+    }
+    let _ = session;
+    st.request_maintenance();
+    true
+}
+
+pub(crate) fn start_or_step_focus_cycle(
+    st: &mut Halley,
+    direction: FocusCycleBindingAction,
+    now: Instant,
+) -> bool {
+    if st.input.interaction_state.focus_cycle_session.is_none() {
+        let origin_focus = st.last_input_surface_node_for_monitor(st.focused_monitor());
+        let candidates = build_candidates(st, origin_focus);
+        if candidates.len() < 2 {
             return false;
         }
 
-        let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() else {
-            return false;
-        };
-        if session.candidates.len() < 2 {
-            return false;
-        }
-        if session.closing_started_at.is_some() {
-            return false;
-        }
-
-        let len = session.candidates.len();
-        let from_index = session.preview_index;
-        let to_index = match direction {
-            FocusCycleBindingAction::Forward => (from_index + 1) % len,
-            FocusCycleBindingAction::Backward => (from_index + len - 1) % len,
-        };
-        let to_visual = match direction {
-            FocusCycleBindingAction::Forward if from_index + 1 == len && to_index == 0 => {
-                len as f32
+        let immersive_origin = origin_focus.and_then(|node_id| {
+            if !st.is_fullscreen_active(node_id)
+                || !fullscreen_origin_is_immersive_target(st, node_id)
+            {
+                return None;
             }
-            FocusCycleBindingAction::Backward if from_index == 0 && to_index + 1 == len => -1.0,
-            _ => to_index as f32,
-        };
-        session.preview_index = to_index;
-        session.step_from_visual_index = from_index as f32;
-        session.step_to_visual_index = to_visual;
-        session.step_started_at = now;
+            let immersive_monitor = st.fullscreen_monitor_for_node(node_id)?;
+            let space = st.model.monitor_state.monitors.get(immersive_monitor)?;
+            Some(FocusCycleImmersiveOrigin {
+                node_id,
+                monitor: immersive_monitor.to_string(),
+                saved_camera_center: space.camera_target_center,
+                saved_zoom_view_size: space.camera_target_view_size,
+            })
+        });
 
-        let preview = session.candidates[session.preview_index];
-        if session
+        st.input.interaction_state.focus_cycle_session = Some(FocusCycleSession {
+            candidates,
+            preview_index: 0,
+            opened_at: now,
+            step_from_visual_index: 0.0,
+            step_to_visual_index: 0.0,
+            step_started_at: now,
+            closing_started_at: None,
+            origin_focus,
+            immersive_origin,
+            immersive_lock_released: false,
+        });
+    }
+
+    preview_step(st, direction, now)
+}
+
+fn restore_origin_without_tracking(st: &mut Halley, session: &FocusCycleSession) {
+    if let Some(origin) = session.origin_focus
+        && session
             .immersive_origin
             .as_ref()
-            .is_some_and(|origin| preview != origin.node_id)
-        {
-            session.immersive_lock_released = true;
-        }
-        let _ = session;
-        self.request_maintenance();
-        true
+            .is_some_and(|immersive| immersive.node_id == origin)
+        && let Some(immersive) = session.immersive_origin.as_ref()
+    {
+        restore_camera_snapshot(
+            st,
+            immersive.monitor.as_str(),
+            immersive.saved_camera_center,
+            immersive.saved_zoom_view_size,
+        );
+    }
+    st.apply_wayland_focus_state(session.origin_focus);
+}
+
+pub(crate) fn cancel_focus_cycle(st: &mut Halley) -> bool {
+    let Some(session) = st.input.interaction_state.focus_cycle_session.clone() else {
+        return false;
+    };
+    if session.closing_started_at.is_some() {
+        return false;
+    }
+    restore_origin_without_tracking(st, &session);
+    if let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() {
+        session.closing_started_at = Some(Instant::now());
+    }
+    st.request_maintenance();
+    true
+}
+
+pub(crate) fn commit_focus_cycle(st: &mut Halley, now: Instant) -> bool {
+    let Some(session) = st.input.interaction_state.focus_cycle_session.clone() else {
+        return false;
+    };
+    if session.closing_started_at.is_some() {
+        return false;
     }
 
-    pub(crate) fn start_or_step_focus_cycle(
-        &mut self,
-        direction: FocusCycleBindingAction,
-        now: Instant,
-    ) -> bool {
-        if self.input.interaction_state.focus_cycle_session.is_none() {
-            let origin_focus = self.last_input_surface_node_for_monitor(self.focused_monitor());
-            let candidates = self.build_candidates(origin_focus);
-            if candidates.len() < 2 {
-                return false;
-            }
+    let target = session
+        .candidates
+        .get(session.preview_index)
+        .copied()
+        .filter(|&id| is_focus_cycle_candidate(st, id))
+        .or(session
+            .origin_focus
+            .filter(|&id| is_focus_cycle_candidate(st, id)));
 
-            let immersive_origin = origin_focus.and_then(|node_id| {
-                if !self.is_fullscreen_active(node_id)
-                    || !fullscreen_origin_is_immersive_target(self, node_id)
-                {
-                    return None;
-                }
-                let immersive_monitor = self.fullscreen_monitor_for_node(node_id)?;
-                let space = self.model.monitor_state.monitors.get(immersive_monitor)?;
-                Some(FocusCycleImmersiveOrigin {
-                    node_id,
-                    monitor: immersive_monitor.to_string(),
-                    saved_camera_center: space.camera_target_center,
-                    saved_zoom_view_size: space.camera_target_view_size,
-                })
-            });
-
-            self.input.interaction_state.focus_cycle_session = Some(FocusCycleSession {
-                candidates,
-                preview_index: 0,
-                opened_at: now,
-                step_from_visual_index: 0.0,
-                step_to_visual_index: 0.0,
-                step_started_at: now,
-                closing_started_at: None,
-                origin_focus,
-                immersive_origin,
-                immersive_lock_released: false,
-            });
+    let Some(target) = target else {
+        st.apply_wayland_focus_state(None);
+        if let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() {
+            session.closing_started_at = Some(now);
         }
-
-        self.preview_step(direction, now)
-    }
-
-    fn restore_origin_without_tracking(&mut self, session: &FocusCycleSession) {
-        if let Some(origin) = session.origin_focus
-            && session
-                .immersive_origin
-                .as_ref()
-                .is_some_and(|immersive| immersive.node_id == origin)
-            && let Some(immersive) = session.immersive_origin.as_ref()
+        st.request_maintenance();
+        return true;
+    };
+    // The alt+tab prewarm captured `target` into the shared offscreen cache, and
+    // the live-window prewarm never refreshes a complete cache entry. Drop it so the
+    // live path rebuilds the picked window at its real geometry next frame instead of
+    // reusing the switcher snapshot.
+    st.ui.render_state.clear_window_offscreen_cache_for(target);
+    if Some(target) == session.origin_focus {
+        if let Some(immersive) = session.immersive_origin.as_ref()
+            && immersive.node_id == target
         {
             restore_camera_snapshot(
-                self,
+                st,
                 immersive.monitor.as_str(),
                 immersive.saved_camera_center,
                 immersive.saved_zoom_view_size,
             );
         }
-        self.apply_wayland_focus_state(session.origin_focus);
-    }
-
-    pub(crate) fn cancel_focus_cycle(&mut self) -> bool {
-        let Some(session) = self.input.interaction_state.focus_cycle_session.clone() else {
-            return false;
-        };
-        if session.closing_started_at.is_some() {
-            return false;
-        }
-        self.restore_origin_without_tracking(&session);
-        if let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() {
-            session.closing_started_at = Some(Instant::now());
-        }
-        self.request_maintenance();
-        true
-    }
-
-    pub(crate) fn commit_focus_cycle(&mut self, now: Instant) -> bool {
-        let Some(session) = self.input.interaction_state.focus_cycle_session.clone() else {
-            return false;
-        };
-        if session.closing_started_at.is_some() {
-            return false;
-        }
-
-        let target = session
-            .candidates
-            .get(session.preview_index)
-            .copied()
-            .filter(|&id| is_focus_cycle_candidate(self, id))
-            .or(session
-                .origin_focus
-                .filter(|&id| is_focus_cycle_candidate(self, id)));
-
-        let Some(target) = target else {
-            self.apply_wayland_focus_state(None);
-            if let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() {
-                session.closing_started_at = Some(now);
-            }
-            self.request_maintenance();
-            return true;
-        };
-        // The alt+tab prewarm captured `target` into the shared offscreen cache, and
-        // the live-window prewarm never refreshes a complete cache entry. Drop it so the
-        // live path rebuilds the picked window at its real geometry next frame instead of
-        // reusing the switcher snapshot.
-        self.ui
-            .render_state
-            .clear_window_offscreen_cache_for(target);
-        if Some(target) == session.origin_focus {
-            if let Some(immersive) = session.immersive_origin.as_ref()
-                && immersive.node_id == target
-            {
-                restore_camera_snapshot(
-                    self,
-                    immersive.monitor.as_str(),
-                    immersive.saved_camera_center,
-                    immersive.saved_zoom_view_size,
-                );
-            }
-            self.apply_wayland_focus_state(Some(target));
-            let _ = self.raise_overlap_policy_node(target);
-            crate::compositor::interaction::pointer::center_pointer_on_node(self, target, now);
-            if let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() {
-                session.closing_started_at = Some(now);
-            }
-            self.request_maintenance();
-            return true;
-        }
-
-        let changed = if self
-            .model
-            .field
-            .cluster_id_for_member_public(target)
-            .is_some()
-        {
-            let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
-                self, target, now,
-            );
-            let _ = self.raise_overlap_policy_node(target);
-            changed
-        } else {
-            let target_monitor = self.monitor_for_node_or_current(target);
-            if crate::compositor::workspace::state::maximize_session_target_for_monitor(
-                self,
-                target_monitor.as_str(),
-            ) == Some(target)
-            {
-                let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
-                    self, target, now,
-                );
-                let _ = self.raise_overlap_policy_node(target);
-                changed
-            } else if self
-                .model
-                .fullscreen_state
-                .fullscreen_active_node
-                .get(target_monitor.as_str())
-                .copied()
-                .filter(|&fullscreen_id| fullscreen_id != target)
-                .is_some_and(|fullscreen_id| {
-                    !self
-                        .model
-                        .fullscreen_state
-                        .fullscreen_restore
-                        .contains_key(&fullscreen_id)
-                })
-                && self.model.field.node(target).is_some_and(|node| {
-                    node.state == halley_core::field::NodeState::Active
-                        && self.surface_is_fully_visible_on_monitor(target_monitor.as_str(), target)
-                })
-            {
-                let _ = self.raise_overlap_policy_node(target);
-                let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
-                    self, target, now,
-                );
-                changed
-            } else {
-                crate::compositor::actions::window::focus_from_presentation_navigation(
-                    self, target, now,
-                ) || crate::compositor::actions::window::focus_or_reveal_surface_node(
-                    self, target, now,
-                )
-            }
-        };
-        if changed {
-            crate::compositor::interaction::pointer::center_pointer_on_node(self, target, now);
-        }
-        if let Some(session) = self.input.interaction_state.focus_cycle_session.as_mut() {
+        st.apply_wayland_focus_state(Some(target));
+        let _ = st.raise_overlap_policy_node(target);
+        crate::compositor::interaction::pointer::center_pointer_on_node(st, target, now);
+        if let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() {
             session.closing_started_at = Some(now);
         }
-        self.request_maintenance();
-        changed
+        st.request_maintenance();
+        return true;
     }
+
+    let changed = if st
+        .model
+        .field
+        .cluster_id_for_member_public(target)
+        .is_some()
+    {
+        let changed =
+            crate::compositor::actions::window::focus_surface_node_without_reveal(st, target, now);
+        let _ = st.raise_overlap_policy_node(target);
+        changed
+    } else {
+        let target_monitor = st.monitor_for_node_or_current(target);
+        if crate::compositor::workspace::state::maximize_session_target_for_monitor(
+            st,
+            target_monitor.as_str(),
+        ) == Some(target)
+        {
+            let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
+                st, target, now,
+            );
+            let _ = st.raise_overlap_policy_node(target);
+            changed
+        } else if st
+            .model
+            .fullscreen_state
+            .fullscreen_active_node
+            .get(target_monitor.as_str())
+            .copied()
+            .filter(|&fullscreen_id| fullscreen_id != target)
+            .is_some_and(|fullscreen_id| {
+                !st.model
+                    .fullscreen_state
+                    .fullscreen_restore
+                    .contains_key(&fullscreen_id)
+            })
+            && st.model.field.node(target).is_some_and(|node| {
+                node.state == halley_core::field::NodeState::Active
+                    && st.surface_is_fully_visible_on_monitor(target_monitor.as_str(), target)
+            })
+        {
+            let _ = st.raise_overlap_policy_node(target);
+            let changed = crate::compositor::actions::window::focus_surface_node_without_reveal(
+                st, target, now,
+            );
+            changed
+        } else {
+            crate::compositor::actions::window::focus_from_presentation_navigation(st, target, now)
+                || crate::compositor::actions::window::focus_or_reveal_surface_node(st, target, now)
+        }
+    };
+    if changed {
+        crate::compositor::interaction::pointer::center_pointer_on_node(st, target, now);
+    }
+    if let Some(session) = st.input.interaction_state.focus_cycle_session.as_mut() {
+        session.closing_started_at = Some(now);
+    }
+    st.request_maintenance();
+    changed
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/focus/decay.rs
+++ b/crates/halley-wl/src/compositor/focus/decay.rs
@@ -93,7 +93,7 @@ pub(crate) fn enforce_single_primary_active_unit(st: &mut Halley) {
     if spawn_placement_transition_active(st, now_ms) {
         return;
     }
-    let companion = st.companion_surface_node(now_ms);
+    let companion = crate::compositor::focus::state::companion_surface_node(st, now_ms);
     let preferred_surface = st.last_input_surface_node();
 
     let active_ids: Vec<NodeId> = st

--- a/crates/halley-wl/src/compositor/focus/decay.rs
+++ b/crates/halley-wl/src/compositor/focus/decay.rs
@@ -1,350 +1,303 @@
 use std::collections::{HashMap, HashSet};
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use super::*;
 use crate::compositor::overlap::system::CollisionExtents;
 use halley_core::viewport::{FocusRing, FocusZone};
 
-pub(crate) struct FocusDecayController<T> {
-    st: T,
+const ACTIVE_RING_OUTSIDE_DECAY_FRAC: f32 = 0.98;
+
+fn focus_ring_center_for_node(st: &Halley, id: NodeId) -> Vec2 {
+    st.model
+        .monitor_state
+        .node_monitor
+        .get(&id)
+        .and_then(|monitor| st.model.monitor_state.monitors.get(monitor))
+        .map(|monitor| monitor.viewport.center)
+        .unwrap_or(st.model.viewport.center)
 }
 
-pub(crate) fn focus_decay_controller<T>(st: T) -> FocusDecayController<T> {
-    FocusDecayController { st }
+fn focus_ring_for_node(st: &Halley, id: NodeId) -> FocusRing {
+    st.model
+        .monitor_state
+        .node_monitor
+        .get(&id)
+        .map(|monitor| st.runtime.tuning.focus_ring_for_output(monitor.as_str()))
+        .unwrap_or_else(|| st.active_focus_ring())
 }
 
-impl<T: Deref<Target = Halley>> Deref for FocusDecayController<T> {
-    type Target = Halley;
+fn focus_ring_coverage_for_extents(
+    _st: &Halley,
+    pos: Vec2,
+    ext: CollisionExtents,
+    focus_center: Vec2,
+    focus_ring: FocusRing,
+) -> (f32, f32) {
+    let samples = 9usize;
+    let width = (ext.left + ext.right).max(1.0);
+    let height = (ext.top + ext.bottom).max(1.0);
+    let left = pos.x - ext.left;
+    let top = pos.y - ext.top;
+    let mut inside = 0usize;
+    let mut total = 0usize;
 
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for FocusDecayController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
-
-impl<T: Deref<Target = Halley>> FocusDecayController<T> {
-    const ACTIVE_RING_OUTSIDE_DECAY_FRAC: f32 = 0.98;
-
-    fn focus_ring_center_for_node(&self, id: NodeId) -> Vec2 {
-        self.model
-            .monitor_state
-            .node_monitor
-            .get(&id)
-            .and_then(|monitor| self.model.monitor_state.monitors.get(monitor))
-            .map(|monitor| monitor.viewport.center)
-            .unwrap_or(self.model.viewport.center)
-    }
-
-    fn focus_ring_for_node(&self, id: NodeId) -> FocusRing {
-        self.model
-            .monitor_state
-            .node_monitor
-            .get(&id)
-            .map(|monitor| self.runtime.tuning.focus_ring_for_output(monitor.as_str()))
-            .unwrap_or_else(|| self.active_focus_ring())
-    }
-
-    fn focus_ring_coverage_for_extents(
-        &self,
-        pos: Vec2,
-        ext: CollisionExtents,
-        focus_center: Vec2,
-        focus_ring: FocusRing,
-    ) -> (f32, f32) {
-        let samples = 9usize;
-        let width = (ext.left + ext.right).max(1.0);
-        let height = (ext.top + ext.bottom).max(1.0);
-        let left = pos.x - ext.left;
-        let top = pos.y - ext.top;
-        let mut inside = 0usize;
-        let mut total = 0usize;
-
-        for ix in 0..samples {
-            for iy in 0..samples {
-                let fx = ix as f32 / (samples - 1) as f32;
-                let fy = iy as f32 / (samples - 1) as f32;
-                let sample = Vec2 {
-                    x: left + fx * width,
-                    y: top + fy * height,
-                };
-                if focus_ring.zone(focus_center, sample) == FocusZone::Inside {
-                    inside += 1;
-                }
-                total += 1;
+    for ix in 0..samples {
+        for iy in 0..samples {
+            let fx = ix as f32 / (samples - 1) as f32;
+            let fy = iy as f32 / (samples - 1) as f32;
+            let sample = Vec2 {
+                x: left + fx * width,
+                y: top + fy * height,
+            };
+            if focus_ring.zone(focus_center, sample) == FocusZone::Inside {
+                inside += 1;
             }
+            total += 1;
         }
-
-        if total == 0 {
-            return (0.0, 1.0);
-        }
-
-        let inside_frac = inside as f32 / total as f32;
-        (inside_frac, (1.0 - inside_frac).max(0.0))
     }
 
-    fn surface_ring_coverage(&self, id: NodeId) -> (f32, f32) {
-        let Some(node) = self.model.field.node(id) else {
-            return (0.0, 1.0);
-        };
-        let focus_center = self.focus_ring_center_for_node(id);
-        let focus_ring = self.focus_ring_for_node(id);
-
-        let ext = match node.state {
-            halley_core::field::NodeState::Active => self.surface_window_collision_extents(node),
-            _ => self.collision_extents_for_node(node),
-        };
-
-        self.focus_ring_coverage_for_extents(node.pos, ext, focus_center, focus_ring)
+    if total == 0 {
+        return (0.0, 1.0);
     }
 
-    pub(crate) fn surface_is_definitively_outside_focus_ring(&self, id: NodeId) -> bool {
-        let (_, outside_frac) = self.surface_ring_coverage(id);
-        outside_frac >= Self::ACTIVE_RING_OUTSIDE_DECAY_FRAC
-    }
+    let inside_frac = inside as f32 / total as f32;
+    (inside_frac, (1.0 - inside_frac).max(0.0))
 }
 
-impl<T: DerefMut<Target = Halley>> FocusDecayController<T> {
-    pub(crate) fn enforce_single_primary_active_unit(&mut self) {
-        let now_ms = self.now_ms(Instant::now());
-        let active_windows_allowed = self.runtime.tuning.field_active_windows_allowed;
-        if active_windows_allowed == 0 {
-            return;
-        }
-        if self.spawn_placement_transition_active(now_ms) {
-            return;
-        }
-        let companion = self.companion_surface_node(now_ms);
-        let preferred_surface = self.last_input_surface_node();
+fn surface_ring_coverage(st: &Halley, id: NodeId) -> (f32, f32) {
+    let Some(node) = st.model.field.node(id) else {
+        return (0.0, 1.0);
+    };
+    let focus_center = focus_ring_center_for_node(st, id);
+    let focus_ring = focus_ring_for_node(st, id);
 
-        let active_ids: Vec<NodeId> = self
-            .model
-            .field
-            .nodes()
+    let ext = match node.state {
+        halley_core::field::NodeState::Active => st.surface_window_collision_extents(node),
+        _ => st.collision_extents_for_node(node),
+    };
+
+    focus_ring_coverage_for_extents(st, node.pos, ext, focus_center, focus_ring)
+}
+
+pub(crate) fn surface_is_definitively_outside_focus_ring(st: &Halley, id: NodeId) -> bool {
+    let (_, outside_frac) = surface_ring_coverage(st, id);
+    outside_frac >= ACTIVE_RING_OUTSIDE_DECAY_FRAC
+}
+
+pub(crate) fn enforce_single_primary_active_unit(st: &mut Halley) {
+    let now_ms = st.now_ms(Instant::now());
+    let active_windows_allowed = st.runtime.tuning.field_active_windows_allowed;
+    if active_windows_allowed == 0 {
+        return;
+    }
+    if spawn_placement_transition_active(st, now_ms) {
+        return;
+    }
+    let companion = st.companion_surface_node(now_ms);
+    let preferred_surface = st.last_input_surface_node();
+
+    let active_ids: Vec<NodeId> = st
+        .model
+        .field
+        .nodes()
+        .iter()
+        .filter_map(|(&id, n)| {
+            (st.model.field.participates_in_field_activity(id)
+                && st.model.field.is_visible(id)
+                && n.kind == halley_core::field::NodeKind::Surface
+                && n.state == halley_core::field::NodeState::Active)
+                .then_some(id)
+        })
+        .collect();
+
+    let mut active_ids_by_monitor: HashMap<Option<String>, Vec<NodeId>> = HashMap::new();
+    for id in active_ids {
+        let monitor = st.model.monitor_state.node_monitor.get(&id).cloned();
+        active_ids_by_monitor.entry(monitor).or_default().push(id);
+    }
+
+    for active_ids in active_ids_by_monitor.into_values() {
+        if active_ids.len() <= active_windows_allowed {
+            continue;
+        }
+
+        let mut keep_set: HashSet<NodeId> = HashSet::new();
+
+        let focused_breakout: Option<NodeId> = active_ids
             .iter()
-            .filter_map(|(&id, n)| {
-                (self.model.field.participates_in_field_activity(id)
-                    && self.model.field.is_visible(id)
-                    && n.kind == halley_core::field::NodeKind::Surface
-                    && n.state == halley_core::field::NodeState::Active)
-                    .then_some(id)
+            .copied()
+            .find(|&id| {
+                let monitor = st.model.monitor_state.node_monitor.get(&id);
+                monitor
+                    .and_then(|m| st.model.focus_state.monitor_focus.get(m))
+                    .copied()
+                    == Some(id)
             })
-            .collect();
-
-        let mut active_ids_by_monitor: HashMap<Option<String>, Vec<NodeId>> = HashMap::new();
-        for id in active_ids {
-            let monitor = self.model.monitor_state.node_monitor.get(&id).cloned();
-            active_ids_by_monitor.entry(monitor).or_default().push(id);
-        }
-
-        for active_ids in active_ids_by_monitor.into_values() {
-            if active_ids.len() <= active_windows_allowed {
-                continue;
-            }
-
-            let mut keep_set: HashSet<NodeId> = HashSet::new();
-
-            let focused_breakout: Option<NodeId> = active_ids
-                .iter()
-                .copied()
-                .find(|&id| {
-                    let monitor = self.model.monitor_state.node_monitor.get(&id);
-                    monitor
-                        .and_then(|m| self.model.focus_state.monitor_focus.get(m))
-                        .copied()
-                        == Some(id)
-                })
-                .or_else(|| {
-                    active_ids.iter().copied().max_by_key(|id| {
-                        self.model
-                            .focus_state
-                            .last_surface_focus_ms
-                            .get(id)
-                            .copied()
-                            .unwrap_or(0)
-                    })
-                });
-
-            if let Some(fid) = focused_breakout {
-                keep_set.insert(fid);
-            }
-
-            if keep_set.len() < active_windows_allowed {
-                let mut ranked = active_ids.clone();
-                ranked.sort_by_key(|id| {
-                    let preferred_rank = u8::from(preferred_surface == Some(*id));
-                    let focus_rank = u8::from({
-                        let monitor = self.model.monitor_state.node_monitor.get(id);
-                        monitor
-                            .and_then(|m| self.model.focus_state.monitor_focus.get(m))
-                            .copied()
-                            == Some(*id)
-                    });
-                    let companion_rank = u8::from(companion == Some(*id));
-                    let inside_rank =
-                        u8::from(!self.surface_is_definitively_outside_focus_ring(*id));
-                    let latest_focus = self
-                        .model
+            .or_else(|| {
+                active_ids.iter().copied().max_by_key(|id| {
+                    st.model
                         .focus_state
                         .last_surface_focus_ms
                         .get(id)
                         .copied()
-                        .unwrap_or(0);
-                    (
-                        preferred_rank,
-                        focus_rank,
-                        companion_rank,
-                        inside_rank,
-                        latest_focus,
-                        id.as_u64(),
-                    )
+                        .unwrap_or(0)
+                })
+            });
+
+        if let Some(fid) = focused_breakout {
+            keep_set.insert(fid);
+        }
+
+        if keep_set.len() < active_windows_allowed {
+            let mut ranked = active_ids.clone();
+            ranked.sort_by_key(|id| {
+                let preferred_rank = u8::from(preferred_surface == Some(*id));
+                let focus_rank = u8::from({
+                    let monitor = st.model.monitor_state.node_monitor.get(id);
+                    monitor
+                        .and_then(|m| st.model.focus_state.monitor_focus.get(m))
+                        .copied()
+                        == Some(*id)
                 });
+                let companion_rank = u8::from(companion == Some(*id));
+                let inside_rank = u8::from(!surface_is_definitively_outside_focus_ring(st, *id));
+                let latest_focus = st
+                    .model
+                    .focus_state
+                    .last_surface_focus_ms
+                    .get(id)
+                    .copied()
+                    .unwrap_or(0);
+                (
+                    preferred_rank,
+                    focus_rank,
+                    companion_rank,
+                    inside_rank,
+                    latest_focus,
+                    id.as_u64(),
+                )
+            });
 
-                for id in ranked.iter().rev().copied() {
-                    keep_set.insert(id);
-                    if keep_set.len() >= active_windows_allowed {
-                        break;
-                    }
+            for id in ranked.iter().rev().copied() {
+                keep_set.insert(id);
+                if keep_set.len() >= active_windows_allowed {
+                    break;
                 }
             }
+        }
 
-            for id in active_ids {
-                if keep_set.contains(&id) {
-                    continue;
-                }
-                if self.is_fullscreen_session_node(id) {
-                    let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-                    continue;
-                }
-                let now = Instant::now();
-                crate::compositor::workspace::state::collapse_active_to_node_or_queue_auto(
-                    self, id, now,
-                );
+        for id in active_ids {
+            if keep_set.contains(&id) {
+                continue;
             }
-        }
-    }
-
-    fn spawn_placement_transition_active(&self, now_ms: u64) -> bool {
-        self.model.spawn_state.active_spawn_pan.is_some()
-            || !self.model.spawn_state.pending_spawn_pan_queue.is_empty()
-            || self.model.spawn_state.pending_pan_activate.is_some()
-            || self
-                .model
-                .spawn_state
-                .pending_spawn_activate_at_ms
-                .values()
-                .any(|&at_ms| at_ms > now_ms)
-            || self
-                .model
-                .spawn_state
-                .pending_tiled_insert_reveal_at_ms
-                .values()
-                .any(|&at_ms| at_ms > now_ms)
-    }
-
-    pub fn apply_single_surface_decay_policy(
-        &mut self,
-        id: NodeId,
-        now_ms: u64,
-        active_delay_ms: u64,
-        inactive_delay_ms: u64,
-    ) {
-        let Some(n) = self.model.field.node(id) else {
-            return;
-        };
-        if !self.model.field.participates_in_field_activity(id)
-            || !self.model.field.is_visible(id)
-            || n.kind != halley_core::field::NodeKind::Surface
-        {
-            return;
-        }
-
-        if self.runtime.tuning.field_active_windows_allowed == 0 {
-            self.model
-                .focus_state
-                .outside_focus_ring_since_ms
-                .remove(&id);
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-            return;
-        }
-
-        if self.is_fullscreen_session_node(id) {
-            self.model
-                .focus_state
-                .outside_focus_ring_since_ms
-                .remove(&id);
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-            return;
-        }
-
-        if crate::compositor::workspace::state::preserve_collapsed_surface(&**self, id) {
-            self.model
-                .focus_state
-                .outside_focus_ring_since_ms
-                .remove(&id);
-            return;
-        }
-
-        if self.is_hard_decay_protected(id, now_ms) {
-            self.model
-                .focus_state
-                .outside_focus_ring_since_ms
-                .remove(&id);
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-            return;
-        }
-
-        let outside_ring = self.surface_is_definitively_outside_focus_ring(id);
-        if !outside_ring {
-            self.model
-                .focus_state
-                .outside_focus_ring_since_ms
-                .remove(&id);
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-            return;
-        }
-
-        let is_primary = self.model.focus_state.primary_interaction_focus == Some(id);
-        let delay_ms = if is_primary {
-            active_delay_ms
-        } else {
-            inactive_delay_ms
-        };
-
-        let outside_since_ms = *self
-            .model
-            .focus_state
-            .outside_focus_ring_since_ms
-            .entry(id)
-            .or_insert(now_ms);
-
-        if now_ms.saturating_sub(outside_since_ms) >= delay_ms {
+            if st.is_fullscreen_session_node(id) {
+                let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+                continue;
+            }
             let now = Instant::now();
-            crate::compositor::workspace::state::collapse_active_to_node_or_queue_auto(
-                self, id, now,
-            );
-        } else {
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
+            crate::compositor::workspace::state::collapse_active_to_node_or_queue_auto(st, id, now);
         }
     }
+}
 
-    fn is_hard_decay_protected(&self, id: NodeId, now_ms: u64) -> bool {
-        self.model.focus_state.primary_interaction_focus == Some(id)
-            || self.is_fullscreen_session_node(id)
-            || self.input.interaction_state.resize_active == Some(id)
-            || crate::compositor::interaction::state::is_recently_resized_node(self, id, now_ms)
-            || self.model.carry_state.carry_zone_hint.contains_key(&id)
-            || self
-                .model
-                .workspace_state
-                .active_transitions
-                .contains_key(&id)
+fn spawn_placement_transition_active(st: &Halley, now_ms: u64) -> bool {
+    st.model.spawn_state.active_spawn_pan.is_some()
+        || !st.model.spawn_state.pending_spawn_pan_queue.is_empty()
+        || st.model.spawn_state.pending_pan_activate.is_some()
+        || st
+            .model
+            .spawn_state
+            .pending_spawn_activate_at_ms
+            .values()
+            .any(|&at_ms| at_ms > now_ms)
+        || st
+            .model
+            .spawn_state
+            .pending_tiled_insert_reveal_at_ms
+            .values()
+            .any(|&at_ms| at_ms > now_ms)
+}
+
+pub fn apply_single_surface_decay_policy(
+    st: &mut Halley,
+    id: NodeId,
+    now_ms: u64,
+    active_delay_ms: u64,
+    inactive_delay_ms: u64,
+) {
+    let Some(n) = st.model.field.node(id) else {
+        return;
+    };
+    if !st.model.field.participates_in_field_activity(id)
+        || !st.model.field.is_visible(id)
+        || n.kind != halley_core::field::NodeKind::Surface
+    {
+        return;
     }
+
+    if st.runtime.tuning.field_active_windows_allowed == 0 {
+        st.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+        return;
+    }
+
+    if st.is_fullscreen_session_node(id) {
+        st.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+        return;
+    }
+
+    if crate::compositor::workspace::state::preserve_collapsed_surface(st, id) {
+        st.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+        return;
+    }
+
+    if is_hard_decay_protected(st, id, now_ms) {
+        st.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+        return;
+    }
+
+    let outside_ring = surface_is_definitively_outside_focus_ring(st, id);
+    if !outside_ring {
+        st.model.focus_state.outside_focus_ring_since_ms.remove(&id);
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+        return;
+    }
+
+    let is_primary = st.model.focus_state.primary_interaction_focus == Some(id);
+    let delay_ms = if is_primary {
+        active_delay_ms
+    } else {
+        inactive_delay_ms
+    };
+
+    let outside_since_ms = *st
+        .model
+        .focus_state
+        .outside_focus_ring_since_ms
+        .entry(id)
+        .or_insert(now_ms);
+
+    if now_ms.saturating_sub(outside_since_ms) >= delay_ms {
+        let now = Instant::now();
+        crate::compositor::workspace::state::collapse_active_to_node_or_queue_auto(st, id, now);
+    } else {
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+    }
+}
+
+fn is_hard_decay_protected(st: &Halley, id: NodeId, now_ms: u64) -> bool {
+    st.model.focus_state.primary_interaction_focus == Some(id)
+        || st.is_fullscreen_session_node(id)
+        || st.input.interaction_state.resize_active == Some(id)
+        || crate::compositor::interaction::state::is_recently_resized_node(st, id, now_ms)
+        || st.model.carry_state.carry_zone_hint.contains_key(&id)
+        || st
+            .model
+            .workspace_state
+            .active_transitions
+            .contains_key(&id)
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/focus/state.rs
+++ b/crates/halley-wl/src/compositor/focus/state.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use eventline::debug;
@@ -33,466 +32,433 @@ pub(crate) struct FocusState {
 pub(crate) const COMPANION_PROTECT_MS: u64 = 12_000;
 pub(crate) const FOCUS_RING_PREVIEW_MS: u64 = 1_500;
 
-pub(crate) struct FocusStateController<T> {
-    st: T,
-}
-
-pub(crate) fn focus_state_controller<T>(st: T) -> FocusStateController<T> {
-    FocusStateController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for FocusStateController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for FocusStateController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
-
-impl<T: Deref<Target = Halley>> FocusStateController<T> {
-    pub(crate) fn companion_surface_node(&self, now_ms: u64) -> Option<NodeId> {
-        let focused = self.model.focus_state.primary_interaction_focus;
-        self.model
-            .focus_state
-            .last_surface_focus_ms
-            .iter()
-            .filter_map(|(&id, &at)| {
-                if Some(id) == focused {
-                    return None;
-                }
-                if now_ms.saturating_sub(at) > COMPANION_PROTECT_MS {
-                    return None;
-                }
-                self.model.field.node(id).and_then(|n| {
-                    (self.model.field.is_visible(id)
-                        && n.kind == halley_core::field::NodeKind::Surface)
-                        .then_some((id, at))
-                })
+pub(crate) fn companion_surface_node(st: &Halley, now_ms: u64) -> Option<NodeId> {
+    let focused = st.model.focus_state.primary_interaction_focus;
+    st.model
+        .focus_state
+        .last_surface_focus_ms
+        .iter()
+        .filter_map(|(&id, &at)| {
+            if Some(id) == focused {
+                return None;
+            }
+            if now_ms.saturating_sub(at) > COMPANION_PROTECT_MS {
+                return None;
+            }
+            st.model.field.node(id).and_then(|n| {
+                (st.model.field.is_visible(id) && n.kind == halley_core::field::NodeKind::Surface)
+                    .then_some((id, at))
             })
-            .max_by_key(|(id, at)| (*at, id.as_u64()))
-            .map(|(id, _)| id)
-    }
+        })
+        .max_by_key(|(id, at)| (*at, id.as_u64()))
+        .map(|(id, _)| id)
+}
 
-    pub fn active_focus_ring(&self) -> FocusRing {
-        self.runtime
-            .tuning
-            .focus_ring_for_output(self.model.monitor_state.current_monitor.as_str())
-    }
+pub fn active_focus_ring(st: &Halley) -> FocusRing {
+    st.runtime
+        .tuning
+        .focus_ring_for_output(st.model.monitor_state.current_monitor.as_str())
+}
 
-    pub fn focus_ring_for_monitor(&self, monitor: &str) -> FocusRing {
-        self.runtime.tuning.focus_ring_for_output(monitor)
-    }
+pub fn focus_ring_for_monitor(st: &Halley, monitor: &str) -> FocusRing {
+    st.runtime.tuning.focus_ring_for_output(monitor)
+}
 
-    pub fn should_draw_focus_ring_preview(&self, now: Instant) -> bool {
-        self.model
+pub fn should_draw_focus_ring_preview(st: &Halley, now: Instant) -> bool {
+    st.model
+        .focus_state
+        .focus_ring_preview_until_ms
+        .get(st.model.monitor_state.current_monitor.as_str())
+        .is_some_and(|&until_ms| st.now_ms(now) < until_ms)
+}
+
+#[allow(dead_code)]
+pub(crate) fn focused_node_for_monitor(st: &Halley, monitor: &str) -> Option<NodeId> {
+    st.model.focus_state.monitor_focus.get(monitor).copied()
+}
+
+#[allow(dead_code)]
+pub(crate) fn focused_monitor_for_node(st: &Halley, id: NodeId) -> Option<String> {
+    st.model.monitor_state.node_monitor.get(&id).cloned()
+}
+
+pub fn overlap_policy_stack_rank(st: &Halley, node_id: NodeId) -> (u64, u64) {
+    (
+        st.model
             .focus_state
-            .focus_ring_preview_until_ms
-            .get(self.model.monitor_state.current_monitor.as_str())
-            .is_some_and(|&until_ms| self.now_ms(now) < until_ms)
-    }
+            .overlap_raise_order
+            .get(&node_id)
+            .copied()
+            .unwrap_or(0),
+        node_id.as_u64(),
+    )
+}
 
-    #[allow(dead_code)]
-    pub(crate) fn focused_node_for_monitor(&self, monitor: &str) -> Option<NodeId> {
-        self.model.focus_state.monitor_focus.get(monitor).copied()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn focused_monitor_for_node(&self, id: NodeId) -> Option<String> {
-        self.model.monitor_state.node_monitor.get(&id).cloned()
-    }
-
-    pub fn overlap_policy_stack_rank(&self, node_id: NodeId) -> (u64, u64) {
-        (
-            self.model
-                .focus_state
-                .overlap_raise_order
-                .get(&node_id)
-                .copied()
-                .unwrap_or(0),
-            node_id.as_u64(),
-        )
-    }
-
-    fn active_surface_is_frontmost_on_monitor(&self, node_id: NodeId) -> bool {
-        let Some(target_monitor) = self.model.monitor_state.node_monitor.get(&node_id) else {
-            return false;
-        };
-        let target_rank = self.overlap_policy_stack_rank(node_id);
-        self.model
-            .field
-            .nodes()
-            .iter()
-            .filter(|&(id, node)| {
-                *id != node_id
-                    && node.kind == halley_core::field::NodeKind::Surface
-                    && node.state == halley_core::field::NodeState::Active
-                    && self.model.field.is_visible(*id)
-                    && self
-                        .model
-                        .monitor_state
-                        .node_monitor
-                        .get(id)
-                        .is_some_and(|monitor| monitor == target_monitor)
-            })
-            .all(|(&id, _)| self.overlap_policy_stack_rank(id) <= target_rank)
-    }
-
-    fn active_surface_world_rect(&self, node_id: NodeId) -> Option<(f32, f32, f32, f32)> {
-        let node = self.model.field.node(node_id)?;
-        if node.kind != halley_core::field::NodeKind::Surface
-            || node.state != halley_core::field::NodeState::Active
-            || !self.model.field.is_visible(node_id)
-        {
-            return None;
-        }
-        let size = node.intrinsic_size;
-        let left = node.pos.x - size.x * 0.5;
-        let top = node.pos.y - size.y * 0.5;
-        Some((left, top, left + size.x.max(1.0), top + size.y.max(1.0)))
-    }
-
-    fn active_surface_overlaps_visible_peer_on_monitor(&self, node_id: NodeId) -> bool {
-        let Some(target_monitor) = self.model.monitor_state.node_monitor.get(&node_id) else {
-            return false;
-        };
-        let Some(target_rect) = self.active_surface_world_rect(node_id) else {
-            return false;
-        };
-        self.model.field.nodes().iter().any(|(&id, node)| {
-            id != node_id
+fn active_surface_is_frontmost_on_monitor(st: &Halley, node_id: NodeId) -> bool {
+    let Some(target_monitor) = st.model.monitor_state.node_monitor.get(&node_id) else {
+        return false;
+    };
+    let target_rank = overlap_policy_stack_rank(st, node_id);
+    st.model
+        .field
+        .nodes()
+        .iter()
+        .filter(|&(id, node)| {
+            *id != node_id
                 && node.kind == halley_core::field::NodeKind::Surface
                 && node.state == halley_core::field::NodeState::Active
-                && self.model.field.is_visible(id)
-                && self
+                && st.model.field.is_visible(*id)
+                && st
                     .model
                     .monitor_state
                     .node_monitor
-                    .get(&id)
+                    .get(id)
                     .is_some_and(|monitor| monitor == target_monitor)
-                && self
-                    .active_surface_world_rect(id)
-                    .is_some_and(|rect| rects_overlap(target_rect, rect))
         })
+        .all(|(&id, _)| overlap_policy_stack_rank(st, id) <= target_rank)
+}
+
+fn active_surface_world_rect(st: &Halley, node_id: NodeId) -> Option<(f32, f32, f32, f32)> {
+    let node = st.model.field.node(node_id)?;
+    if node.kind != halley_core::field::NodeKind::Surface
+        || node.state != halley_core::field::NodeState::Active
+        || !st.model.field.is_visible(node_id)
+    {
+        return None;
     }
+    let size = node.intrinsic_size;
+    let left = node.pos.x - size.x * 0.5;
+    let top = node.pos.y - size.y * 0.5;
+    Some((left, top, left + size.x.max(1.0), top + size.y.max(1.0)))
+}
+
+fn active_surface_overlaps_visible_peer_on_monitor(st: &Halley, node_id: NodeId) -> bool {
+    let Some(target_monitor) = st.model.monitor_state.node_monitor.get(&node_id) else {
+        return false;
+    };
+    let Some(target_rect) = active_surface_world_rect(st, node_id) else {
+        return false;
+    };
+    st.model.field.nodes().iter().any(|(&id, node)| {
+        id != node_id
+            && node.kind == halley_core::field::NodeKind::Surface
+            && node.state == halley_core::field::NodeState::Active
+            && st.model.field.is_visible(id)
+            && st
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&id)
+                .is_some_and(|monitor| monitor == target_monitor)
+            && active_surface_world_rect(st, id)
+                .is_some_and(|rect| rects_overlap(target_rect, rect))
+    })
 }
 
 fn rects_overlap(a: (f32, f32, f32, f32), b: (f32, f32, f32, f32)) -> bool {
     a.0 < b.2 && b.0 < a.2 && a.1 < b.3 && b.1 < a.3
 }
 
-impl<T: DerefMut<Target = Halley>> FocusStateController<T> {
-    pub(crate) fn focus_monitor_view(&mut self, monitor: &str, now: Instant) {
-        let open_monitors = self
-            .model
-            .cluster_state
-            .cluster_bloom_open
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        for open_monitor in open_monitors {
-            if open_monitor != monitor {
-                let _ = self.close_cluster_bloom_for_monitor(open_monitor.as_str());
-            }
+pub(crate) fn focus_monitor_view(st: &mut Halley, monitor: &str, now: Instant) {
+    let open_monitors = st
+        .model
+        .cluster_state
+        .cluster_bloom_open
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    for open_monitor in open_monitors {
+        if open_monitor != monitor {
+            let _ = st.close_cluster_bloom_for_monitor(open_monitor.as_str());
         }
-        self.set_interaction_monitor(monitor);
-        self.set_focused_monitor(monitor);
-        self.model.spawn_state.pending_spawn_monitor = None;
-        let _ = self.activate_monitor(monitor);
-        if !self
-            .model
-            .focus_state
-            .blocked_monitor_focus_restore
-            .contains(monitor)
-            && let Some(id) = self.last_focused_surface_node_for_monitor(monitor)
-        {
-            self.set_interaction_focus(Some(id), 30_000, now);
-            debug!(
-                "monitor focus restored surface: monitor={} node_id={}",
-                monitor,
-                id.as_u64()
-            );
-            return;
-        }
-        self.set_interaction_focus(None, 0, now);
-        let view_center = self.view_center_for_monitor(monitor);
-        let spawn = self.spawn_monitor_state_mut(monitor);
-        spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
-        spawn.spawn_view_anchor = view_center;
-        spawn.spawn_patch = None;
-        spawn.spawn_pan_start_center = None;
-        debug!(
-            "monitor view focus set: monitor={} interaction_monitor={} focused_monitor={}",
-            monitor,
-            self.interaction_monitor(),
-            self.focused_monitor()
-        );
     }
+    st.set_interaction_monitor(monitor);
+    st.set_focused_monitor(monitor);
+    st.model.spawn_state.pending_spawn_monitor = None;
+    let _ = st.activate_monitor(monitor);
+    if !st
+        .model
+        .focus_state
+        .blocked_monitor_focus_restore
+        .contains(monitor)
+        && let Some(id) = st.last_focused_surface_node_for_monitor(monitor)
+    {
+        set_interaction_focus(st, Some(id), 30_000, now);
+        debug!(
+            "monitor focus restored surface: monitor={} node_id={}",
+            monitor,
+            id.as_u64()
+        );
+        return;
+    }
+    set_interaction_focus(st, None, 0, now);
+    let view_center = st.view_center_for_monitor(monitor);
+    let spawn = st.spawn_monitor_state_mut(monitor);
+    spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+    spawn.spawn_view_anchor = view_center;
+    spawn.spawn_patch = None;
+    spawn.spawn_pan_start_center = None;
+    debug!(
+        "monitor view focus set: monitor={} interaction_monitor={} focused_monitor={}",
+        monitor,
+        st.interaction_monitor(),
+        st.focused_monitor()
+    );
+}
 
-    pub fn set_interaction_focus(&mut self, id: Option<NodeId>, hold_ms: u64, now: Instant) {
-        let prev = self.model.focus_state.primary_interaction_focus;
-        let now_ms = self.now_ms(now);
+pub fn set_interaction_focus(st: &mut Halley, id: Option<NodeId>, hold_ms: u64, now: Instant) {
+    let prev = st.model.focus_state.primary_interaction_focus;
+    let now_ms = st.now_ms(now);
 
-        if prev == id {
-            if let Some(fid) = id {
-                let requested_until = now_ms.saturating_add(hold_ms.max(1));
-                self.model.focus_state.interaction_focus_until_ms = self
-                    .model
-                    .focus_state
-                    .interaction_focus_until_ms
-                    .max(requested_until);
-                self.update_focus_tracking_for_surface(fid, now_ms);
-                if let Some(monitor) = self.model.monitor_state.node_monitor.get(&fid).cloned() {
-                    self.model
-                        .focus_state
-                        .blocked_monitor_focus_restore
-                        .remove(&monitor);
-                    self.set_interaction_monitor(monitor.as_str());
-                    self.set_focused_monitor(monitor.as_str());
-                    self.model.spawn_state.pending_spawn_monitor = None;
-                    let _ = self.activate_monitor(monitor.as_str());
-                    let spawn = self.spawn_monitor_state_mut(monitor.as_str());
-                    spawn.spawn_anchor_mode =
-                        crate::compositor::spawn::state::SpawnAnchorMode::Focus;
-                    spawn.spawn_pan_start_center = None;
-                    self.model.focus_state.monitor_focus.insert(monitor, fid);
-                } else {
-                    let current_monitor = self.model.monitor_state.current_monitor.clone();
-                    let spawn = self.spawn_monitor_state_mut(current_monitor.as_str());
-                    spawn.spawn_anchor_mode =
-                        crate::compositor::spawn::state::SpawnAnchorMode::Focus;
-                    spawn.spawn_pan_start_center = None;
-                }
-
-                self.reassert_wayland_keyboard_focus_if_drifted(id);
-            } else {
-                self.model.focus_state.interaction_focus_until_ms = 0;
-                self.reassert_wayland_keyboard_focus_if_drifted(None);
-            }
-            self.request_maintenance();
-            return;
-        }
-
-        self.model.focus_state.primary_interaction_focus = id;
+    if prev == id {
         if let Some(fid) = id {
-            self.model.focus_state.interaction_focus_until_ms =
-                now_ms.saturating_add(hold_ms.max(1));
-            self.update_focus_tracking_for_surface(fid, now_ms);
-            if let Some(monitor) = self.model.monitor_state.node_monitor.get(&fid).cloned() {
-                let open_monitors = self
-                    .model
-                    .cluster_state
-                    .cluster_bloom_open
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                for open_monitor in open_monitors {
-                    if open_monitor != monitor {
-                        let _ = self.close_cluster_bloom_for_monitor(open_monitor.as_str());
-                    }
-                }
-                self.model
+            let requested_until = now_ms.saturating_add(hold_ms.max(1));
+            st.model.focus_state.interaction_focus_until_ms = st
+                .model
+                .focus_state
+                .interaction_focus_until_ms
+                .max(requested_until);
+            st.update_focus_tracking_for_surface(fid, now_ms);
+            if let Some(monitor) = st.model.monitor_state.node_monitor.get(&fid).cloned() {
+                st.model
                     .focus_state
                     .blocked_monitor_focus_restore
                     .remove(&monitor);
-                self.set_interaction_monitor(monitor.as_str());
-                self.set_focused_monitor(monitor.as_str());
-                self.model.spawn_state.pending_spawn_monitor = None;
-                let _ = self.activate_monitor(monitor.as_str());
-                let spawn = self.spawn_monitor_state_mut(monitor.as_str());
+                st.set_interaction_monitor(monitor.as_str());
+                st.set_focused_monitor(monitor.as_str());
+                st.model.spawn_state.pending_spawn_monitor = None;
+                let _ = st.activate_monitor(monitor.as_str());
+                let spawn = st.spawn_monitor_state_mut(monitor.as_str());
                 spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::Focus;
                 spawn.spawn_pan_start_center = None;
-                self.model.focus_state.monitor_focus.insert(monitor, fid);
+                st.model.focus_state.monitor_focus.insert(monitor, fid);
             } else {
-                let current_monitor = self.model.monitor_state.current_monitor.clone();
-                let spawn = self.spawn_monitor_state_mut(current_monitor.as_str());
+                let current_monitor = st.model.monitor_state.current_monitor.clone();
+                let spawn = st.spawn_monitor_state_mut(current_monitor.as_str());
                 spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::Focus;
                 spawn.spawn_pan_start_center = None;
             }
+
+            reassert_wayland_keyboard_focus_if_drifted(st, id);
         } else {
-            self.model.focus_state.interaction_focus_until_ms = 0;
+            st.model.focus_state.interaction_focus_until_ms = 0;
+            reassert_wayland_keyboard_focus_if_drifted(st, None);
         }
+        st.request_maintenance();
+        return;
+    }
 
-        if prev != id {
+    st.model.focus_state.primary_interaction_focus = id;
+    if let Some(fid) = id {
+        st.model.focus_state.interaction_focus_until_ms = now_ms.saturating_add(hold_ms.max(1));
+        st.update_focus_tracking_for_surface(fid, now_ms);
+        if let Some(monitor) = st.model.monitor_state.node_monitor.get(&fid).cloned() {
+            let open_monitors = st
+                .model
+                .cluster_state
+                .cluster_bloom_open
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>();
+            for open_monitor in open_monitors {
+                if open_monitor != monitor {
+                    let _ = st.close_cluster_bloom_for_monitor(open_monitor.as_str());
+                }
+            }
+            st.model
+                .focus_state
+                .blocked_monitor_focus_restore
+                .remove(&monitor);
+            st.set_interaction_monitor(monitor.as_str());
+            st.set_focused_monitor(monitor.as_str());
+            st.model.spawn_state.pending_spawn_monitor = None;
+            let _ = st.activate_monitor(monitor.as_str());
+            let spawn = st.spawn_monitor_state_mut(monitor.as_str());
+            spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::Focus;
+            spawn.spawn_pan_start_center = None;
+            st.model.focus_state.monitor_focus.insert(monitor, fid);
+        } else {
+            let current_monitor = st.model.monitor_state.current_monitor.clone();
+            let spawn = st.spawn_monitor_state_mut(current_monitor.as_str());
+            spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::Focus;
+            spawn.spawn_pan_start_center = None;
+        }
+    } else {
+        st.model.focus_state.interaction_focus_until_ms = 0;
+    }
+
+    if prev != id {
+        debug!(
+            "interaction focus changed: {:?} -> {:?} (hold_ms={})",
+            prev.map(|n| n.as_u64()),
+            id.map(|n| n.as_u64()),
+            hold_ms
+        );
+    }
+    st.apply_wayland_focus_state(id);
+    st.request_maintenance();
+}
+
+pub(crate) fn restore_pan_return_active_focus(st: &mut Halley, now: Instant) {
+    if !st.runtime.tuning.restore_last_active_on_pan_return {
+        st.model.focus_state.pan_restore_active_focus = None;
+        return;
+    }
+    let Some(id) = st.model.focus_state.pan_restore_active_focus else {
+        return;
+    };
+    let Some(n) = st.model.field.node(id) else {
+        st.model.focus_state.pan_restore_active_focus = None;
+        return;
+    };
+    if !st.model.field.is_visible(id) || n.kind != halley_core::field::NodeKind::Surface {
+        st.model.focus_state.pan_restore_active_focus = None;
+        return;
+    }
+    if n.state == halley_core::field::NodeState::Active {
+        st.model.focus_state.pan_restore_active_focus = None;
+        return;
+    }
+
+    if crate::compositor::workspace::state::preserve_collapsed_surface(st, id) {
+        st.model.focus_state.pan_restore_active_focus = None;
+        return;
+    }
+
+    let target_monitor = st
+        .model
+        .monitor_state
+        .node_monitor
+        .get(&id)
+        .cloned()
+        .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone());
+    let focus_center = st.view_center_for_monitor(target_monitor.as_str());
+    let focus_ring = focus_ring_for_monitor(st, target_monitor.as_str());
+    if focus_ring.zone(focus_center, n.pos) != FocusZone::Inside {
+        return;
+    }
+
+    let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+    crate::compositor::workspace::state::mark_active_transition(st, id, now, 280);
+
+    set_interaction_focus(st, Some(id), 12_000, now);
+    st.model.focus_state.pan_restore_active_focus = None;
+}
+
+pub fn reassert_wayland_keyboard_focus_if_drifted(st: &mut Halley, id: Option<NodeId>) {
+    if st.model.monitor_state.layer_keyboard_focus.is_some() {
+        crate::compositor::monitor::layer_shell::reassert_layer_surface_keyboard_focus_if_drifted(
+            st,
+        );
+        return;
+    }
+    let desired_focus = id.and_then(|fid| st.wl_surface_for_node(fid));
+    if let Some(keyboard) = st.platform.seat.get_keyboard() {
+        let current_focus = keyboard.current_focus();
+        let matches = match (&current_focus, &desired_focus) {
+            (Some(current), Some(desired)) => current.id() == desired.id(),
+            (None, None) => true,
+            _ => false,
+        };
+        if !matches {
             debug!(
-                "interaction focus changed: {:?} -> {:?} (hold_ms={})",
-                prev.map(|n| n.as_u64()),
-                id.map(|n| n.as_u64()),
-                hold_ms
+                "keyboard focus drift detected; reasserting desired focus={:?} current={:?}",
+                desired_focus.as_ref().map(|wl| format!("{:?}", wl.id())),
+                current_focus.as_ref().map(|wl| format!("{:?}", wl.id()))
             );
-        }
-        self.apply_wayland_focus_state(id);
-        self.request_maintenance();
-    }
-
-    pub(crate) fn restore_pan_return_active_focus(&mut self, now: Instant) {
-        if !self.runtime.tuning.restore_last_active_on_pan_return {
-            self.model.focus_state.pan_restore_active_focus = None;
-            return;
-        }
-        let Some(id) = self.model.focus_state.pan_restore_active_focus else {
-            return;
-        };
-        let Some(n) = self.model.field.node(id) else {
-            self.model.focus_state.pan_restore_active_focus = None;
-            return;
-        };
-        if !self.model.field.is_visible(id) || n.kind != halley_core::field::NodeKind::Surface {
-            self.model.focus_state.pan_restore_active_focus = None;
-            return;
-        }
-        if n.state == halley_core::field::NodeState::Active {
-            self.model.focus_state.pan_restore_active_focus = None;
-            return;
-        }
-
-        if crate::compositor::workspace::state::preserve_collapsed_surface(&**self, id) {
-            self.model.focus_state.pan_restore_active_focus = None;
-            return;
-        }
-
-        let target_monitor = self
-            .model
-            .monitor_state
-            .node_monitor
-            .get(&id)
-            .cloned()
-            .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone());
-        let focus_center = self.view_center_for_monitor(target_monitor.as_str());
-        let focus_ring = self.focus_ring_for_monitor(target_monitor.as_str());
-        if focus_ring.zone(focus_center, n.pos) != FocusZone::Inside {
-            return;
-        }
-
-        let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-        crate::compositor::workspace::state::mark_active_transition(&mut **self, id, now, 280);
-
-        self.set_interaction_focus(Some(id), 12_000, now);
-        self.model.focus_state.pan_restore_active_focus = None;
-    }
-
-    pub fn reassert_wayland_keyboard_focus_if_drifted(&mut self, id: Option<NodeId>) {
-        if self.model.monitor_state.layer_keyboard_focus.is_some() {
-            crate::compositor::monitor::layer_shell::reassert_layer_surface_keyboard_focus_if_drifted(self);
-            return;
-        }
-        let desired_focus = id.and_then(|fid| self.wl_surface_for_node(fid));
-        if let Some(keyboard) = self.platform.seat.get_keyboard() {
-            let current_focus = keyboard.current_focus();
-            let matches = match (&current_focus, &desired_focus) {
-                (Some(current), Some(desired)) => current.id() == desired.id(),
-                (None, None) => true,
-                _ => false,
-            };
-            if !matches {
-                debug!(
-                    "keyboard focus drift detected; reasserting desired focus={:?} current={:?}",
-                    desired_focus.as_ref().map(|wl| format!("{:?}", wl.id())),
-                    current_focus.as_ref().map(|wl| format!("{:?}", wl.id()))
-                );
-                crate::compositor::focus::system::set_keyboard_focus(
-                    self,
-                    desired_focus.clone(),
-                    SERIAL_COUNTER.next_serial(),
-                );
-                self.update_selection_focus_from_surface(desired_focus.as_ref());
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn set_monitor_focus(&mut self, monitor: &str, id: NodeId) {
-        self.model
-            .focus_state
-            .monitor_focus
-            .insert(monitor.to_string(), id);
-    }
-
-    pub fn set_recent_top_node(&mut self, node_id: NodeId, until: Instant) {
-        self.model.focus_state.recent_top_node = Some(node_id);
-        self.model.focus_state.recent_top_until = Some(until);
-    }
-
-    pub fn raise_overlap_policy_node(&mut self, node_id: NodeId) -> bool {
-        if !self.model.field.node(node_id).is_some_and(|node| {
-            node.kind == halley_core::field::NodeKind::Surface
-                && node.state == halley_core::field::NodeState::Active
-                && self.model.field.is_visible(node_id)
-        }) {
-            return false;
-        }
-        let needs_raise_above_fullscreen = self
-            .model
-            .monitor_state
-            .node_monitor
-            .get(&node_id)
-            .and_then(|monitor| {
-                self.model
-                    .fullscreen_state
-                    .fullscreen_active_node
-                    .get(monitor.as_str())
-                    .copied()
-            })
-            .is_some_and(|fullscreen_id| {
-                fullscreen_id != node_id
-                    && self.overlap_policy_stack_rank(node_id).0
-                        <= self.overlap_policy_stack_rank(fullscreen_id).0
-            });
-        if !needs_raise_above_fullscreen && self.active_surface_is_frontmost_on_monitor(node_id) {
-            return false;
-        }
-        self.model.focus_state.next_overlap_raise_order = self
-            .model
-            .focus_state
-            .next_overlap_raise_order
-            .saturating_add(1);
-        let order = self.model.focus_state.next_overlap_raise_order;
-        self.model
-            .focus_state
-            .overlap_raise_order
-            .insert(node_id, order);
-        let should_animate_raise = match self.runtime.tuning.raise_animation_trigger() {
-            halley_config::RaiseAnimationTrigger::Always => true,
-            halley_config::RaiseAnimationTrigger::Overlap => {
-                self.active_surface_overlaps_visible_peer_on_monitor(node_id)
-            }
-        };
-        if self.runtime.tuning.raise_animation_enabled() && should_animate_raise {
-            let now = Instant::now();
-            self.request_window_animation_prewarm(node_id, now);
-            let duration_ms = self.runtime.tuning.raise_animation_duration_ms();
-            let scale = self.runtime.tuning.raise_animation_scale();
-            let shadow_boost = self.runtime.tuning.raise_animation_shadow_boost();
-            self.ui.render_state.start_raise_animation(
-                node_id,
-                now,
-                duration_ms,
-                scale,
-                shadow_boost,
+            crate::compositor::focus::system::set_keyboard_focus(
+                st,
+                desired_focus.clone(),
+                SERIAL_COUNTER.next_serial(),
             );
+            st.update_selection_focus_from_surface(desired_focus.as_ref());
         }
-        self.request_maintenance();
-        true
     }
+}
 
-    pub fn recent_top_node_active(&mut self, now: Instant) -> Option<NodeId> {
-        if self
-            .model
-            .focus_state
-            .recent_top_until
-            .is_some_and(|until| now >= until)
-        {
-            self.model.focus_state.recent_top_node = None;
-            self.model.focus_state.recent_top_until = None;
-            return None;
-        }
-        self.model.focus_state.recent_top_node
+#[allow(dead_code)]
+pub(crate) fn set_monitor_focus(st: &mut Halley, monitor: &str, id: NodeId) {
+    st.model
+        .focus_state
+        .monitor_focus
+        .insert(monitor.to_string(), id);
+}
+
+pub fn set_recent_top_node(st: &mut Halley, node_id: NodeId, until: Instant) {
+    st.model.focus_state.recent_top_node = Some(node_id);
+    st.model.focus_state.recent_top_until = Some(until);
+}
+
+pub fn raise_overlap_policy_node(st: &mut Halley, node_id: NodeId) -> bool {
+    if !st.model.field.node(node_id).is_some_and(|node| {
+        node.kind == halley_core::field::NodeKind::Surface
+            && node.state == halley_core::field::NodeState::Active
+            && st.model.field.is_visible(node_id)
+    }) {
+        return false;
     }
+    let needs_raise_above_fullscreen = st
+        .model
+        .monitor_state
+        .node_monitor
+        .get(&node_id)
+        .and_then(|monitor| {
+            st.model
+                .fullscreen_state
+                .fullscreen_active_node
+                .get(monitor.as_str())
+                .copied()
+        })
+        .is_some_and(|fullscreen_id| {
+            fullscreen_id != node_id
+                && overlap_policy_stack_rank(st, node_id).0
+                    <= overlap_policy_stack_rank(st, fullscreen_id).0
+        });
+    if !needs_raise_above_fullscreen && active_surface_is_frontmost_on_monitor(st, node_id) {
+        return false;
+    }
+    st.model.focus_state.next_overlap_raise_order = st
+        .model
+        .focus_state
+        .next_overlap_raise_order
+        .saturating_add(1);
+    let order = st.model.focus_state.next_overlap_raise_order;
+    st.model
+        .focus_state
+        .overlap_raise_order
+        .insert(node_id, order);
+    let should_animate_raise = match st.runtime.tuning.raise_animation_trigger() {
+        halley_config::RaiseAnimationTrigger::Always => true,
+        halley_config::RaiseAnimationTrigger::Overlap => {
+            active_surface_overlaps_visible_peer_on_monitor(st, node_id)
+        }
+    };
+    if st.runtime.tuning.raise_animation_enabled() && should_animate_raise {
+        let now = Instant::now();
+        st.request_window_animation_prewarm(node_id, now);
+        let duration_ms = st.runtime.tuning.raise_animation_duration_ms();
+        let scale = st.runtime.tuning.raise_animation_scale();
+        let shadow_boost = st.runtime.tuning.raise_animation_shadow_boost();
+        st.ui
+            .render_state
+            .start_raise_animation(node_id, now, duration_ms, scale, shadow_boost);
+    }
+    st.request_maintenance();
+    true
+}
+
+pub fn recent_top_node_active(st: &mut Halley, now: Instant) -> Option<NodeId> {
+    if st
+        .model
+        .focus_state
+        .recent_top_until
+        .is_some_and(|until| now >= until)
+    {
+        st.model.focus_state.recent_top_node = None;
+        st.model.focus_state.recent_top_until = None;
+        return None;
+    }
+    st.model.focus_state.recent_top_node
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/focus/state.rs
+++ b/crates/halley-wl/src/compositor/focus/state.rs
@@ -352,7 +352,8 @@ pub fn reassert_wayland_keyboard_focus_if_drifted(st: &mut Halley, id: Option<No
         );
         return;
     }
-    let desired_focus = id.and_then(|fid| st.wl_surface_for_node(fid));
+    let desired_focus =
+        id.and_then(|fid| crate::compositor::focus::system::wl_surface_for_node(st, fid));
     if let Some(keyboard) = st.platform.seat.get_keyboard() {
         let current_focus = keyboard.current_focus();
         let matches = match (&current_focus, &desired_focus) {

--- a/crates/halley-wl/src/compositor/focus/system.rs
+++ b/crates/halley-wl/src/compositor/focus/system.rs
@@ -188,7 +188,8 @@ pub fn apply_wayland_focus_state(st: &mut Halley, id: Option<NodeId>) {
         st.enter_xdg_fullscreen(fid, None, Instant::now());
     }
     st.model.monitor_state.layer_keyboard_focus = None;
-    let requested_focus_surface = focus_id.and_then(|fid| st.wl_surface_for_node(fid));
+    let requested_focus_surface =
+        focus_id.and_then(|fid| crate::compositor::focus::system::wl_surface_for_node(st, fid));
     let active_constrained_surface =
         crate::compositor::interaction::pointer::active_constrained_pointer_surface(st)
             .map(|(surface, _)| surface);

--- a/crates/halley-wl/src/compositor/focus/system.rs
+++ b/crates/halley-wl/src/compositor/focus/system.rs
@@ -11,7 +11,6 @@ use smithay::wayland::selection::primary_selection::set_primary_focus;
 
 use crate::compositor::ctx::FocusCtx;
 use smithay::input::Seat;
-use std::ops::{Deref, DerefMut};
 use std::time::{Duration, Instant};
 
 pub(crate) fn on_seat_focus_changed(
@@ -27,28 +26,6 @@ pub(crate) fn on_seat_focus_changed(
     let client = focused.and_then(|wl| wl.client());
     set_data_device_focus(ctx.display_handle, seat, client.clone());
     set_primary_focus(ctx.display_handle, seat, client);
-}
-
-pub(crate) struct FocusSystemController<T> {
-    st: T,
-}
-
-pub(crate) fn focus_system_controller<T>(st: T) -> FocusSystemController<T> {
-    FocusSystemController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for FocusSystemController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for FocusSystemController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
 }
 
 /// Single choke point for every keyboard focus change. When focus actually moves
@@ -142,7 +119,6 @@ pub(crate) fn minimal_reveal_center_for_surface_on_monitor(
     read::minimal_reveal_center_for_surface_on_monitor(st, monitor, id)
 }
 
-#[cfg(test)]
 pub(crate) fn fullscreen_focus_override(st: &Halley, requested: Option<NodeId>) -> Option<NodeId> {
     read::fullscreen_focus_override(st, requested)
 }
@@ -163,424 +139,408 @@ pub fn last_input_surface_node_for_monitor(st: &Halley, monitor: &str) -> Option
     read::last_input_surface_node_for_monitor(st, monitor)
 }
 
-impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
-    pub fn set_app_focused(&mut self, focused: bool) {
-        self.model.focus_state.app_focused = focused;
-    }
+pub fn set_app_focused(st: &mut Halley, focused: bool) {
+    st.model.focus_state.app_focused = focused;
+}
 
-    pub(crate) fn clear_keyboard_focus(&mut self) {
-        set_keyboard_focus(self, None, SERIAL_COUNTER.next_serial());
-        self.update_selection_focus_from_surface(None);
+pub(crate) fn clear_keyboard_focus(st: &mut Halley) {
+    set_keyboard_focus(st, None, SERIAL_COUNTER.next_serial());
+    update_selection_focus_from_surface(st, None);
+}
+
+pub(crate) const VIEWPORT_PAN_DURATION_MS: u64 = 260;
+const SPAWN_VIEW_HANDOFF_PAN_RATIO: f32 = 0.35;
+const SPAWN_VIEW_HANDOFF_FOCUS_RATIO: f32 = 0.25;
+
+pub fn apply_wayland_focus_state(st: &mut Halley, id: Option<NodeId>) {
+    if crate::protocol::wayland::session_lock::session_lock_active(st) {
+        crate::protocol::wayland::session_lock::reassert_keyboard_focus_if_drifted(st);
+        return;
+    }
+    let focus_id = fullscreen_focus_override(st, id).or(id);
+    if let Some(fid) = focus_id
+        && st
+            .model
+            .fullscreen_state
+            .fullscreen_suspended_node
+            .values()
+            .any(|&nid| nid == fid)
+    {
+        if let Some(entry) = st
+            .model
+            .fullscreen_state
+            .fullscreen_restore
+            .get(&fid)
+            .copied()
+        {
+            let target_monitor = st.monitor_for_node_or_current(fid);
+            if let Some(space) = st.model.monitor_state.monitors.get_mut(&target_monitor) {
+                space.viewport.center = entry.viewport_center;
+                space.camera_target_center = entry.viewport_center;
+            }
+            if st.model.monitor_state.current_monitor == target_monitor {
+                st.model.viewport.center = entry.viewport_center;
+                st.model.camera_target_center = st.model.viewport.center;
+                st.runtime.tuning.viewport_center = st.model.viewport.center;
+                st.input.interaction_state.viewport_pan_anim = None;
+            }
+        }
+        st.enter_xdg_fullscreen(fid, None, Instant::now());
+    }
+    st.model.monitor_state.layer_keyboard_focus = None;
+    let requested_focus_surface = focus_id.and_then(|fid| st.wl_surface_for_node(fid));
+    let active_constrained_surface =
+        crate::compositor::interaction::pointer::active_constrained_pointer_surface(st)
+            .map(|(surface, _)| surface);
+    let locked_surface_node = active_constrained_surface
+        .as_ref()
+        .and_then(|surface| st.model.surface_to_node.get(&surface.id()).copied());
+    let keep_locked_focus = keep_locked_focus_for_request(st, locked_surface_node, focus_id);
+    let focus_surface = if keep_locked_focus {
+        active_constrained_surface
+            .clone()
+            .or(requested_focus_surface.clone())
+    } else {
+        requested_focus_surface.clone()
+    };
+    if !keep_locked_focus
+        && active_constrained_surface
+            .as_ref()
+            .is_some_and(|surface| Some(surface.id()) != focus_surface.as_ref().map(|wl| wl.id()))
+    {
+        crate::compositor::interaction::pointer::release_active_pointer_constraint(st);
+    }
+    set_keyboard_focus(st, focus_surface.clone(), SERIAL_COUNTER.next_serial());
+    update_selection_focus_from_surface(st, focus_surface.as_ref());
+
+    for top in st.platform.xdg_shell_state.toplevel_surfaces() {
+        let key = top.wl_surface().id();
+        let node_id = st.model.surface_to_node.get(&key).copied();
+
+        let activated = node_id.is_some_and(|nid| {
+            st.model
+                .monitor_state
+                .node_monitor
+                .get(&nid)
+                .and_then(|monitor| st.model.focus_state.monitor_focus.get(monitor))
+                .copied()
+                == Some(nid)
+                || Some(nid) == focus_id
+        });
+
+        let state_changed = top.with_pending_state(|s| {
+            let was_active = s.states.contains(xdg_toplevel::State::Activated);
+            if activated {
+                s.states.set(xdg_toplevel::State::Activated);
+            } else {
+                s.states.unset(xdg_toplevel::State::Activated);
+            }
+            st.apply_toplevel_tiled_hint(s);
+            was_active != activated
+        });
+
+        if state_changed {
+            top.send_configure();
+        }
     }
 }
 
-impl<T: DerefMut<Target = Halley>> FocusSystemController<T> {
-    pub(crate) const VIEWPORT_PAN_DURATION_MS: u64 = 260;
-    const SPAWN_VIEW_HANDOFF_PAN_RATIO: f32 = 0.35;
-    const SPAWN_VIEW_HANDOFF_FOCUS_RATIO: f32 = 0.25;
-
-    pub(crate) fn fullscreen_focus_override(&self, requested: Option<NodeId>) -> Option<NodeId> {
-        read::fullscreen_focus_override(self, requested)
+pub fn update_focus_tracking_for_surface(st: &mut Halley, fid: NodeId, now_ms: u64) {
+    let Some(node_state) = st
+        .model
+        .field
+        .node(fid)
+        .map(|n| (n.kind.clone(), n.state.clone()))
+    else {
+        return;
+    };
+    if node_state.0 != halley_core::field::NodeKind::Surface
+        || !st.model.field.participates_in_field_activity(fid)
+        || !st.model.field.is_visible(fid)
+    {
+        return;
     }
 
-    pub fn apply_wayland_focus_state(&mut self, id: Option<NodeId>) {
-        if crate::protocol::wayland::session_lock::session_lock_active(self) {
-            crate::protocol::wayland::session_lock::reassert_keyboard_focus_if_drifted(self);
-            return;
-        }
-        let focus_id = self.fullscreen_focus_override(id).or(id);
-        if let Some(fid) = focus_id
-            && self
-                .model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .values()
-                .any(|&nid| nid == fid)
-        {
-            if let Some(entry) = self
-                .model
-                .fullscreen_state
-                .fullscreen_restore
-                .get(&fid)
-                .copied()
-            {
-                let target_monitor = self.monitor_for_node_or_current(fid);
-                if let Some(space) = self.model.monitor_state.monitors.get_mut(&target_monitor) {
-                    space.viewport.center = entry.viewport_center;
-                    space.camera_target_center = entry.viewport_center;
-                }
-                if self.model.monitor_state.current_monitor == target_monitor {
-                    self.model.viewport.center = entry.viewport_center;
-                    self.model.camera_target_center = self.model.viewport.center;
-                    self.runtime.tuning.viewport_center = self.model.viewport.center;
-                    self.input.interaction_state.viewport_pan_anim = None;
-                }
-            }
-            self.enter_xdg_fullscreen(fid, None, Instant::now());
-        }
-        self.model.monitor_state.layer_keyboard_focus = None;
-        let requested_focus_surface = focus_id.and_then(|fid| self.wl_surface_for_node(fid));
-        let active_constrained_surface =
-            crate::compositor::interaction::pointer::active_constrained_pointer_surface(self)
-                .map(|(surface, _)| surface);
-        let locked_surface_node = active_constrained_surface
-            .as_ref()
-            .and_then(|surface| self.model.surface_to_node.get(&surface.id()).copied());
-        let keep_locked_focus = keep_locked_focus_for_request(self, locked_surface_node, focus_id);
-        let focus_surface = if keep_locked_focus {
-            active_constrained_surface
-                .clone()
-                .or(requested_focus_surface.clone())
-        } else {
-            requested_focus_surface.clone()
-        };
-        if !keep_locked_focus
-            && active_constrained_surface.as_ref().is_some_and(|surface| {
-                Some(surface.id()) != focus_surface.as_ref().map(|wl| wl.id())
-            })
-        {
-            crate::compositor::interaction::pointer::release_active_pointer_constraint(self);
-        }
-        set_keyboard_focus(self, focus_surface.clone(), SERIAL_COUNTER.next_serial());
-        self.update_selection_focus_from_surface(focus_surface.as_ref());
-
-        for top in self.platform.xdg_shell_state.toplevel_surfaces() {
-            let key = top.wl_surface().id();
-            let node_id = self.model.surface_to_node.get(&key).copied();
-
-            let activated = node_id.is_some_and(|nid| {
-                self.model
-                    .monitor_state
-                    .node_monitor
-                    .get(&nid)
-                    .and_then(|monitor| self.model.focus_state.monitor_focus.get(monitor))
-                    .copied()
-                    == Some(nid)
-                    || Some(nid) == focus_id
-            });
-
-            let state_changed = top.with_pending_state(|s| {
-                let was_active = s.states.contains(xdg_toplevel::State::Activated);
-                if activated {
-                    s.states.set(xdg_toplevel::State::Activated);
-                } else {
-                    s.states.unset(xdg_toplevel::State::Activated);
-                }
-                self.apply_toplevel_tiled_hint(s);
-                was_active != activated
-            });
-
-            if state_changed {
-                top.send_configure();
-            }
-        }
+    st.model
+        .focus_state
+        .last_surface_focus_ms
+        .insert(fid, now_ms);
+    st.model
+        .focus_state
+        .outside_focus_ring_since_ms
+        .remove(&fid);
+    if st.model.focus_state.suppress_trail_record_once {
+        st.model.focus_state.suppress_trail_record_once = false;
+    } else {
+        st.record_focus_trail_visit(fid);
     }
 
-    pub fn update_focus_tracking_for_surface(&mut self, fid: NodeId, now_ms: u64) {
-        let Some(node_state) = self
-            .model
-            .field
-            .node(fid)
-            .map(|n| (n.kind.clone(), n.state.clone()))
-        else {
-            return;
-        };
-        if node_state.0 != halley_core::field::NodeKind::Surface
-            || !self.model.field.participates_in_field_activity(fid)
-            || !self.model.field.is_visible(fid)
-        {
-            return;
-        }
-
-        self.model
-            .focus_state
-            .last_surface_focus_ms
-            .insert(fid, now_ms);
-        self.model
-            .focus_state
-            .outside_focus_ring_since_ms
-            .remove(&fid);
-        if self.model.focus_state.suppress_trail_record_once {
-            self.model.focus_state.suppress_trail_record_once = false;
-        } else {
-            self.record_focus_trail_visit(fid);
-        }
-
-        if node_state.1 == halley_core::field::NodeState::Active {
-            let _ = self.model.field.touch(fid, now_ms);
-            let _ = self.model.field.set_decay_level(fid, DecayLevel::Hot);
-            if self.runtime.tuning.restore_last_active_on_pan_return {
-                self.model.focus_state.pan_restore_active_focus = Some(fid);
-            }
+    if node_state.1 == halley_core::field::NodeState::Active {
+        let _ = st.model.field.touch(fid, now_ms);
+        let _ = st.model.field.set_decay_level(fid, DecayLevel::Hot);
+        if st.runtime.tuning.restore_last_active_on_pan_return {
+            st.model.focus_state.pan_restore_active_focus = Some(fid);
         }
     }
+}
 
-    pub fn note_pan_activity(&mut self, now: Instant) {
-        self.input.interaction_state.viewport_pan_anim = None;
-        let now_ms = self.now_ms(now);
-        self.input.interaction_state.pan_dominant_until_ms = now_ms.saturating_add(220);
-        let current_monitor = self.model.monitor_state.current_monitor.clone();
-        let viewport_center = self.model.viewport.center;
-        let spawn = self.spawn_monitor_state_mut(current_monitor.as_str());
-        spawn.spawn_last_pan_ms = now_ms;
-        spawn.spawn_pan_start_center.get_or_insert(viewport_center);
-        if self.runtime.tuning.restore_last_active_on_pan_return
-            && self.model.focus_state.pan_restore_active_focus.is_none()
-        {
-            self.model.focus_state.pan_restore_active_focus =
-                read::last_focused_active_surface_node(self);
+pub fn note_pan_activity(st: &mut Halley, now: Instant) {
+    st.input.interaction_state.viewport_pan_anim = None;
+    let now_ms = st.now_ms(now);
+    st.input.interaction_state.pan_dominant_until_ms = now_ms.saturating_add(220);
+    let current_monitor = st.model.monitor_state.current_monitor.clone();
+    let viewport_center = st.model.viewport.center;
+    let spawn = st.spawn_monitor_state_mut(current_monitor.as_str());
+    spawn.spawn_last_pan_ms = now_ms;
+    spawn.spawn_pan_start_center.get_or_insert(viewport_center);
+    if st.runtime.tuning.restore_last_active_on_pan_return
+        && st.model.focus_state.pan_restore_active_focus.is_none()
+    {
+        st.model.focus_state.pan_restore_active_focus = read::last_focused_active_surface_node(st);
+    }
+    st.input.interaction_state.suspend_overlap_resolve = false;
+    st.input.interaction_state.suspend_state_checks = false;
+    st.request_maintenance();
+}
+
+fn spawn_view_handoff_pan_distance(st: &Halley) -> f32 {
+    st.model.viewport.size.x.min(st.model.viewport.size.y) * SPAWN_VIEW_HANDOFF_PAN_RATIO
+}
+
+fn spawn_view_handoff_focus_distance(st: &Halley) -> f32 {
+    st.model.viewport.size.x.hypot(st.model.viewport.size.y) * SPAWN_VIEW_HANDOFF_FOCUS_RATIO
+}
+
+pub(crate) fn note_pan_viewport_change(st: &mut Halley, _now: Instant) {
+    let current_monitor = st.model.monitor_state.current_monitor.clone();
+    let spawn_pan_active = st.model.spawn_state.active_spawn_pan.is_some()
+        || !st.model.spawn_state.pending_spawn_pan_queue.is_empty()
+        || st.model.spawn_state.pending_pan_activate.is_some();
+    if st
+        .spawn_monitor_state(current_monitor.as_str())
+        .spawn_anchor_mode
+        == crate::compositor::spawn::state::SpawnAnchorMode::View
+        && !spawn_pan_active
+    {
+        st.spawn_monitor_state_mut(current_monitor.as_str())
+            .spawn_view_anchor = st.model.viewport.center;
+    }
+    st.request_maintenance();
+    if spawn_pan_active {
+        return;
+    }
+    let Some(start_center) = st
+        .spawn_monitor_state(current_monitor.as_str())
+        .spawn_pan_start_center
+    else {
+        return;
+    };
+
+    let moved = ((st.model.viewport.center.x - start_center.x).powi(2)
+        + (st.model.viewport.center.y - start_center.y).powi(2))
+    .sqrt();
+    if moved < spawn_view_handoff_pan_distance(st) {
+        return;
+    }
+
+    let focus_far = st
+        .last_input_surface_node()
+        .and_then(|id| st.model.field.node(id))
+        .map(|node| {
+            let dx = st.model.viewport.center.x - node.pos.x;
+            let dy = st.model.viewport.center.y - node.pos.y;
+            dx.hypot(dy) >= spawn_view_handoff_focus_distance(st)
+        })
+        .unwrap_or(true);
+    if !focus_far {
+        return;
+    }
+
+    let viewport_center = st.model.viewport.center;
+    let spawn = st.spawn_monitor_state_mut(current_monitor.as_str());
+    spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
+    spawn.spawn_view_anchor = viewport_center;
+    spawn.spawn_patch = None;
+    spawn.spawn_pan_start_center = Some(viewport_center);
+    st.model.focus_state.pan_restore_active_focus = None;
+}
+
+pub fn set_pan_restore_focus_target(st: &mut Halley, id: NodeId) {
+    st.model.focus_state.pan_restore_active_focus = Some(id);
+}
+
+pub fn animate_viewport_center_to(st: &mut Halley, target_center: Vec2, now: Instant) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    animate_viewport_center_to_on_monitor_delayed(st, monitor.as_str(), target_center, now, 0)
+}
+
+pub fn animate_viewport_center_to_on_monitor(
+    st: &mut Halley,
+    monitor: &str,
+    target_center: Vec2,
+    now: Instant,
+) -> bool {
+    animate_viewport_center_to_on_monitor_delayed(st, monitor, target_center, now, 0)
+}
+
+pub fn animate_viewport_center_to_delayed(
+    st: &mut Halley,
+    target_center: Vec2,
+    now: Instant,
+    delay_ms: u64,
+) -> bool {
+    let monitor = st.model.monitor_state.current_monitor.clone();
+    animate_viewport_center_to_on_monitor_delayed(
+        st,
+        monitor.as_str(),
+        target_center,
+        now,
+        delay_ms,
+    )
+}
+
+pub fn animate_viewport_center_to_on_monitor_delayed(
+    st: &mut Halley,
+    monitor: &str,
+    target_center: Vec2,
+    now: Instant,
+    delay_ms: u64,
+) -> bool {
+    if !st.model.monitor_state.monitors.contains_key(monitor) {
+        return false;
+    }
+    let from = if st.model.monitor_state.current_monitor == monitor {
+        st.model.viewport.center
+    } else {
+        st.model
+            .monitor_state
+            .monitors
+            .get(monitor)
+            .map(|space| space.viewport.center)
+            .unwrap_or(st.model.viewport.center)
+    };
+    let dx = target_center.x - from.x;
+    let dy = target_center.y - from.y;
+    if dx.abs() < 0.25 && dy.abs() < 0.25 {
+        return false;
+    }
+    st.input.interaction_state.viewport_pan_anim = Some(ViewportPanAnim {
+        monitor: monitor.to_string(),
+        start_ms: st.now_ms(now),
+        delay_ms,
+        duration_ms: VIEWPORT_PAN_DURATION_MS,
+        from_center: from,
+        to_center: target_center,
+    });
+    true
+}
+
+pub(crate) fn tick_viewport_pan_animation(st: &mut Halley, now_ms: u64) {
+    let Some(anim) = st.input.interaction_state.viewport_pan_anim.clone() else {
+        return;
+    };
+
+    if !st
+        .model
+        .monitor_state
+        .monitors
+        .contains_key(anim.monitor.as_str())
+    {
+        st.input.interaction_state.viewport_pan_anim = None;
+        return;
+    }
+
+    let set_center = |st: &mut Halley, center: Vec2| {
+        if st.model.monitor_state.current_monitor == anim.monitor {
+            st.model.viewport.center = center;
+            st.model.camera_target_center = center;
+            st.runtime.tuning.viewport_center = center;
         }
-        self.input.interaction_state.suspend_overlap_resolve = false;
-        self.input.interaction_state.suspend_state_checks = false;
-        self.request_maintenance();
-    }
-
-    fn spawn_view_handoff_pan_distance(&self) -> f32 {
-        self.model.viewport.size.x.min(self.model.viewport.size.y)
-            * Self::SPAWN_VIEW_HANDOFF_PAN_RATIO
-    }
-
-    fn spawn_view_handoff_focus_distance(&self) -> f32 {
-        self.model.viewport.size.x.hypot(self.model.viewport.size.y)
-            * Self::SPAWN_VIEW_HANDOFF_FOCUS_RATIO
-    }
-
-    pub(crate) fn note_pan_viewport_change(&mut self, _now: Instant) {
-        let current_monitor = self.model.monitor_state.current_monitor.clone();
-        let spawn_pan_active = self.model.spawn_state.active_spawn_pan.is_some()
-            || !self.model.spawn_state.pending_spawn_pan_queue.is_empty()
-            || self.model.spawn_state.pending_pan_activate.is_some();
-        if self
-            .spawn_monitor_state(current_monitor.as_str())
-            .spawn_anchor_mode
-            == crate::compositor::spawn::state::SpawnAnchorMode::View
-            && !spawn_pan_active
-        {
-            self.spawn_monitor_state_mut(current_monitor.as_str())
-                .spawn_view_anchor = self.model.viewport.center;
-        }
-        self.request_maintenance();
-        if spawn_pan_active {
-            return;
-        }
-        let Some(start_center) = self
-            .spawn_monitor_state(current_monitor.as_str())
-            .spawn_pan_start_center
-        else {
-            return;
-        };
-
-        let moved = ((self.model.viewport.center.x - start_center.x).powi(2)
-            + (self.model.viewport.center.y - start_center.y).powi(2))
-        .sqrt();
-        if moved < self.spawn_view_handoff_pan_distance() {
-            return;
-        }
-
-        let focus_far = self
-            .last_input_surface_node()
-            .and_then(|id| self.model.field.node(id))
-            .map(|node| {
-                let dx = self.model.viewport.center.x - node.pos.x;
-                let dy = self.model.viewport.center.y - node.pos.y;
-                dx.hypot(dy) >= self.spawn_view_handoff_focus_distance()
-            })
-            .unwrap_or(true);
-        if !focus_far {
-            return;
-        }
-
-        let viewport_center = self.model.viewport.center;
-        let spawn = self.spawn_monitor_state_mut(current_monitor.as_str());
-        spawn.spawn_anchor_mode = crate::compositor::spawn::state::SpawnAnchorMode::View;
-        spawn.spawn_view_anchor = viewport_center;
-        spawn.spawn_patch = None;
-        spawn.spawn_pan_start_center = Some(viewport_center);
-        self.model.focus_state.pan_restore_active_focus = None;
-    }
-
-    pub fn set_pan_restore_focus_target(&mut self, id: NodeId) {
-        self.model.focus_state.pan_restore_active_focus = Some(id);
-    }
-
-    pub fn animate_viewport_center_to(&mut self, target_center: Vec2, now: Instant) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        self.animate_viewport_center_to_on_monitor_delayed(monitor.as_str(), target_center, now, 0)
-    }
-
-    pub fn animate_viewport_center_to_on_monitor(
-        &mut self,
-        monitor: &str,
-        target_center: Vec2,
-        now: Instant,
-    ) -> bool {
-        self.animate_viewport_center_to_on_monitor_delayed(monitor, target_center, now, 0)
-    }
-
-    pub fn animate_viewport_center_to_delayed(
-        &mut self,
-        target_center: Vec2,
-        now: Instant,
-        delay_ms: u64,
-    ) -> bool {
-        let monitor = self.model.monitor_state.current_monitor.clone();
-        self.animate_viewport_center_to_on_monitor_delayed(
-            monitor.as_str(),
-            target_center,
-            now,
-            delay_ms,
-        )
-    }
-
-    pub fn animate_viewport_center_to_on_monitor_delayed(
-        &mut self,
-        monitor: &str,
-        target_center: Vec2,
-        now: Instant,
-        delay_ms: u64,
-    ) -> bool {
-        if !self.model.monitor_state.monitors.contains_key(monitor) {
-            return false;
-        }
-        let from = if self.model.monitor_state.current_monitor == monitor {
-            self.model.viewport.center
-        } else {
-            self.model
-                .monitor_state
-                .monitors
-                .get(monitor)
-                .map(|space| space.viewport.center)
-                .unwrap_or(self.model.viewport.center)
-        };
-        let dx = target_center.x - from.x;
-        let dy = target_center.y - from.y;
-        if dx.abs() < 0.25 && dy.abs() < 0.25 {
-            return false;
-        }
-        self.input.interaction_state.viewport_pan_anim = Some(ViewportPanAnim {
-            monitor: monitor.to_string(),
-            start_ms: self.now_ms(now),
-            delay_ms,
-            duration_ms: Self::VIEWPORT_PAN_DURATION_MS,
-            from_center: from,
-            to_center: target_center,
-        });
-        true
-    }
-
-    pub(crate) fn tick_viewport_pan_animation(&mut self, now_ms: u64) {
-        let Some(anim) = self.input.interaction_state.viewport_pan_anim.clone() else {
-            return;
-        };
-
-        if !self
+        if let Some(space) = st
             .model
             .monitor_state
             .monitors
-            .contains_key(anim.monitor.as_str())
+            .get_mut(anim.monitor.as_str())
         {
-            self.input.interaction_state.viewport_pan_anim = None;
-            return;
+            space.viewport.center = center;
+            space.camera_target_center = center;
         }
+    };
 
-        let set_center = |st: &mut Halley, center: Vec2| {
-            if st.model.monitor_state.current_monitor == anim.monitor {
-                st.model.viewport.center = center;
-                st.model.camera_target_center = center;
-                st.runtime.tuning.viewport_center = center;
-            }
-            if let Some(space) = st
-                .model
-                .monitor_state
-                .monitors
-                .get_mut(anim.monitor.as_str())
-            {
-                space.viewport.center = center;
-                space.camera_target_center = center;
-            }
-        };
-
-        if now_ms <= anim.start_ms.saturating_add(anim.delay_ms) {
-            set_center(self, anim.from_center);
-            return;
-        }
-        let dur = anim.duration_ms.max(1);
-        let elapsed_ms = now_ms.saturating_sub(anim.start_ms.saturating_add(anim.delay_ms));
-        let t = (elapsed_ms as f32 / dur as f32).clamp(0.0, 1.0);
-        let e = if t < 0.5 {
-            4.0 * t * t * t
-        } else {
-            1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
-        };
-        let center = Vec2 {
-            x: anim.from_center.x + (anim.to_center.x - anim.from_center.x) * e,
-            y: anim.from_center.y + (anim.to_center.y - anim.from_center.y) * e,
-        };
-        set_center(self, center);
-        if t >= 1.0 {
-            self.input.interaction_state.viewport_pan_anim = None;
-        }
+    if now_ms <= anim.start_ms.saturating_add(anim.delay_ms) {
+        set_center(st, anim.from_center);
+        return;
     }
-
-    pub(crate) fn maybe_pan_to_restored_focus_on_close(
-        &mut self,
-        monitor: &str,
-        id: NodeId,
-        now: Instant,
-    ) -> bool {
-        read::maybe_pan_to_restored_focus_on_close(self, monitor, id, now)
+    let dur = anim.duration_ms.max(1);
+    let elapsed_ms = now_ms.saturating_sub(anim.start_ms.saturating_add(anim.delay_ms));
+    let t = (elapsed_ms as f32 / dur as f32).clamp(0.0, 1.0);
+    let e = if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
+    };
+    let center = Vec2 {
+        x: anim.from_center.x + (anim.to_center.x - anim.from_center.x) * e,
+        y: anim.from_center.y + (anim.to_center.y - anim.from_center.y) * e,
+    };
+    set_center(st, center);
+    if t >= 1.0 {
+        st.input.interaction_state.viewport_pan_anim = None;
     }
+}
 
-    pub fn begin_resize_interaction(&mut self, id: NodeId, now: Instant) {
-        self.input.interaction_state.resize_active = Some(id);
-        self.input.interaction_state.resize_static_node = Some(id);
-        self.input.interaction_state.resize_static_lock_pos = None;
-        self.input.interaction_state.resize_static_until_ms =
-            self.now_ms(now).saturating_add(60_000);
-        self.input.interaction_state.suspend_overlap_resolve = true;
-        self.input.interaction_state.suspend_state_checks = true;
-        self.set_interaction_focus(Some(id), 60_000, now);
-        let now_ms = self.now_ms(now);
-        if self.model.field.participates_in_field_activity(id) {
-            let _ = self.model.field.touch(id, now_ms);
-            let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-        }
-        self.model
-            .workspace_state
-            .manual_collapsed_nodes
-            .remove(&id);
-        self.request_maintenance();
-    }
+pub(crate) fn maybe_pan_to_restored_focus_on_close(
+    st: &mut Halley,
+    monitor: &str,
+    id: NodeId,
+    now: Instant,
+) -> bool {
+    read::maybe_pan_to_restored_focus_on_close(st, monitor, id, now)
+}
 
-    pub fn end_resize_interaction(&mut self, now: Instant) {
-        let ended = self.input.interaction_state.resize_active.take();
-        if let Some(id) = ended {
-            self.input.interaction_state.resize_static_node = Some(id);
-            self.input.interaction_state.resize_static_lock_pos =
-                self.model.field.node(id).map(|n| n.pos);
-            self.input.interaction_state.resize_static_until_ms =
-                self.now_ms(now).saturating_add(120);
-            self.set_interaction_focus(Some(id), 30_000, now);
-        } else {
-            self.input.interaction_state.resize_static_lock_pos = None;
-            self.set_interaction_focus(None, 0, now);
-        }
-        self.input.interaction_state.suspend_state_checks = false;
-        self.input.interaction_state.suspend_overlap_resolve = false;
-        self.resolve_surface_overlap();
-        self.request_maintenance();
+pub fn begin_resize_interaction(st: &mut Halley, id: NodeId, now: Instant) {
+    st.input.interaction_state.resize_active = Some(id);
+    st.input.interaction_state.resize_static_node = Some(id);
+    st.input.interaction_state.resize_static_lock_pos = None;
+    st.input.interaction_state.resize_static_until_ms = st.now_ms(now).saturating_add(60_000);
+    st.input.interaction_state.suspend_overlap_resolve = true;
+    st.input.interaction_state.suspend_state_checks = true;
+    st.set_interaction_focus(Some(id), 60_000, now);
+    let now_ms = st.now_ms(now);
+    if st.model.field.participates_in_field_activity(id) {
+        let _ = st.model.field.touch(id, now_ms);
+        let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
     }
+    st.model.workspace_state.manual_collapsed_nodes.remove(&id);
+    st.request_maintenance();
+}
 
-    pub fn resolve_overlap_now(&mut self) {
-        let saved_suspend = self.input.interaction_state.suspend_overlap_resolve;
-        self.input.interaction_state.suspend_overlap_resolve = false;
-        self.resolve_surface_overlap();
-        self.input.interaction_state.suspend_overlap_resolve = saved_suspend;
+pub fn end_resize_interaction(st: &mut Halley, now: Instant) {
+    let ended = st.input.interaction_state.resize_active.take();
+    if let Some(id) = ended {
+        st.input.interaction_state.resize_static_node = Some(id);
+        st.input.interaction_state.resize_static_lock_pos = st.model.field.node(id).map(|n| n.pos);
+        st.input.interaction_state.resize_static_until_ms = st.now_ms(now).saturating_add(120);
+        st.set_interaction_focus(Some(id), 30_000, now);
+    } else {
+        st.input.interaction_state.resize_static_lock_pos = None;
+        st.set_interaction_focus(None, 0, now);
     }
+    st.input.interaction_state.suspend_state_checks = false;
+    st.input.interaction_state.suspend_overlap_resolve = false;
+    st.resolve_surface_overlap();
+    st.request_maintenance();
+}
 
-    pub fn set_last_active_size_now(&mut self, id: NodeId, size: Vec2) {
-        self.model.workspace_state.last_active_size.insert(id, size);
-    }
+pub fn resolve_overlap_now(st: &mut Halley) {
+    let saved_suspend = st.input.interaction_state.suspend_overlap_resolve;
+    st.input.interaction_state.suspend_overlap_resolve = false;
+    st.resolve_surface_overlap();
+    st.input.interaction_state.suspend_overlap_resolve = saved_suspend;
+}
+
+pub fn set_last_active_size_now(st: &mut Halley, id: NodeId, size: Vec2) {
+    st.model.workspace_state.last_active_size.insert(id, size);
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/focus/trail.rs
+++ b/crates/halley-wl/src/compositor/focus/trail.rs
@@ -2,17 +2,7 @@ use super::*;
 use halley_api::TrailDirection;
 use halley_core::decay::DecayLevel;
 use halley_core::trail::Trail;
-use std::ops::{Deref, DerefMut};
 
-pub(crate) struct FocusTrailController<T> {
-    st: T,
-}
-
-pub(crate) fn focus_trail_controller<T>(st: T) -> FocusTrailController<T> {
-    FocusTrailController { st }
-}
-
-#[cfg(test)]
 pub(crate) fn trail_for_monitor_mut<'a>(
     st: &'a mut Halley,
     monitor: &str,
@@ -24,296 +14,257 @@ pub(crate) fn trail_for_monitor_mut<'a>(
         .or_insert_with(Trail::new)
 }
 
-impl<T: Deref<Target = Halley>> Deref for FocusTrailController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
+pub(crate) fn record_focus_trail_visit(st: &mut Halley, id: NodeId) {
+    let monitor = st
+        .model
+        .monitor_state
+        .node_monitor
+        .get(&id)
+        .cloned()
+        .unwrap_or_else(|| st.focused_monitor().to_string());
+    if st
+        .active_cluster_workspace_for_monitor(monitor.as_str())
+        .is_some()
+    {
+        return;
     }
+    let trail_history_length = st.runtime.tuning.trail_history_length;
+    let trail = trail_for_monitor_mut(st, monitor.as_str());
+    if trail.cursor() == Some(id) {
+        return;
+    }
+    trail.record(id);
+    trail.truncate_to(trail_history_length);
 }
 
-impl<T: DerefMut<Target = Halley>> DerefMut for FocusTrailController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
+fn should_keep_trail_node(st: &Halley, id: NodeId) -> bool {
+    st.model.field.node(id).is_some_and(|n| {
+        st.model.field.is_visible(id)
+            && n.kind == halley_core::field::NodeKind::Surface
+            && matches!(
+                n.state,
+                halley_core::field::NodeState::Active | halley_core::field::NodeState::Node
+            )
+    })
 }
 
-impl<T: DerefMut<Target = Halley>> FocusTrailController<T> {
-    pub(crate) fn trail_for_monitor_mut(
-        &mut self,
-        monitor: &str,
-    ) -> &mut halley_core::trail::Trail {
-        self.model
-            .focus_state
-            .focus_trail
-            .entry(monitor.to_string())
-            .or_insert_with(Trail::new)
+fn select_trail_target(st: &mut Halley, id: NodeId, now: Instant) -> bool {
+    let Some(node) = st.model.field.node(id).cloned() else {
+        return false;
+    };
+    if !should_keep_trail_node(st, id) {
+        return false;
     }
 
-    pub(crate) fn record_focus_trail_visit(&mut self, id: NodeId) {
-        let monitor = self
+    st.model.focus_state.suppress_trail_record_once = true;
+    let moved = match node.state {
+        halley_core::field::NodeState::Active => {
+            if crate::compositor::actions::window::focus_from_presentation_navigation(st, id, now) {
+                true
+            } else {
+                let restoring_suspended_fullscreen = st
+                    .model
+                    .fullscreen_state
+                    .fullscreen_suspended_node
+                    .values()
+                    .any(|&nid| nid == id);
+                st.set_interaction_focus(Some(id), 30_000, now);
+                let _ = st.raise_overlap_policy_node(id);
+                if restoring_suspended_fullscreen {
+                    true
+                } else {
+                    st.animate_viewport_center_to(node.pos, now)
+                }
+            }
+        }
+        halley_core::field::NodeState::Node => {
+            if crate::compositor::actions::window::focus_from_presentation_navigation(st, id, now) {
+                true
+            } else {
+                crate::compositor::actions::window::promote_node_level(st, id, now)
+            }
+        }
+        _ => false,
+    };
+
+    if !moved {
+        st.model.focus_state.suppress_trail_record_once = false;
+    }
+
+    if !moved && st.model.field.node(id).is_some() {
+        st.request_maintenance();
+        return true;
+    }
+
+    moved
+}
+
+pub(crate) fn navigate_window_trail(
+    st: &mut Halley,
+    direction: TrailDirection,
+    now: Instant,
+) -> bool {
+    let monitor = st.focused_monitor().to_string();
+    if st
+        .active_cluster_workspace_for_monitor(monitor.as_str())
+        .is_some()
+    {
+        return false;
+    }
+    let trail_wrap = st.runtime.tuning.trail_wrap;
+    let current_focus = st.model.focus_state.primary_interaction_focus;
+    let mut remaining = st
+        .model
+        .focus_state
+        .focus_trail
+        .get(monitor.as_str())
+        .map(|trail| trail.len())
+        .unwrap_or(0)
+        .max(1);
+    loop {
+        if remaining == 0 {
+            return false;
+        }
+        remaining -= 1;
+        let next = {
+            let trail = trail_for_monitor_mut(st, monitor.as_str());
+            match direction {
+                TrailDirection::Prev if trail_wrap => trail.back_wrapping(),
+                TrailDirection::Prev => trail.back(),
+                TrailDirection::Next if trail_wrap => trail.forward_wrapping(),
+                TrailDirection::Next => trail.forward(),
+            }
+        };
+        let Some(id) = next else {
+            return false;
+        };
+        if !should_keep_trail_node(st, id) {
+            trail_for_monitor_mut(st, monitor.as_str()).forget_node(id);
+            continue;
+        }
+        if st
             .model
             .monitor_state
             .node_monitor
             .get(&id)
-            .cloned()
-            .unwrap_or_else(|| self.focused_monitor().to_string());
-        if self
-            .active_cluster_workspace_for_monitor(monitor.as_str())
-            .is_some()
+            .map(|m| m.as_str())
+            != Some(monitor.as_str())
         {
-            return;
+            trail_for_monitor_mut(st, monitor.as_str()).forget_node(id);
+            continue;
         }
-        let trail_history_length = self.runtime.tuning.trail_history_length;
-        let trail = self.trail_for_monitor_mut(monitor.as_str());
-        if trail.cursor() == Some(id) {
-            return;
+        if Some(id) == current_focus {
+            continue;
         }
-        trail.record(id);
-        trail.truncate_to(trail_history_length);
+        return select_trail_target(st, id, now);
     }
+}
 
-    fn should_keep_trail_node(&self, id: NodeId) -> bool {
-        self.model.field.node(id).is_some_and(|n| {
-            self.model.field.is_visible(id)
-                && n.kind == halley_core::field::NodeKind::Surface
-                && matches!(
-                    n.state,
-                    halley_core::field::NodeState::Active | halley_core::field::NodeState::Node
-                )
-        })
+pub(crate) fn previous_window_from_trail_on_close(
+    st: &mut Halley,
+    monitor: &str,
+    closing_id: NodeId,
+) -> Option<NodeId> {
+    if st.active_cluster_workspace_for_monitor(monitor).is_some() {
+        return None;
     }
+    let mut remaining = st
+        .model
+        .focus_state
+        .focus_trail
+        .get(monitor)
+        .map(|trail| trail.len())
+        .unwrap_or(0)
+        .max(1);
 
-    fn select_trail_target(&mut self, id: NodeId, now: Instant) -> bool {
-        let Some(node) = self.model.field.node(id).cloned() else {
-            return false;
-        };
-        if !self.should_keep_trail_node(id) {
-            return false;
-        }
-
-        self.model.focus_state.suppress_trail_record_once = true;
-        let moved = match node.state {
-            halley_core::field::NodeState::Active => {
-                if crate::compositor::actions::window::focus_from_presentation_navigation(
-                    self, id, now,
-                ) {
-                    true
-                } else {
-                    let restoring_suspended_fullscreen = self
-                        .model
-                        .fullscreen_state
-                        .fullscreen_suspended_node
-                        .values()
-                        .any(|&nid| nid == id);
-                    self.set_interaction_focus(Some(id), 30_000, now);
-                    let _ = self.raise_overlap_policy_node(id);
-                    if restoring_suspended_fullscreen {
-                        true
-                    } else {
-                        self.animate_viewport_center_to(node.pos, now)
-                    }
-                }
-            }
-            halley_core::field::NodeState::Node => {
-                if crate::compositor::actions::window::focus_from_presentation_navigation(
-                    self, id, now,
-                ) {
-                    true
-                } else {
-                    crate::compositor::actions::window::promote_node_level(self, id, now)
-                }
-            }
-            _ => false,
-        };
-
-        if !moved {
-            self.model.focus_state.suppress_trail_record_once = false;
-        }
-
-        if !moved && self.model.field.node(id).is_some() {
-            self.request_maintenance();
-            return true;
-        }
-
-        moved
-    }
-
-    pub(crate) fn navigate_window_trail(
-        &mut self,
-        direction: TrailDirection,
-        now: Instant,
-    ) -> bool {
-        let monitor = self.focused_monitor().to_string();
-        if self
-            .active_cluster_workspace_for_monitor(monitor.as_str())
-            .is_some()
-        {
-            return false;
-        }
-        let trail_wrap = self.runtime.tuning.trail_wrap;
-        let current_focus = self.model.focus_state.primary_interaction_focus;
-        let mut remaining = self
-            .model
-            .focus_state
-            .focus_trail
-            .get(monitor.as_str())
-            .map(|trail| trail.len())
-            .unwrap_or(0)
-            .max(1);
-        loop {
-            if remaining == 0 {
-                return false;
-            }
-            remaining -= 1;
-            let next = {
-                let trail = self.trail_for_monitor_mut(monitor.as_str());
-                match direction {
-                    TrailDirection::Prev if trail_wrap => trail.back_wrapping(),
-                    TrailDirection::Prev => trail.back(),
-                    TrailDirection::Next if trail_wrap => trail.forward_wrapping(),
-                    TrailDirection::Next => trail.forward(),
-                }
-            };
-            let Some(id) = next else {
-                return false;
-            };
-            if !self.should_keep_trail_node(id) {
-                self.trail_for_monitor_mut(monitor.as_str()).forget_node(id);
-                continue;
-            }
-            if self
-                .model
-                .monitor_state
-                .node_monitor
-                .get(&id)
-                .map(|m| m.as_str())
-                != Some(monitor.as_str())
-            {
-                self.trail_for_monitor_mut(monitor.as_str()).forget_node(id);
-                continue;
-            }
-            if Some(id) == current_focus {
-                continue;
-            }
-            return self.select_trail_target(id, now);
-        }
-    }
-
-    pub(crate) fn previous_window_from_trail_on_close(
-        &mut self,
-        monitor: &str,
-        closing_id: NodeId,
-    ) -> Option<NodeId> {
-        if self.active_cluster_workspace_for_monitor(monitor).is_some() {
+    loop {
+        if remaining == 0 {
             return None;
         }
-        let mut remaining = self
+        remaining -= 1;
+
+        let next = {
+            let trail = trail_for_monitor_mut(st, monitor);
+            if trail.cursor() != Some(closing_id) {
+                trail.forget_node(closing_id);
+            }
+            trail.back()
+        };
+
+        let Some(id) = next else {
+            return None;
+        };
+        if id == closing_id {
+            continue;
+        }
+        if !should_keep_trail_node(st, id) {
+            trail_for_monitor_mut(st, monitor).forget_node(id);
+            continue;
+        }
+        if st
             .model
-            .focus_state
-            .focus_trail
-            .get(monitor)
-            .map(|trail| trail.len())
-            .unwrap_or(0)
-            .max(1);
-
-        loop {
-            if remaining == 0 {
-                return None;
-            }
-            remaining -= 1;
-
-            let next = {
-                let trail = self.trail_for_monitor_mut(monitor);
-                if trail.cursor() != Some(closing_id) {
-                    trail.forget_node(closing_id);
-                }
-                trail.back()
-            };
-
-            let Some(id) = next else {
-                return None;
-            };
-            if id == closing_id {
-                continue;
-            }
-            if !self.should_keep_trail_node(id) {
-                self.trail_for_monitor_mut(monitor).forget_node(id);
-                continue;
-            }
-            if self
-                .model
-                .monitor_state
-                .node_monitor
-                .get(&id)
-                .map(|m| m.as_str())
-                != Some(monitor)
-            {
-                self.trail_for_monitor_mut(monitor).forget_node(id);
-                continue;
-            }
-            return Some(id);
+            .monitor_state
+            .node_monitor
+            .get(&id)
+            .map(|m| m.as_str())
+            != Some(monitor)
+        {
+            trail_for_monitor_mut(st, monitor).forget_node(id);
+            continue;
         }
+        return Some(id);
+    }
+}
+
+pub(crate) fn restore_focus_to_node_after_close(
+    st: &mut Halley,
+    monitor: &str,
+    id: NodeId,
+    now: Instant,
+    suppress_pan: bool,
+) -> bool {
+    if st.active_cluster_workspace_for_monitor(monitor).is_some() {
+        return false;
+    }
+    let Some(node) = st.model.field.node(id).cloned() else {
+        return false;
+    };
+    if !should_keep_trail_node(st, id) {
+        return false;
     }
 
-    pub(crate) fn restore_focus_to_node_after_close(
-        &mut self,
-        monitor: &str,
-        id: NodeId,
-        now: Instant,
-        suppress_pan: bool,
-    ) -> bool {
-        if self.active_cluster_workspace_for_monitor(monitor).is_some() {
-            return false;
-        }
-        let Some(node) = self.model.field.node(id).cloned() else {
-            return false;
-        };
-        if !self.should_keep_trail_node(id) {
-            return false;
-        }
-
-        self.model.focus_state.suppress_trail_record_once = true;
-        let cluster_local = self.active_cluster_workspace_for_monitor(monitor).is_some();
-        let restored = match node.state {
-            halley_core::field::NodeState::Active => {
-                self.set_interaction_focus(Some(id), 30_000, now);
-                if !cluster_local && !suppress_pan {
-                    self.maybe_pan_to_restored_focus_on_close(monitor, id, now);
-                }
-                true
+    st.model.focus_state.suppress_trail_record_once = true;
+    let cluster_local = st.active_cluster_workspace_for_monitor(monitor).is_some();
+    let restored = match node.state {
+        halley_core::field::NodeState::Active => {
+            st.set_interaction_focus(Some(id), 30_000, now);
+            if !cluster_local && !suppress_pan {
+                st.maybe_pan_to_restored_focus_on_close(monitor, id, now);
             }
-            halley_core::field::NodeState::Node => {
-                self.model
-                    .workspace_state
-                    .manual_collapsed_nodes
-                    .remove(&id);
-                let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-                self.model
-                    .spawn_state
-                    .pending_spawn_activate_at_ms
-                    .remove(&id);
-                crate::compositor::workspace::state::mark_active_transition(
-                    &mut **self,
-                    id,
-                    now,
-                    360,
-                );
-                self.set_interaction_focus(Some(id), 30_000, now);
-                if !cluster_local && !suppress_pan {
-                    self.maybe_pan_to_restored_focus_on_close(monitor, id, now);
-                }
-                true
-            }
-            _ => false,
-        };
-
-        if !restored {
-            self.model.focus_state.suppress_trail_record_once = false;
+            true
         }
+        halley_core::field::NodeState::Node => {
+            st.model.workspace_state.manual_collapsed_nodes.remove(&id);
+            let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+            st.model
+                .spawn_state
+                .pending_spawn_activate_at_ms
+                .remove(&id);
+            crate::compositor::workspace::state::mark_active_transition(st, id, now, 360);
+            st.set_interaction_focus(Some(id), 30_000, now);
+            if !cluster_local && !suppress_pan {
+                st.maybe_pan_to_restored_focus_on_close(monitor, id, now);
+            }
+            true
+        }
+        _ => false,
+    };
 
-        restored
+    if !restored {
+        st.model.focus_state.suppress_trail_record_once = false;
     }
+
+    restored
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/focus/trail.rs
+++ b/crates/halley-wl/src/compositor/focus/trail.rs
@@ -239,7 +239,9 @@ pub(crate) fn restore_focus_to_node_after_close(
         halley_core::field::NodeState::Active => {
             st.set_interaction_focus(Some(id), 30_000, now);
             if !cluster_local && !suppress_pan {
-                st.maybe_pan_to_restored_focus_on_close(monitor, id, now);
+                crate::compositor::focus::system::maybe_pan_to_restored_focus_on_close(
+                    st, monitor, id, now,
+                );
             }
             true
         }
@@ -253,7 +255,9 @@ pub(crate) fn restore_focus_to_node_after_close(
             crate::compositor::workspace::state::mark_active_transition(st, id, now, 360);
             st.set_interaction_focus(Some(id), 30_000, now);
             if !cluster_local && !suppress_pan {
-                st.maybe_pan_to_restored_focus_on_close(monitor, id, now);
+                crate::compositor::focus::system::maybe_pan_to_restored_focus_on_close(
+                    st, monitor, id, now,
+                );
             }
             true
         }

--- a/crates/halley-wl/src/compositor/fullscreen/mod.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/mod.rs
@@ -13,7 +13,6 @@ use smithay::reexports::wayland_server::{
 
 use crate::animation::{AnimSpec, AnimStyle};
 use crate::compositor::activity::{CommitActivity, VisualState};
-use crate::compositor::ctx::FullscreenCtx;
 use crate::compositor::debug_scene::{DebugScene, build_debug_scene};
 use crate::compositor::root::Halley;
 

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -1,45 +1,11 @@
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
-use std::ops::{Deref, DerefMut};
 
 use super::*;
-use crate::compositor::ctx::FullscreenCtx;
 
-impl FullscreenCtx<'_> {
-    pub(crate) fn enter_xdg_fullscreen(
-        &mut self,
-        node_id: NodeId,
-        output: Option<WlOutput>,
-        now: Instant,
-    ) {
-        self.st.enter_xdg_fullscreen(node_id, output, now);
-    }
-
-    pub(crate) fn exit_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        self.st.exit_xdg_fullscreen(node_id, now);
-    }
-}
-
-pub(crate) fn enter_xdg_fullscreen(
-    ctx: &mut FullscreenCtx<'_>,
-    node_id: NodeId,
-    output: Option<WlOutput>,
-    now: Instant,
-) {
-    ctx.enter_xdg_fullscreen(node_id, output, now);
-}
-
-pub(crate) fn exit_xdg_fullscreen(ctx: &mut FullscreenCtx<'_>, node_id: NodeId, now: Instant) {
-    ctx.exit_xdg_fullscreen(node_id, now);
-}
-
-pub(crate) fn on_seat_focus_changed(
-    ctx: &mut FullscreenCtx<'_>,
-    focused: Option<&WlSurface>,
-    now: Instant,
-) {
-    let _ = (ctx, focused, now);
+pub(crate) fn on_seat_focus_changed(st: &mut Halley, focused: Option<&WlSurface>, now: Instant) {
+    let _ = (st, focused, now);
 }
 
 #[cfg(test)]
@@ -875,28 +841,6 @@ mod tests {
     }
 }
 
-pub(crate) struct FullscreenController<T> {
-    st: T,
-}
-
-pub(crate) fn fullscreen_controller<T>(st: T) -> FullscreenController<T> {
-    FullscreenController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for FullscreenController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for FullscreenController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
-
 fn fullscreen_animation_progress(start_ms: u64, duration_ms: u64, now_ms: u64) -> f32 {
     let elapsed = now_ms.saturating_sub(start_ms);
     let t = (elapsed as f32 / duration_ms.max(1) as f32).clamp(0.0, 1.0);
@@ -1018,738 +962,719 @@ pub(crate) fn is_fullscreen_session_node(st: &Halley, node_id: NodeId) -> bool {
             .any(|&id| id == node_id)
 }
 
-impl<T: DerefMut<Target = Halley>> FullscreenController<T> {
-    fn fullscreen_monitor_name(&self, node_id: NodeId, output: Option<&WlOutput>) -> String {
-        output
-            .and_then(|requested_output| {
-                self.model
-                    .monitor_state
-                    .outputs
-                    .iter()
-                    .find_map(|(name, output)| {
-                        output.owns(requested_output).then_some(name.clone())
-                    })
-            })
-            .or_else(|| self.model.monitor_state.node_monitor.get(&node_id).cloned())
-            .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone())
-    }
+fn fullscreen_monitor_name(st: &Halley, node_id: NodeId, output: Option<&WlOutput>) -> String {
+    output
+        .and_then(|requested_output| {
+            st.model
+                .monitor_state
+                .outputs
+                .iter()
+                .find_map(|(name, output)| output.owns(requested_output).then_some(name.clone()))
+        })
+        .or_else(|| st.model.monitor_state.node_monitor.get(&node_id).cloned())
+        .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone())
+}
 
-    fn fullscreen_monitor_view(&self, monitor_name: &str) -> (Vec2, Vec2) {
-        self.model
-            .monitor_state
-            .monitors
-            .get(monitor_name)
-            .map(|monitor| (monitor.viewport.center, monitor.viewport.size))
-            .unwrap_or((self.model.viewport.center, self.model.viewport.size))
-    }
+fn fullscreen_monitor_view(st: &Halley, monitor_name: &str) -> (Vec2, Vec2) {
+    st.model
+        .monitor_state
+        .monitors
+        .get(monitor_name)
+        .map(|monitor| (monitor.viewport.center, monitor.viewport.size))
+        .unwrap_or((st.model.viewport.center, st.model.viewport.size))
+}
 
-    fn reset_monitor_zoom_once(&mut self, monitor_name: &str) {
-        if let Some(monitor) = self.model.monitor_state.monitors.get_mut(monitor_name) {
-            monitor.zoom_ref_size = monitor.viewport.size;
-            monitor.camera_target_view_size = monitor.viewport.size;
+fn reset_monitor_zoom_once(st: &mut Halley, monitor_name: &str) {
+    if let Some(monitor) = st.model.monitor_state.monitors.get_mut(monitor_name) {
+        monitor.zoom_ref_size = monitor.viewport.size;
+        monitor.camera_target_view_size = monitor.viewport.size;
+    }
+    if st.model.monitor_state.current_monitor == monitor_name {
+        st.model.zoom_ref_size = st.model.viewport.size;
+        st.model.camera_target_view_size = st.model.viewport.size;
+    }
+}
+
+fn fullscreen_target_size_for(st: &Halley, monitor_name: &str) -> (i32, i32) {
+    st.model
+        .monitor_state
+        .outputs
+        .get(monitor_name)
+        .and_then(|output| output.current_mode())
+        .map(|mode| (mode.size.w, mode.size.h))
+        .unwrap_or_else(|| {
+            let (_, size) = fullscreen_monitor_view(st, monitor_name);
+            (
+                size.x.round().max(96.0) as i32,
+                size.y.round().max(72.0) as i32,
+            )
+        })
+}
+
+fn fullscreen_suspended_monitor_for_node(st: &Halley, node_id: NodeId) -> Option<&str> {
+    st.model
+        .fullscreen_state
+        .fullscreen_suspended_node
+        .iter()
+        .find_map(|(monitor, &id)| (id == node_id).then_some(monitor.as_str()))
+}
+
+fn fullscreen_restore_entries_for_monitor(
+    st: &Halley,
+    monitor_name: &str,
+    exclude_node: Option<NodeId>,
+) -> Vec<(
+    NodeId,
+    crate::compositor::fullscreen::state::FullscreenSessionEntry,
+)> {
+    let (monitor_viewport_center, _) = fullscreen_monitor_view(st, monitor_name);
+    st.model
+        .fullscreen_state
+        .fullscreen_restore
+        .iter()
+        .filter(|&(&id, entry)| {
+            if exclude_node == Some(id) {
+                return false;
+            }
+            let matches_saved_viewport =
+                (entry.viewport_center.x - monitor_viewport_center.x).abs() < 1.0
+                    && (entry.viewport_center.y - monitor_viewport_center.y).abs() < 1.0;
+            let matches_assigned_monitor = st
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&id)
+                .is_some_and(|node_monitor| node_monitor == monitor_name);
+            matches_saved_viewport || matches_assigned_monitor
+        })
+        .map(|(&id, &entry)| (id, entry))
+        .collect()
+}
+
+fn clear_non_target_fullscreen_restore_entries(
+    st: &mut Halley,
+    monitor_name: &str,
+    target: NodeId,
+) {
+    let stale = fullscreen_restore_entries_for_monitor(st, monitor_name, Some(target))
+        .into_iter()
+        .collect::<Vec<_>>();
+    for (id, entry) in stale {
+        let _ = st.model.field.set_pinned(id, entry.pinned);
+        st.input.interaction_state.physics_velocity.remove(&id);
+        st.model.fullscreen_state.fullscreen_restore.remove(&id);
+        st.model.fullscreen_state.fullscreen_motion.remove(&id);
+        st.model.fullscreen_state.fullscreen_scale_anim.remove(&id);
+    }
+}
+
+fn request_toplevel_fullscreen_state(
+    st: &mut Halley,
+    node_id: NodeId,
+    fullscreen: bool,
+    output: Option<WlOutput>,
+    size: Option<(i32, i32)>,
+) {
+    let monitor_name = if fullscreen {
+        fullscreen_monitor_name(st, node_id, output.as_ref())
+    } else {
+        fullscreen_monitor_for_node(st, node_id)
+            .map(str::to_string)
+            .or_else(|| st.model.monitor_state.node_monitor.get(&node_id).cloned())
+            .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone())
+    };
+    let focused_node = st
+        .last_input_surface_node_for_monitor(monitor_name.as_str())
+        .or_else(|| st.last_input_surface_node());
+    let bounds_size = if fullscreen {
+        size.unwrap_or_else(|| fullscreen_target_size_for(st, monitor_name.as_str()))
+    } else {
+        let view = st.usable_viewport_for_monitor(&monitor_name);
+        (view.size.x as i32, view.size.y as i32)
+    };
+    for top in st.platform.xdg_shell_state.toplevel_surfaces() {
+        let wl = top.wl_surface();
+        let key = wl.id();
+        if st.model.surface_to_node.get(&key).copied() != Some(node_id) {
+            continue;
         }
-        if self.model.monitor_state.current_monitor == monitor_name {
-            self.model.zoom_ref_size = self.model.viewport.size;
-            self.model.camera_target_view_size = self.model.viewport.size;
-        }
+        let (min_w, min_h) = crate::compositor::surface::toplevel_min_size_for_node(st, node_id);
+        top.with_pending_state(|s| {
+            s.size = size.map(|(w, h)| (w.max(min_w).max(96), h.max(min_h).max(72)).into());
+            s.bounds = Some((bounds_size.0.max(96), bounds_size.1.max(72)).into());
+            if focused_node == Some(node_id) {
+                s.states.set(xdg_toplevel::State::Activated);
+            } else {
+                s.states.unset(xdg_toplevel::State::Activated);
+            }
+            if fullscreen {
+                s.states.set(xdg_toplevel::State::Fullscreen);
+                s.fullscreen_output = output;
+            } else {
+                s.states.unset(xdg_toplevel::State::Fullscreen);
+                s.fullscreen_output = None;
+            }
+            st.apply_toplevel_tiled_hint(s);
+        });
+        top.send_configure();
+        break;
     }
+}
 
-    fn fullscreen_target_size_for(&self, monitor_name: &str) -> (i32, i32) {
-        self.model
-            .monitor_state
-            .outputs
-            .get(monitor_name)
-            .and_then(|output| output.current_mode())
-            .map(|mode| (mode.size.w, mode.size.h))
-            .unwrap_or_else(|| {
-                let (_, size) = self.fullscreen_monitor_view(monitor_name);
-                (
-                    size.x.round().max(96.0) as i32,
-                    size.y.round().max(72.0) as i32,
-                )
-            })
-    }
+/// Returns the monitor name that `node_id` is currently fullscreened on, if any.
+fn exit_xdg_fullscreen_inner(
+    st: &mut Halley,
+    node_id: NodeId,
+    now: Instant,
+    suspend: bool,
+    preserve_client_fullscreen: bool,
+) {
+    // Find which monitor this node is fullscreened on.
+    let monitor_name = match fullscreen_monitor_for_node(st, node_id) {
+        Some(m) => m.to_owned(),
+        None => return, // not active fullscreen on any monitor
+    };
 
-    fn fullscreen_suspended_monitor_for_node(&self, node_id: NodeId) -> Option<&str> {
-        self.model
+    st.model
+        .fullscreen_state
+        .clear_direct_scanout_for_monitor(&monitor_name);
+
+    st.input.interaction_state.reset_input_state_requested = true;
+
+    if suspend {
+        st.model
             .fullscreen_state
             .fullscreen_suspended_node
-            .iter()
-            .find_map(|(monitor, &id)| (id == node_id).then_some(monitor.as_str()))
-    }
-
-    fn fullscreen_restore_entries_for_monitor(
-        &self,
-        monitor_name: &str,
-        exclude_node: Option<NodeId>,
-    ) -> Vec<(
-        NodeId,
-        crate::compositor::fullscreen::state::FullscreenSessionEntry,
-    )> {
-        let (monitor_viewport_center, _) = self.fullscreen_monitor_view(monitor_name);
-        self.model
-            .fullscreen_state
-            .fullscreen_restore
-            .iter()
-            .filter(|&(&id, entry)| {
-                if exclude_node == Some(id) {
-                    return false;
-                }
-                let matches_saved_viewport =
-                    (entry.viewport_center.x - monitor_viewport_center.x).abs() < 1.0
-                        && (entry.viewport_center.y - monitor_viewport_center.y).abs() < 1.0;
-                let matches_assigned_monitor = self
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&id)
-                    .is_some_and(|node_monitor| node_monitor == monitor_name);
-                matches_saved_viewport || matches_assigned_monitor
-            })
-            .map(|(&id, &entry)| (id, entry))
-            .collect()
-    }
-
-    fn clear_non_target_fullscreen_restore_entries(&mut self, monitor_name: &str, target: NodeId) {
-        let stale = self
-            .fullscreen_restore_entries_for_monitor(monitor_name, Some(target))
-            .into_iter()
-            .collect::<Vec<_>>();
-        for (id, entry) in stale {
-            let _ = self.model.field.set_pinned(id, entry.pinned);
-            self.input.interaction_state.physics_velocity.remove(&id);
-            self.model.fullscreen_state.fullscreen_restore.remove(&id);
-            self.model.fullscreen_state.fullscreen_motion.remove(&id);
-            self.model
+            .insert(monitor_name.clone(), node_id);
+        if preserve_client_fullscreen {
+            st.model
                 .fullscreen_state
-                .fullscreen_scale_anim
-                .remove(&id);
-        }
-    }
-
-    fn request_toplevel_fullscreen_state(
-        &mut self,
-        node_id: NodeId,
-        fullscreen: bool,
-        output: Option<WlOutput>,
-        size: Option<(i32, i32)>,
-    ) {
-        let monitor_name = if fullscreen {
-            self.fullscreen_monitor_name(node_id, output.as_ref())
-        } else {
-            self.fullscreen_monitor_for_node(node_id)
-                .map(str::to_string)
-                .or_else(|| self.model.monitor_state.node_monitor.get(&node_id).cloned())
-                .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone())
-        };
-        let focused_node = self
-            .last_input_surface_node_for_monitor(monitor_name.as_str())
-            .or_else(|| self.last_input_surface_node());
-        let bounds_size = if fullscreen {
-            size.unwrap_or_else(|| self.fullscreen_target_size_for(monitor_name.as_str()))
-        } else {
-            let view = self.usable_viewport_for_monitor(&monitor_name);
-            (view.size.x as i32, view.size.y as i32)
-        };
-        for top in self.platform.xdg_shell_state.toplevel_surfaces() {
-            let wl = top.wl_surface();
-            let key = wl.id();
-            if self.model.surface_to_node.get(&key).copied() != Some(node_id) {
-                continue;
-            }
-            let (min_w, min_h) =
-                crate::compositor::surface::toplevel_min_size_for_node(self, node_id);
-            top.with_pending_state(|s| {
-                s.size = size.map(|(w, h)| (w.max(min_w).max(96), h.max(min_h).max(72)).into());
-                s.bounds = Some((bounds_size.0.max(96), bounds_size.1.max(72)).into());
-                if focused_node == Some(node_id) {
-                    s.states.set(xdg_toplevel::State::Activated);
-                } else {
-                    s.states.unset(xdg_toplevel::State::Activated);
-                }
-                if fullscreen {
-                    s.states.set(xdg_toplevel::State::Fullscreen);
-                    s.fullscreen_output = output;
-                } else {
-                    s.states.unset(xdg_toplevel::State::Fullscreen);
-                    s.fullscreen_output = None;
-                }
-                self.apply_toplevel_tiled_hint(s);
-            });
-            top.send_configure();
-            break;
-        }
-    }
-
-    /// Returns the monitor name that `node_id` is currently fullscreened on, if any.
-    fn exit_xdg_fullscreen_inner(
-        &mut self,
-        node_id: NodeId,
-        now: Instant,
-        suspend: bool,
-        preserve_client_fullscreen: bool,
-    ) {
-        // Find which monitor this node is fullscreened on.
-        let monitor_name = match self.fullscreen_monitor_for_node(node_id) {
-            Some(m) => m.to_owned(),
-            None => return, // not active fullscreen on any monitor
-        };
-
-        self.model
-            .fullscreen_state
-            .clear_direct_scanout_for_monitor(&monitor_name);
-
-        self.input.interaction_state.reset_input_state_requested = true;
-
-        if suspend {
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
+                .fullscreen_soft_suspended_node
                 .insert(monitor_name.clone(), node_id);
-            if preserve_client_fullscreen {
-                self.model
-                    .fullscreen_state
-                    .fullscreen_soft_suspended_node
-                    .insert(monitor_name.clone(), node_id);
-            } else {
-                self.model
-                    .fullscreen_state
-                    .fullscreen_soft_suspended_node
-                    .remove(&monitor_name);
-            }
         } else {
-            // If we're doing a hard exit, clear any suspended state for this monitor too.
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .remove(&monitor_name);
-            self.model
+            st.model
                 .fullscreen_state
                 .fullscreen_soft_suspended_node
                 .remove(&monitor_name);
         }
-
-        // Genuine exit (not a suspend or client-fullscreen release): ease the monitor
-        // camera back to the zoom/center captured on entry, matching the window's
-        // shrink animation, so we don't stay plopped at 1.0 zoom.
-        if !suspend && !preserve_client_fullscreen {
-            if let Some(camera) = self
-                .model
-                .fullscreen_state
-                .fullscreen_camera_restore
-                .remove(&monitor_name)
-            {
-                crate::compositor::workspace::state::set_monitor_camera_target_snapshot(
-                    self,
-                    &monitor_name,
-                    camera,
-                );
-            }
-        }
-
-        self.clear_non_target_fullscreen_restore_entries(&monitor_name, node_id);
-
-        // A hard exit on the current monitor animates the window shrinking back
-        // to its restored geometry. Capture the current full visual rect now,
-        // while the node is still the active fullscreen node, so the anim can
-        // ease from it (the node leaves active state below).
-        let should_animate = !suspend
-            && !preserve_client_fullscreen
-            && self.runtime.tuning.fullscreen_animation_enabled()
-            && self.model.monitor_state.current_monitor == monitor_name;
-        let exit_anim_from = should_animate.then(|| {
-            fullscreen_visual_for_node_on_current_monitor_at(self, node_id, now)
-                .unwrap_or_else(|| self.fullscreen_monitor_view(&monitor_name))
-        });
-
-        let restore_entry = self
-            .model
+    } else {
+        // If we're doing a hard exit, clear any suspended state for this monitor too.
+        st.model
             .fullscreen_state
-            .fullscreen_restore
-            .get(&node_id)
-            .copied();
-        if let Some(entry) = restore_entry {
-            self.restore_fullscreen_snapshot(node_id, entry);
-        }
-
-        if preserve_client_fullscreen {
-            // Keep the xdg-toplevel protocol fullscreen state intact while the
-            // compositor releases its local fullscreen layout lock.
-        } else if let Some(entry) = self
-            .model
-            .fullscreen_state
-            .fullscreen_restore
-            .get(&node_id)
-            .copied()
-        {
-            let (min_w, min_h) =
-                crate::compositor::surface::toplevel_min_size_for_node(self, node_id);
-            self.request_toplevel_fullscreen_state(
-                node_id,
-                false,
-                None,
-                Some((
-                    entry.size.x.round().max(min_w as f32).max(96.0) as i32,
-                    entry.size.y.round().max(min_h as f32).max(72.0) as i32,
-                )),
-            );
-        } else {
-            self.request_toplevel_fullscreen_state(node_id, false, None, None);
-        }
-
-        self.model
-            .fullscreen_state
-            .fullscreen_active_node
+            .fullscreen_suspended_node
             .remove(&monitor_name);
-        if let Some(from) = exit_anim_from {
-            // Reverse anim: shrink from the full rect back to the restored
-            // geometry. The node is no longer active, but the lingering
-            // scale anim keeps driving `fullscreen_visual_*` as a pure visual
-            // overlay until it expires in `tick_fullscreen_motion`.
-            let to = crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
-                self, node_id, now,
+        st.model
+            .fullscreen_state
+            .fullscreen_soft_suspended_node
+            .remove(&monitor_name);
+    }
+
+    // Genuine exit (not a suspend or client-fullscreen release): ease the monitor
+    // camera back to the zoom/center captured on entry, matching the window's
+    // shrink animation, so we don't stay plopped at 1.0 zoom.
+    if !suspend && !preserve_client_fullscreen {
+        if let Some(camera) = st
+            .model
+            .fullscreen_state
+            .fullscreen_camera_restore
+            .remove(&monitor_name)
+        {
+            crate::compositor::workspace::state::set_monitor_camera_target_snapshot(
+                st,
+                &monitor_name,
+                camera,
+            );
+        }
+    }
+
+    clear_non_target_fullscreen_restore_entries(st, &monitor_name, node_id);
+
+    // A hard exit on the current monitor animates the window shrinking back
+    // to its restored geometry. Capture the current full visual rect now,
+    // while the node is still the active fullscreen node, so the anim can
+    // ease from it (the node leaves active state below).
+    let should_animate = !suspend
+        && !preserve_client_fullscreen
+        && st.runtime.tuning.fullscreen_animation_enabled()
+        && st.model.monitor_state.current_monitor == monitor_name;
+    let exit_anim_from = should_animate.then(|| {
+        fullscreen_visual_for_node_on_current_monitor_at(st, node_id, now)
+            .unwrap_or_else(|| fullscreen_monitor_view(st, &monitor_name))
+    });
+
+    let restore_entry = st
+        .model
+        .fullscreen_state
+        .fullscreen_restore
+        .get(&node_id)
+        .copied();
+    if let Some(entry) = restore_entry {
+        restore_fullscreen_snapshot(st, node_id, entry);
+    }
+
+    if preserve_client_fullscreen {
+        // Keep the xdg-toplevel protocol fullscreen state intact while the
+        // compositor releases its local fullscreen layout lock.
+    } else if let Some(entry) = st
+        .model
+        .fullscreen_state
+        .fullscreen_restore
+        .get(&node_id)
+        .copied()
+    {
+        let (min_w, min_h) = crate::compositor::surface::toplevel_min_size_for_node(st, node_id);
+        request_toplevel_fullscreen_state(
+            st,
+            node_id,
+            false,
+            None,
+            Some((
+                entry.size.x.round().max(min_w as f32).max(96.0) as i32,
+                entry.size.y.round().max(min_h as f32).max(72.0) as i32,
+            )),
+        );
+    } else {
+        request_toplevel_fullscreen_state(st, node_id, false, None, None);
+    }
+
+    st.model
+        .fullscreen_state
+        .fullscreen_active_node
+        .remove(&monitor_name);
+    if let Some(from) = exit_anim_from {
+        // Reverse anim: shrink from the full rect back to the restored
+        // geometry. The node is no longer active, but the lingering
+        // scale anim keeps driving `fullscreen_visual_*` as a pure visual
+        // overlay until it expires in `tick_fullscreen_motion`.
+        let to =
+            crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                st, node_id, now,
             )
             .or_else(|| restore_entry.map(|entry| (entry.pos, entry.size)))
             .unwrap_or(from);
-            let start_ms = self.now_ms(now);
-            let duration_ms = self.runtime.tuning.fullscreen_animation_duration_ms();
-            self.model.fullscreen_state.fullscreen_scale_anim.insert(
-                node_id,
-                crate::compositor::fullscreen::state::FullscreenScaleAnim {
-                    monitor: monitor_name.clone(),
-                    from_pos: from.0,
-                    to_pos: to.0,
-                    from_size: from.1,
-                    to_size: to.1,
-                    start_ms,
-                    duration_ms,
-                },
-            );
-        } else {
-            self.model
-                .fullscreen_state
-                .fullscreen_scale_anim
-                .remove(&node_id);
-        }
-        self.model
-            .fullscreen_state
-            .fullscreen_origin
-            .remove(&node_id);
-        if !suspend {
-            self.model
-                .fullscreen_state
-                .fullscreen_restore
-                .remove(&node_id);
-        }
-        self.request_maintenance();
-    }
-
-    pub(crate) fn soft_suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        self.exit_xdg_fullscreen_inner(node_id, now, true, true);
-    }
-
-    fn restore_fullscreen_snapshot(
-        &mut self,
-        id: NodeId,
-        entry: crate::compositor::fullscreen::state::FullscreenSessionEntry,
-    ) {
-        if let Some(node) = self.model.field.node_mut(id) {
-            node.pos = entry.pos;
-            node.intrinsic_size = entry.intrinsic_size;
-        }
-        let _ = self.model.field.sync_active_footprint_to_intrinsic(id);
-        if let Some(loc) = entry.bbox_loc {
-            self.ui.render_state.cache.bbox_loc.insert(id, loc);
-        } else {
-            self.ui.render_state.cache.bbox_loc.remove(&id);
-        }
-        if let Some(geo) = entry.window_geometry {
-            self.ui.render_state.cache.window_geometry.insert(id, geo);
-        } else {
-            self.ui.render_state.cache.window_geometry.remove(&id);
-        }
-        self.set_last_active_size_now(id, entry.intrinsic_size);
-    }
-
-    pub(crate) fn enter_xdg_fullscreen(
-        &mut self,
-        node_id: NodeId,
-        output: Option<WlOutput>,
-        now: Instant,
-    ) {
-        self.enter_fullscreen(
+        let start_ms = st.now_ms(now);
+        let duration_ms = st.runtime.tuning.fullscreen_animation_duration_ms();
+        st.model.fullscreen_state.fullscreen_scale_anim.insert(
             node_id,
-            output,
-            now,
-            crate::compositor::fullscreen::state::FullscreenOrigin::ClientRequest,
-        )
-    }
-
-    pub(crate) fn enter_user_fullscreen(
-        &mut self,
-        node_id: NodeId,
-        output: Option<WlOutput>,
-        now: Instant,
-    ) {
-        self.enter_fullscreen(
-            node_id,
-            output,
-            now,
-            crate::compositor::fullscreen::state::FullscreenOrigin::UserKeybind,
-        )
-    }
-
-    fn enter_fullscreen(
-        &mut self,
-        node_id: NodeId,
-        output: Option<WlOutput>,
-        now: Instant,
-        origin: crate::compositor::fullscreen::state::FullscreenOrigin,
-    ) {
-        let monitor_name = self.fullscreen_monitor_name(node_id, output.as_ref());
-
-        self.model
-            .fullscreen_state
-            .clear_direct_scanout_for_monitor(&monitor_name);
-
-        // Already fullscreen on this monitor — no-op.
-        if self
-            .model
-            .fullscreen_state
-            .fullscreen_active_node
-            .get(&monitor_name)
-            == Some(&node_id)
-        {
-            self.model
-                .fullscreen_state
-                .fullscreen_origin
-                .insert(node_id, origin);
-            if origin == crate::compositor::fullscreen::state::FullscreenOrigin::ClientRequest {
-                let target_size = self.fullscreen_target_size_for(monitor_name.as_str());
-                self.request_toplevel_fullscreen_state(node_id, true, output, Some(target_size));
-            }
-            return;
-        }
-
-        let soft_resume = self
-            .model
-            .fullscreen_state
-            .fullscreen_soft_suspended_node
-            .get(&monitor_name)
-            == Some(&node_id);
-
-        if soft_resume {
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .remove(&monitor_name);
-            self.model
-                .fullscreen_state
-                .fullscreen_soft_suspended_node
-                .remove(&monitor_name);
-        } else {
-            // Clear any suspended state for this monitor.
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .remove(&monitor_name);
-            self.model
-                .fullscreen_state
-                .fullscreen_soft_suspended_node
-                .remove(&monitor_name);
-        }
-
-        // If another window is fullscreened on the same monitor, exit it first.
-        if let Some(existing) = self
-            .model
-            .fullscreen_state
-            .fullscreen_active_node
-            .get(&monitor_name)
-            .copied()
-        {
-            self.exit_xdg_fullscreen(existing, now);
-        }
-
-        let target_size = self.fullscreen_target_size_for(monitor_name.as_str());
-        let (viewport_center, viewport_size) = self.fullscreen_monitor_view(monitor_name.as_str());
-        self.clear_non_target_fullscreen_restore_entries(&monitor_name, node_id);
-
-        // Capture the pre-fullscreen camera (zoom + center) once per monitor so exiting
-        // fullscreen returns to it instead of staying at 1.0. `or_insert` keeps the
-        // original across fullscreen→fullscreen swaps and soft suspend/resume.
-        let pre_fullscreen_camera = crate::compositor::workspace::state::snapshot_monitor_camera(
-            self,
-            monitor_name.as_str(),
-        );
-        self.model
-            .fullscreen_state
-            .fullscreen_camera_restore
-            .entry(monitor_name.clone())
-            .or_insert(pre_fullscreen_camera);
-
-        // One-time reset of the target monitor's zoom to 1.0. Do not hold or lock it.
-        self.reset_monitor_zoom_once(monitor_name.as_str());
-
-        let Some(node) = self.model.field.node(node_id).cloned() else {
-            return;
-        };
-
-        let soft_resume_entry = soft_resume
-            .then(|| {
-                self.model
-                    .fullscreen_state
-                    .fullscreen_restore
-                    .get(&node_id)
-                    .copied()
-            })
-            .flatten();
-        let saved_size = soft_resume_entry
-            .map(|entry| entry.size)
-            .unwrap_or_else(|| {
-                crate::compositor::surface::current_surface_size_for_node(self, node_id)
-                    .unwrap_or(node.intrinsic_size)
-            });
-        let saved_bbox_loc = soft_resume_entry
-            .and_then(|entry| entry.bbox_loc)
-            .or_else(|| self.ui.render_state.cache.bbox_loc.get(&node_id).copied());
-        let saved_window_geometry = soft_resume_entry
-            .and_then(|entry| entry.window_geometry)
-            .or_else(|| {
-                self.ui
-                    .render_state
-                    .cache
-                    .window_geometry
-                    .get(&node_id)
-                    .copied()
-            });
-        let saved_pos = soft_resume_entry.map(|entry| entry.pos).unwrap_or(node.pos);
-        let saved_intrinsic_size = soft_resume_entry
-            .map(|entry| entry.intrinsic_size)
-            .unwrap_or(node.intrinsic_size);
-        let saved_pinned = soft_resume_entry
-            .map(|entry| entry.pinned)
-            .unwrap_or(node.pinned);
-
-        self.model.fullscreen_state.fullscreen_restore.insert(
-            node_id,
-            crate::compositor::fullscreen::state::FullscreenSessionEntry {
-                pos: saved_pos,
-                size: saved_size,
-                viewport_center,
-                intrinsic_size: saved_intrinsic_size,
-                bbox_loc: saved_bbox_loc,
-                window_geometry: saved_window_geometry,
-                pinned: saved_pinned,
+            crate::compositor::fullscreen::state::FullscreenScaleAnim {
+                monitor: monitor_name.clone(),
+                from_pos: from.0,
+                to_pos: to.0,
+                from_size: from.1,
+                to_size: to.1,
+                start_ms,
+                duration_ms,
             },
         );
-        if self.runtime.tuning.fullscreen_animation_enabled() && !soft_resume {
-            self.request_window_animation_prewarm(node_id, now);
-            let from = (self.model.monitor_state.current_monitor == monitor_name)
-                .then(|| {
-                    crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
-                        self,
-                        node_id,
-                        now,
-                    )
-                })
-                .flatten()
-                .unwrap_or((saved_pos, saved_size));
-            let start_ms = self.now_ms(now);
-            let duration_ms = self.runtime.tuning.fullscreen_animation_duration_ms();
-            self.model.fullscreen_state.fullscreen_scale_anim.insert(
-                node_id,
-                crate::compositor::fullscreen::state::FullscreenScaleAnim {
-                    monitor: monitor_name.clone(),
-                    from_pos: from.0,
-                    to_pos: viewport_center,
-                    from_size: from.1,
-                    to_size: viewport_size,
-                    start_ms,
-                    duration_ms,
-                },
-            );
-        } else {
-            self.model
-                .fullscreen_state
-                .fullscreen_scale_anim
-                .remove(&node_id);
-        }
-        if !soft_resume {
-            self.request_toplevel_fullscreen_state(node_id, true, output, Some(target_size));
-        }
-        self.assign_node_to_monitor(node_id, monitor_name.as_str());
-        self.model
+    } else {
+        st.model
             .fullscreen_state
-            .fullscreen_active_node
-            .insert(monitor_name, node_id);
-        self.model
+            .fullscreen_scale_anim
+            .remove(&node_id);
+    }
+    st.model.fullscreen_state.fullscreen_origin.remove(&node_id);
+    if !suspend {
+        st.model
+            .fullscreen_state
+            .fullscreen_restore
+            .remove(&node_id);
+    }
+    st.request_maintenance();
+}
+
+pub(crate) fn soft_suspend_xdg_fullscreen(st: &mut Halley, node_id: NodeId, now: Instant) {
+    exit_xdg_fullscreen_inner(st, node_id, now, true, true);
+}
+
+fn restore_fullscreen_snapshot(
+    st: &mut Halley,
+    id: NodeId,
+    entry: crate::compositor::fullscreen::state::FullscreenSessionEntry,
+) {
+    if let Some(node) = st.model.field.node_mut(id) {
+        node.pos = entry.pos;
+        node.intrinsic_size = entry.intrinsic_size;
+    }
+    let _ = st.model.field.sync_active_footprint_to_intrinsic(id);
+    if let Some(loc) = entry.bbox_loc {
+        st.ui.render_state.cache.bbox_loc.insert(id, loc);
+    } else {
+        st.ui.render_state.cache.bbox_loc.remove(&id);
+    }
+    if let Some(geo) = entry.window_geometry {
+        st.ui.render_state.cache.window_geometry.insert(id, geo);
+    } else {
+        st.ui.render_state.cache.window_geometry.remove(&id);
+    }
+    st.set_last_active_size_now(id, entry.intrinsic_size);
+}
+
+pub(crate) fn enter_xdg_fullscreen(
+    st: &mut Halley,
+    node_id: NodeId,
+    output: Option<WlOutput>,
+    now: Instant,
+) {
+    enter_fullscreen(
+        st,
+        node_id,
+        output,
+        now,
+        crate::compositor::fullscreen::state::FullscreenOrigin::ClientRequest,
+    )
+}
+
+pub(crate) fn enter_user_fullscreen(
+    st: &mut Halley,
+    node_id: NodeId,
+    output: Option<WlOutput>,
+    now: Instant,
+) {
+    enter_fullscreen(
+        st,
+        node_id,
+        output,
+        now,
+        crate::compositor::fullscreen::state::FullscreenOrigin::UserKeybind,
+    )
+}
+
+fn enter_fullscreen(
+    st: &mut Halley,
+    node_id: NodeId,
+    output: Option<WlOutput>,
+    now: Instant,
+    origin: crate::compositor::fullscreen::state::FullscreenOrigin,
+) {
+    let monitor_name = fullscreen_monitor_name(st, node_id, output.as_ref());
+
+    st.model
+        .fullscreen_state
+        .clear_direct_scanout_for_monitor(&monitor_name);
+
+    // Already fullscreen on this monitor — no-op.
+    if st
+        .model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(&monitor_name)
+        == Some(&node_id)
+    {
+        st.model
             .fullscreen_state
             .fullscreen_origin
             .insert(node_id, origin);
-        self.set_interaction_focus(Some(node_id), 30_000, now);
-        let _ = self.raise_overlap_policy_node(node_id);
-        self.request_maintenance();
+        if origin == crate::compositor::fullscreen::state::FullscreenOrigin::ClientRequest {
+            let target_size = fullscreen_target_size_for(st, monitor_name.as_str());
+            request_toplevel_fullscreen_state(st, node_id, true, output, Some(target_size));
+        }
+        return;
     }
 
-    pub(crate) fn exit_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        if !self.is_fullscreen_active(node_id)
-            && let Some(monitor) = self
-                .fullscreen_suspended_monitor_for_node(node_id)
-                .map(str::to_string)
-        {
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .remove(&monitor);
-            self.model
-                .fullscreen_state
-                .fullscreen_active_node
-                .insert(monitor, node_id);
-        }
-        // Clear suspended state on whatever monitor this node is on.
-        if let Some(monitor) = self
-            .fullscreen_monitor_for_node(node_id)
-            .map(|s| s.to_owned())
-        {
-            self.model
-                .fullscreen_state
-                .fullscreen_suspended_node
-                .remove(&monitor);
-        }
-        self.exit_xdg_fullscreen_inner(node_id, now, false, false);
-    }
+    let soft_resume = st
+        .model
+        .fullscreen_state
+        .fullscreen_soft_suspended_node
+        .get(&monitor_name)
+        == Some(&node_id);
 
-    pub(crate) fn drop_fullscreen_surface(&mut self, id: NodeId, _now: Instant) {
-        if !self.is_fullscreen_active(id)
-            && let Some(monitor) = self
-                .fullscreen_suspended_monitor_for_node(id)
-                .map(str::to_string)
-        {
-            self.model
-                .fullscreen_state
-                .fullscreen_active_node
-                .insert(monitor, id);
-        }
-
-        // Clear suspended state if this node was suspended on any monitor.
-        self.model
+    if soft_resume {
+        st.model
             .fullscreen_state
             .fullscreen_suspended_node
-            .retain(|_, &mut nid| nid != id);
-        self.model
+            .remove(&monitor_name);
+        st.model
             .fullscreen_state
             .fullscreen_soft_suspended_node
-            .retain(|_, &mut nid| nid != id);
-
-        if self.is_fullscreen_active(id) {
-            let monitor_name = self
-                .fullscreen_monitor_for_node(id)
-                .map(|s| s.to_owned())
-                .unwrap(); // safe: is_fullscreen_active just confirmed it
-
-            self.input.interaction_state.reset_input_state_requested = true;
-            self.model
-                .fullscreen_state
-                .fullscreen_active_node
-                .remove(&monitor_name);
-
-            self.clear_non_target_fullscreen_restore_entries(&monitor_name, id);
-        }
-
-        self.model.fullscreen_state.fullscreen_restore.remove(&id);
-        self.model.fullscreen_state.fullscreen_origin.remove(&id);
-        self.model.fullscreen_state.fullscreen_motion.remove(&id);
-        self.model
+            .remove(&monitor_name);
+    } else {
+        // Clear any suspended state for this monitor.
+        st.model
             .fullscreen_state
-            .fullscreen_scale_anim
-            .remove(&id);
-        self.model
+            .fullscreen_suspended_node
+            .remove(&monitor_name);
+        st.model
             .fullscreen_state
-            .clear_direct_scanout_for_node(id);
+            .fullscreen_soft_suspended_node
+            .remove(&monitor_name);
     }
 
-    pub(crate) fn tick_fullscreen_motion(&mut self, now: Instant) {
-        if self.model.fullscreen_state.fullscreen_motion.is_empty()
-            && self.model.fullscreen_state.fullscreen_scale_anim.is_empty()
-        {
-            return;
-        }
+    // If another window is fullscreened on the same monitor, exit it first.
+    if let Some(existing) = st
+        .model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(&monitor_name)
+        .copied()
+    {
+        exit_xdg_fullscreen(st, existing, now);
+    }
 
-        let now_ms = self.now_ms(now);
-        let motions: Vec<(
-            NodeId,
-            crate::compositor::fullscreen::state::FullscreenMotion,
-        )> = self
-            .model
-            .fullscreen_state
-            .fullscreen_motion
-            .iter()
-            .map(|(&id, &motion)| (id, motion))
-            .collect();
-        let mut finished = Vec::new();
+    let target_size = fullscreen_target_size_for(st, monitor_name.as_str());
+    let (viewport_center, viewport_size) = fullscreen_monitor_view(st, monitor_name.as_str());
+    clear_non_target_fullscreen_restore_entries(st, &monitor_name, node_id);
 
-        for (id, motion) in motions {
-            let elapsed = now_ms.saturating_sub(motion.start_ms);
-            let t = (elapsed as f32 / motion.duration_ms.max(1) as f32).clamp(0.0, 1.0);
-            let e = if t < 0.5 {
-                4.0 * t * t * t
-            } else {
-                1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
-            };
-            let pos = Vec2 {
-                x: motion.from.x + (motion.to.x - motion.from.x) * e,
-                y: motion.from.y + (motion.to.y - motion.from.y) * e,
-            };
-            let _ = self.model.field.carry(id, pos);
-            if t >= 1.0 {
-                finished.push((id, motion));
-            }
-        }
+    // Capture the pre-fullscreen camera (zoom + center) once per monitor so exiting
+    // fullscreen returns to it instead of staying at 1.0. `or_insert` keeps the
+    // original across fullscreen→fullscreen swaps and soft suspend/resume.
+    let pre_fullscreen_camera =
+        crate::compositor::workspace::state::snapshot_monitor_camera(st, monitor_name.as_str());
+    st.model
+        .fullscreen_state
+        .fullscreen_camera_restore
+        .entry(monitor_name.clone())
+        .or_insert(pre_fullscreen_camera);
 
-        for (id, motion) in finished {
-            self.model.fullscreen_state.fullscreen_motion.remove(&id);
-            if let Some(node) = self.model.field.node_mut(id) {
-                node.pos = motion.to;
-            }
-            self.input.interaction_state.physics_velocity.remove(&id);
-            if let Some(entry) = self
-                .model
+    // One-time reset of the target monitor's zoom to 1.0. Do not hold or lock it.
+    reset_monitor_zoom_once(st, monitor_name.as_str());
+
+    let Some(node) = st.model.field.node(node_id).cloned() else {
+        return;
+    };
+
+    let soft_resume_entry = soft_resume
+        .then(|| {
+            st.model
                 .fullscreen_state
                 .fullscreen_restore
-                .get(&id)
+                .get(&node_id)
                 .copied()
-            {
-                // A node finishing its motion should be pinned only if the fullscreen
-                // it was displaced for is still active — i.e. the monitor it belongs
-                // to still has an active fullscreen session.
-                let node_monitor = self
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&id)
-                    .cloned()
-                    .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone());
-                let displaced_for_active = self
-                    .model
-                    .fullscreen_state
-                    .fullscreen_active_node
-                    .contains_key(&node_monitor);
+        })
+        .flatten();
+    let saved_size = soft_resume_entry
+        .map(|entry| entry.size)
+        .unwrap_or_else(|| {
+            crate::compositor::surface::current_surface_size_for_node(st, node_id)
+                .unwrap_or(node.intrinsic_size)
+        });
+    let saved_bbox_loc = soft_resume_entry
+        .and_then(|entry| entry.bbox_loc)
+        .or_else(|| st.ui.render_state.cache.bbox_loc.get(&node_id).copied());
+    let saved_window_geometry = soft_resume_entry
+        .and_then(|entry| entry.window_geometry)
+        .or_else(|| {
+            st.ui
+                .render_state
+                .cache
+                .window_geometry
+                .get(&node_id)
+                .copied()
+        });
+    let saved_pos = soft_resume_entry.map(|entry| entry.pos).unwrap_or(node.pos);
+    let saved_intrinsic_size = soft_resume_entry
+        .map(|entry| entry.intrinsic_size)
+        .unwrap_or(node.intrinsic_size);
+    let saved_pinned = soft_resume_entry
+        .map(|entry| entry.pinned)
+        .unwrap_or(node.pinned);
 
-                if displaced_for_active {
-                    let _ = self.model.field.set_pinned(id, true);
-                } else {
-                    let _ = self.model.field.set_pinned(id, entry.pinned);
-                    self.model.fullscreen_state.fullscreen_restore.remove(&id);
-                }
-            }
-        }
-
-        self.model
+    st.model.fullscreen_state.fullscreen_restore.insert(
+        node_id,
+        crate::compositor::fullscreen::state::FullscreenSessionEntry {
+            pos: saved_pos,
+            size: saved_size,
+            viewport_center,
+            intrinsic_size: saved_intrinsic_size,
+            bbox_loc: saved_bbox_loc,
+            window_geometry: saved_window_geometry,
+            pinned: saved_pinned,
+        },
+    );
+    if st.runtime.tuning.fullscreen_animation_enabled() && !soft_resume {
+        st.request_window_animation_prewarm(node_id, now);
+        let from = (st.model.monitor_state.current_monitor == monitor_name)
+            .then(|| {
+                crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                    st,
+                    node_id,
+                    now,
+                )
+            })
+            .flatten()
+            .unwrap_or((saved_pos, saved_size));
+        let start_ms = st.now_ms(now);
+        let duration_ms = st.runtime.tuning.fullscreen_animation_duration_ms();
+        st.model.fullscreen_state.fullscreen_scale_anim.insert(
+            node_id,
+            crate::compositor::fullscreen::state::FullscreenScaleAnim {
+                monitor: monitor_name.clone(),
+                from_pos: from.0,
+                to_pos: viewport_center,
+                from_size: from.1,
+                to_size: viewport_size,
+                start_ms,
+                duration_ms,
+            },
+        );
+    } else {
+        st.model
             .fullscreen_state
             .fullscreen_scale_anim
-            .retain(|_, anim| now_ms < anim.start_ms.saturating_add(anim.duration_ms));
-        if !self.model.fullscreen_state.fullscreen_scale_anim.is_empty() {
-            self.request_maintenance();
+            .remove(&node_id);
+    }
+    if !soft_resume {
+        request_toplevel_fullscreen_state(st, node_id, true, output, Some(target_size));
+    }
+    st.assign_node_to_monitor(node_id, monitor_name.as_str());
+    st.model
+        .fullscreen_state
+        .fullscreen_active_node
+        .insert(monitor_name, node_id);
+    st.model
+        .fullscreen_state
+        .fullscreen_origin
+        .insert(node_id, origin);
+    st.set_interaction_focus(Some(node_id), 30_000, now);
+    let _ = st.raise_overlap_policy_node(node_id);
+    st.request_maintenance();
+}
+
+pub(crate) fn exit_xdg_fullscreen(st: &mut Halley, node_id: NodeId, now: Instant) {
+    if !is_fullscreen_active(st, node_id)
+        && let Some(monitor) =
+            fullscreen_suspended_monitor_for_node(st, node_id).map(str::to_string)
+    {
+        st.model
+            .fullscreen_state
+            .fullscreen_suspended_node
+            .remove(&monitor);
+        st.model
+            .fullscreen_state
+            .fullscreen_active_node
+            .insert(monitor, node_id);
+    }
+    // Clear suspended state on whatever monitor this node is on.
+    if let Some(monitor) = fullscreen_monitor_for_node(st, node_id).map(|s| s.to_owned()) {
+        st.model
+            .fullscreen_state
+            .fullscreen_suspended_node
+            .remove(&monitor);
+    }
+    exit_xdg_fullscreen_inner(st, node_id, now, false, false);
+}
+
+pub(crate) fn drop_fullscreen_surface(st: &mut Halley, id: NodeId, _now: Instant) {
+    if !is_fullscreen_active(st, id)
+        && let Some(monitor) = fullscreen_suspended_monitor_for_node(st, id).map(str::to_string)
+    {
+        st.model
+            .fullscreen_state
+            .fullscreen_active_node
+            .insert(monitor, id);
+    }
+
+    // Clear suspended state if this node was suspended on any monitor.
+    st.model
+        .fullscreen_state
+        .fullscreen_suspended_node
+        .retain(|_, &mut nid| nid != id);
+    st.model
+        .fullscreen_state
+        .fullscreen_soft_suspended_node
+        .retain(|_, &mut nid| nid != id);
+
+    if is_fullscreen_active(st, id) {
+        let monitor_name = fullscreen_monitor_for_node(st, id)
+            .map(|s| s.to_owned())
+            .unwrap(); // safe: is_fullscreen_active just confirmed it
+
+        st.input.interaction_state.reset_input_state_requested = true;
+        st.model
+            .fullscreen_state
+            .fullscreen_active_node
+            .remove(&monitor_name);
+
+        clear_non_target_fullscreen_restore_entries(st, &monitor_name, id);
+    }
+
+    st.model.fullscreen_state.fullscreen_restore.remove(&id);
+    st.model.fullscreen_state.fullscreen_origin.remove(&id);
+    st.model.fullscreen_state.fullscreen_motion.remove(&id);
+    st.model.fullscreen_state.fullscreen_scale_anim.remove(&id);
+    st.model.fullscreen_state.clear_direct_scanout_for_node(id);
+}
+
+pub(crate) fn tick_fullscreen_motion(st: &mut Halley, now: Instant) {
+    if st.model.fullscreen_state.fullscreen_motion.is_empty()
+        && st.model.fullscreen_state.fullscreen_scale_anim.is_empty()
+    {
+        return;
+    }
+
+    let now_ms = st.now_ms(now);
+    let motions: Vec<(
+        NodeId,
+        crate::compositor::fullscreen::state::FullscreenMotion,
+    )> = st
+        .model
+        .fullscreen_state
+        .fullscreen_motion
+        .iter()
+        .map(|(&id, &motion)| (id, motion))
+        .collect();
+    let mut finished = Vec::new();
+
+    for (id, motion) in motions {
+        let elapsed = now_ms.saturating_sub(motion.start_ms);
+        let t = (elapsed as f32 / motion.duration_ms.max(1) as f32).clamp(0.0, 1.0);
+        let e = if t < 0.5 {
+            4.0 * t * t * t
+        } else {
+            1.0 - (-2.0 * t + 2.0).powf(3.0) * 0.5
+        };
+        let pos = Vec2 {
+            x: motion.from.x + (motion.to.x - motion.from.x) * e,
+            y: motion.from.y + (motion.to.y - motion.from.y) * e,
+        };
+        let _ = st.model.field.carry(id, pos);
+        if t >= 1.0 {
+            finished.push((id, motion));
         }
+    }
+
+    for (id, motion) in finished {
+        st.model.fullscreen_state.fullscreen_motion.remove(&id);
+        if let Some(node) = st.model.field.node_mut(id) {
+            node.pos = motion.to;
+        }
+        st.input.interaction_state.physics_velocity.remove(&id);
+        if let Some(entry) = st
+            .model
+            .fullscreen_state
+            .fullscreen_restore
+            .get(&id)
+            .copied()
+        {
+            // A node finishing its motion should be pinned only if the fullscreen
+            // it was displaced for is still active — i.e. the monitor it belongs
+            // to still has an active fullscreen session.
+            let node_monitor = st
+                .model
+                .monitor_state
+                .node_monitor
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone());
+            let displaced_for_active = st
+                .model
+                .fullscreen_state
+                .fullscreen_active_node
+                .contains_key(&node_monitor);
+
+            if displaced_for_active {
+                let _ = st.model.field.set_pinned(id, true);
+            } else {
+                let _ = st.model.field.set_pinned(id, entry.pinned);
+                st.model.fullscreen_state.fullscreen_restore.remove(&id);
+            }
+        }
+    }
+
+    st.model
+        .fullscreen_state
+        .fullscreen_scale_anim
+        .retain(|_, anim| now_ms < anim.start_ms.saturating_add(anim.duration_ms));
+    if !st.model.fullscreen_state.fullscreen_scale_anim.is_empty() {
+        st.request_maintenance();
     }
 }

--- a/crates/halley-wl/src/compositor/interaction/state.rs
+++ b/crates/halley-wl/src/compositor/interaction/state.rs
@@ -373,6 +373,9 @@ pub(crate) struct InteractionState {
     pub(crate) apogee_session: Option<crate::compositor::overview::ApogeeSession>,
     pub(crate) apogee_live_preview_node: Option<NodeId>,
     pub(crate) apogee_live_preview_last_at: Option<Instant>,
+    /// Apogee tile (window or core) currently under the cursor, used to draw the
+    /// hover ring. Unlike `apogee_live_preview_node` this also tracks core tiles.
+    pub(crate) apogee_hover_node: Option<NodeId>,
     pub(crate) overlay_hover_target: Option<OverlayHoverTarget>,
     pub(crate) cursor_override_until_ms: Option<u64>,
     pub(crate) pending_core_hover: Option<PendingCoreHover>,

--- a/crates/halley-wl/src/compositor/monitor/camera.rs
+++ b/crates/halley-wl/src/compositor/monitor/camera.rs
@@ -1,27 +1,4 @@
 use super::*;
-use std::ops::{Deref, DerefMut};
-
-pub(crate) struct CameraController<T> {
-    st: T,
-}
-
-pub(crate) fn camera_controller<T>(st: T) -> CameraController<T> {
-    CameraController { st }
-}
-
-impl<T: Deref<Target = Halley>> Deref for CameraController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for CameraController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
 
 #[inline]
 fn zoom_step(st: &Halley) -> f32 {
@@ -43,65 +20,6 @@ fn zoom_smooth_rate(st: &Halley) -> f32 {
 #[inline]
 pub(crate) fn camera_view_size(st: &Halley) -> Vec2 {
     st.model.zoom_ref_size
-}
-
-impl<T: Deref<Target = Halley>> CameraController<T> {
-    #[inline]
-    pub(crate) fn view_size(&self) -> Vec2 {
-        camera_view_size(self)
-    }
-
-    #[inline]
-    pub(crate) fn zoom_blocked_by_interaction(&self) -> bool {
-        zoom_blocked_by_interaction(self)
-    }
-
-    #[inline]
-    pub(crate) fn pan_blocked_on_monitor(&self, monitor: &str) -> bool {
-        pan_blocked_on_monitor(self, monitor)
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> CameraController<T> {
-    #[inline]
-    pub(crate) fn pan_target(&mut self, delta: Vec2) {
-        pan_camera_target(self, delta)
-    }
-
-    #[inline]
-    pub(crate) fn set_target_view_size(&mut self, size: Vec2) {
-        set_camera_target_view_size(self, size)
-    }
-
-    #[inline]
-    pub(crate) fn snap_targets_to_live(&mut self) {
-        snap_camera_targets_to_live(self)
-    }
-
-    #[inline]
-    pub(crate) fn update_zoom_live_surface_sizes(&mut self) {
-        update_zoom_live_surface_sizes(self)
-    }
-
-    #[inline]
-    pub(crate) fn zoom_by_steps(&mut self, steps: f32) {
-        zoom_by_steps(self, steps)
-    }
-
-    #[inline]
-    pub(crate) fn reset_zoom(&mut self) {
-        reset_zoom(self)
-    }
-
-    #[inline]
-    pub(crate) fn tick_smoothing(&mut self, now: Instant) {
-        tick_camera_smoothing(self, now)
-    }
-
-    #[inline]
-    pub(crate) fn tick_smoothing_passive(&mut self, now: Instant) -> bool {
-        tick_camera_smoothing_passive(self, now)
-    }
 }
 
 #[inline]
@@ -469,11 +387,11 @@ mod tests {
             y: base.y * 1.5,
         };
         state.model.camera_target_view_size = zoomed_out;
-        camera_controller(&mut state).reset_zoom();
+        reset_zoom(&mut state);
         assert_eq!(state.model.camera_target_view_size, zoomed_out);
 
         state.model.camera_target_view_size = base;
-        camera_controller(&mut state).zoom_by_steps(-1.0);
+        zoom_by_steps(&mut state, -1.0);
         assert_eq!(state.model.camera_target_view_size, base);
     }
 
@@ -514,7 +432,7 @@ mod tests {
         assert!(pan_blocked_on_monitor(&state, current_monitor.as_str()));
 
         let before = state.model.camera_target_view_size;
-        camera_controller(&mut state).zoom_by_steps(-1.0);
+        zoom_by_steps(&mut state, -1.0);
         assert_eq!(state.model.camera_target_view_size, before);
     }
 
@@ -606,7 +524,7 @@ mod tests {
         let _ = state.activate_monitor("right");
 
         let before = state.model.camera_target_view_size;
-        camera_controller(&mut state).zoom_by_steps(-1.0);
+        zoom_by_steps(&mut state, -1.0);
 
         assert_eq!(state.model.camera_target_view_size, before);
         assert!(state.model.zoom_log_vel > 0.0);
@@ -622,8 +540,8 @@ mod tests {
         let mut state = Halley::new_for_test(&dh, tuning);
 
         let before = state.model.camera_target_view_size;
-        camera_controller(&mut state).zoom_by_steps(1.0);
-        camera_controller(&mut state).reset_zoom();
+        zoom_by_steps(&mut state, 1.0);
+        reset_zoom(&mut state);
 
         assert_eq!(state.model.camera_target_view_size, before);
     }
@@ -639,17 +557,23 @@ mod tests {
         let mut state = Halley::new_for_test(&dh, tuning);
         let base = state.model.viewport.size;
 
-        camera_controller(&mut state).set_target_view_size(Vec2 {
-            x: base.x * 10.0,
-            y: base.y * 10.0,
-        });
+        set_camera_target_view_size(
+            &mut state,
+            Vec2 {
+                x: base.x * 10.0,
+                y: base.y * 10.0,
+            },
+        );
         assert_eq!(state.model.camera_target_view_size.x, base.x / 0.5);
         assert_eq!(state.model.camera_target_view_size.y, base.y / 0.5);
 
-        camera_controller(&mut state).set_target_view_size(Vec2 {
-            x: base.x * 0.1,
-            y: base.y * 0.1,
-        });
+        set_camera_target_view_size(
+            &mut state,
+            Vec2 {
+                x: base.x * 0.1,
+                y: base.y * 0.1,
+            },
+        );
         assert_eq!(state.model.camera_target_view_size.x, base.x / 1.5);
         assert_eq!(state.model.camera_target_view_size.y, base.y / 1.5);
     }

--- a/crates/halley-wl/src/compositor/monitor/layer_shell.rs
+++ b/crates/halley-wl/src/compositor/monitor/layer_shell.rs
@@ -386,7 +386,11 @@ fn register_layer_surface_impl(
         assigned_monitor_for_no_output(st, &namespace)
     };
 
-    st.assign_layer_surface_to_monitor(surface.wl_surface(), assigned_monitor.clone());
+    crate::compositor::monitor::state::assign_layer_surface_to_monitor(
+        st,
+        surface.wl_surface(),
+        assigned_monitor.clone(),
+    );
     st.model
         .monitor_state
         .layer_surface_namespace

--- a/crates/halley-wl/src/compositor/overview.rs
+++ b/crates/halley-wl/src/compositor/overview.rs
@@ -622,6 +622,41 @@ pub(crate) fn activate_apogee_target(st: &mut Halley, node_id: NodeId, now: Inst
         }
     }
 
+    // An overflow-bar member of an active tile-mode cluster workspace: promote it
+    // into the master slot (the layout shifts the old master into overflow) rather
+    // than trying to reveal a HIDDEN_BY_CLUSTER node.
+    let target_monitor = st.monitor_for_node_or_current(node_id);
+    if let Some(cid) = st.active_cluster_workspace_for_monitor(target_monitor.as_str()) {
+        let is_overflow = st
+            .model
+            .cluster_state
+            .cluster_overflow_members
+            .get(target_monitor.as_str())
+            .is_some_and(|members| members.contains(&node_id));
+        if is_overflow {
+            let max_stack = st.runtime.tuning.tile_max_stack;
+            let master = st
+                .model
+                .field
+                .cluster(cid)
+                .and_then(|cluster| cluster.visible_members(max_stack).first().copied());
+            if let Some(master) = master {
+                let now_ms = st.now_ms(now);
+                let _ =
+                    crate::compositor::clusters::system::swap_cluster_overflow_member_with_visible(
+                        st,
+                        target_monitor.as_str(),
+                        cid,
+                        node_id,
+                        master,
+                        now_ms,
+                    );
+            }
+            st.set_interaction_focus(Some(node_id), 30_000, now);
+            return;
+        }
+    }
+
     if crate::compositor::actions::window::focus_from_presentation_navigation(st, node_id, now)
         || crate::compositor::actions::window::focus_or_reveal_surface_node(st, node_id, now)
     {
@@ -738,6 +773,66 @@ fn build_apogee_tiles(
             core_raw.push(entry);
         } else {
             raw.push(entry);
+        }
+    }
+
+    // Surface an active cluster workspace's overflow-bar members as window tiles.
+    // They are HIDDEN_BY_CLUSTER on the desktop (so the loop above skips them) yet
+    // still real workspace nodes; showing them lets the overview promote one into
+    // the layout. They fly in from the overflow strip.
+    if matches!(
+        crate::compositor::clusters::system::active_cluster_layout_kind(st),
+        halley_core::cluster_layout::ClusterWorkspaceLayoutKind::Tiling
+    ) && let Some(overflow_ids) = st
+        .model
+        .cluster_state
+        .cluster_overflow_members
+        .get(monitor)
+        .cloned()
+    {
+        let strip = st
+            .model
+            .cluster_state
+            .cluster_overflow_rects
+            .get(monitor)
+            .copied();
+        let already: std::collections::HashSet<NodeId> = raw.iter().map(|e| e.0).collect();
+        for oid in overflow_ids {
+            if already.contains(&oid) {
+                continue;
+            }
+            let Some(node) = view.field.node(oid) else {
+                continue;
+            };
+            let preview_size = apogee_window_preview_size(&view, oid, node.intrinsic_size);
+            let aspect = window_aspect(&view, oid, preview_size);
+            let weight = (preview_size.x * preview_size.y).max(1.0);
+            let from = if let Some(strip) = strip {
+                let side = strip.w.max(8.0);
+                TileRect {
+                    cx: strip.x + strip.w * 0.5,
+                    cy: strip.y + strip.h * 0.5,
+                    w: side,
+                    h: side,
+                }
+            } else {
+                let (cx, cy) = view.world_to_screen(screen_w, screen_h, node.pos.x, node.pos.y);
+                TileRect {
+                    cx: cx as f32,
+                    cy: cy as f32,
+                    w: (preview_size.x * scale_x).max(8.0),
+                    h: (preview_size.y * scale_y).max(8.0),
+                }
+            };
+            raw.push((
+                oid,
+                ApogeeTileKind::Window,
+                false,
+                node.pos,
+                aspect,
+                weight,
+                from,
+            ));
         }
     }
 

--- a/crates/halley-wl/src/compositor/overview.rs
+++ b/crates/halley-wl/src/compositor/overview.rs
@@ -622,36 +622,23 @@ pub(crate) fn activate_apogee_target(st: &mut Halley, node_id: NodeId, now: Inst
         }
     }
 
-    // An overflow-bar member of an active tile-mode cluster workspace: promote it
-    // into the master slot (the layout shifts the old master into overflow) rather
-    // than trying to reveal a HIDDEN_BY_CLUSTER node.
+    // Any member of an active cluster workspace: promote it into the master slot
+    // (the relayout shifts the old master down; an overflow member becomes visible)
+    // and focus it, rather than revealing it at its windowed field position.
     let target_monitor = st.monitor_for_node_or_current(node_id);
     if let Some(cid) = st.active_cluster_workspace_for_monitor(target_monitor.as_str()) {
-        let is_overflow = st
+        let is_member = st
             .model
-            .cluster_state
-            .cluster_overflow_members
-            .get(target_monitor.as_str())
-            .is_some_and(|members| members.contains(&node_id));
-        if is_overflow {
-            let max_stack = st.runtime.tuning.tile_max_stack;
-            let master = st
+            .field
+            .cluster(cid)
+            .is_some_and(|cluster| cluster.members().contains(&node_id));
+        if is_member {
+            let _ = st
                 .model
                 .field
-                .cluster(cid)
-                .and_then(|cluster| cluster.visible_members(max_stack).first().copied());
-            if let Some(master) = master {
-                let now_ms = st.now_ms(now);
-                let _ =
-                    crate::compositor::clusters::system::swap_cluster_overflow_member_with_visible(
-                        st,
-                        target_monitor.as_str(),
-                        cid,
-                        node_id,
-                        master,
-                        now_ms,
-                    );
-            }
+                .promote_cluster_member_to_master(cid, node_id);
+            let now_ms = st.now_ms(now);
+            st.layout_active_cluster_workspace_for_monitor(target_monitor.as_str(), now_ms);
             st.set_interaction_focus(Some(node_id), 30_000, now);
             return;
         }

--- a/crates/halley-wl/src/compositor/overview.rs
+++ b/crates/halley-wl/src/compositor/overview.rs
@@ -280,6 +280,25 @@ impl Halley {
             .iter()
             .map(|(monitor, space)| (monitor.clone(), (space.width, space.height)))
             .collect::<std::collections::HashMap<_, _>>();
+        // Desktop draw rank per window tile, computed under an immutable borrow so
+        // the close fly-back can overlap windows in the same z-order the live
+        // desktop uses (otherwise they snap into order when the overlay clears).
+        let draw_ranks: std::collections::HashMap<NodeId, (u64, u64)> =
+            match self.input.interaction_state.apogee_session.as_ref() {
+                Some(session) => session
+                    .monitors
+                    .iter()
+                    .flat_map(|m| m.tiles.iter())
+                    .filter(|tile| matches!(tile.kind, ApogeeTileKind::Window))
+                    .map(|tile| {
+                        (
+                            tile.node_id,
+                            crate::window::active_surface_draw_rank(self, tile.node_id),
+                        )
+                    })
+                    .collect(),
+                None => std::collections::HashMap::new(),
+            };
         if let Some(session) = self.input.interaction_state.apogee_session.as_mut() {
             if session.phase == ApogeePhase::Closing {
                 return;
@@ -287,11 +306,26 @@ impl Halley {
             self.input.interaction_state.apogee_live_preview_node = None;
             self.input.interaction_state.apogee_live_preview_last_at = None;
             let eased = ease_in_out_cubic(session.progress(now));
+            let pending_sel = session.pending_selection;
             for monitor_session in &mut session.monitors {
                 let (screen_w, screen_h) = screen_sizes
                     .get(&monitor_session.monitor)
                     .copied()
                     .unwrap_or((1, 1));
+                // Reorder window tiles into the live desktop's z-order so the
+                // fly-back overlaps correctly, then keep any picked tile on top.
+                monitor_session
+                    .tiles
+                    .sort_by_key(|tile| draw_ranks.get(&tile.node_id).copied().unwrap_or((0, 0)));
+                if let Some(sel) = pending_sel
+                    && let Some(idx) = monitor_session
+                        .tiles
+                        .iter()
+                        .position(|tile| tile.node_id == sel)
+                {
+                    let tile = monitor_session.tiles.remove(idx);
+                    monitor_session.tiles.push(tile);
+                }
                 // Fly back from the currently displayed atlas rect, not from the
                 // raw atlas slot, so scroll position does not snap on close.
                 for tile in &mut monitor_session.tiles {
@@ -592,6 +626,24 @@ pub(crate) fn activate_apogee_target(st: &mut Halley, node_id: NodeId, now: Inst
         || crate::compositor::actions::window::focus_or_reveal_surface_node(st, node_id, now)
     {
         return;
+    }
+    // A cluster core: open the cluster (enter its workspace) instead of just
+    // panning to it, when the knob is enabled.
+    if st.runtime.tuning.apogee.open_cluster_on_select
+        && st.model.field.cluster_id_for_core_public(node_id).is_some()
+    {
+        let monitor = st.monitor_for_node_or_current(node_id);
+        if st.focused_monitor() != monitor {
+            st.focus_monitor_view(monitor.as_str(), now);
+        }
+        if crate::compositor::clusters::system::enter_cluster_workspace_by_core(
+            st,
+            node_id,
+            monitor.as_str(),
+            now,
+        ) {
+            return;
+        }
     }
     // Cluster cores (and any non-surface node): focus + pan to its Field position.
     if let Some(pos) = st.model.field.node(node_id).map(|node| node.pos) {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1439,18 +1439,18 @@ impl Halley {
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn viewport_center_for_monitor(&self, monitor: &str) -> Vec2 {
-        super::spawn::reveal::spawn_reveal_controller(self).viewport_center_for_monitor(monitor)
+        super::spawn::reveal::placement::viewport_center_for_monitor(self, monitor)
     }
 
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn resolve_spawn_target_monitor(&self) -> String {
-        super::spawn::reveal::spawn_reveal_controller(self).resolve_spawn_target_monitor()
+        super::spawn::reveal::placement::resolve_spawn_target_monitor(self)
     }
 
     #[cfg(test)]
     pub(crate) fn current_spawn_focus(&self, monitor: &str) -> (Option<NodeId>, Vec2) {
-        super::spawn::reveal::spawn_reveal_controller(self).current_spawn_focus(monitor)
+        super::spawn::reveal::placement::current_spawn_focus(self, monitor)
     }
 
     #[cfg(test)]
@@ -1460,29 +1460,29 @@ impl Halley {
         monitor: &str,
         id: NodeId,
     ) -> bool {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .viewport_fully_contains_surface_on_monitor(monitor, id)
+        super::spawn::reveal::placement::viewport_fully_contains_surface_on_monitor(
+            self, monitor, id,
+        )
     }
 
     #[cfg(test)]
     pub(crate) fn right_spawn_candidate_for_focus(&self, id: NodeId, size: Vec2) -> Option<Vec2> {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .right_spawn_candidate_for_focus(id, size)
+        super::spawn::reveal::placement::right_spawn_candidate_for_focus(self, id, size)
     }
 
     #[cfg(test)]
     pub(crate) fn star_candidate_offsets(&self, size: Vec2) -> Vec<Vec2> {
-        super::spawn::reveal::spawn_reveal_controller(self).star_candidate_offsets(size)
+        super::spawn::reveal::placement::star_candidate_offsets(self, size)
     }
 
     #[cfg(test)]
     pub(crate) fn spawn_star_step_x(&self, size: Vec2) -> f32 {
-        super::spawn::reveal::spawn_reveal_controller(self).spawn_star_step_x(size)
+        super::spawn::reveal::placement::spawn_star_step_x(self, size)
     }
 
     #[cfg(test)]
     pub(crate) fn spawn_star_step_y(&self, size: Vec2) -> f32 {
-        super::spawn::reveal::spawn_reveal_controller(self).spawn_star_step_y(size)
+        super::spawn::reveal::placement::spawn_star_step_y(self, size)
     }
 
     #[cfg(test)]
@@ -1492,8 +1492,7 @@ impl Halley {
         size: Vec2,
         dir: Vec2,
     ) -> Option<Vec2> {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .spawn_candidate_for_focus_dir(id, size, dir)
+        super::spawn::reveal::placement::spawn_candidate_for_focus_dir(self, id, size, dir)
     }
 
     #[cfg(test)]
@@ -1505,20 +1504,21 @@ impl Halley {
         focus_pos: Vec2,
         growth_dir: Vec2,
     ) {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .update_spawn_patch(monitor, anchor, focus_node, focus_pos, growth_dir)
+        super::spawn::reveal::placement::update_spawn_patch(
+            self, monitor, anchor, focus_node, focus_pos, growth_dir,
+        )
     }
 
     #[allow(dead_code)]
     pub(crate) fn pick_spawn_position(&mut self, size: Vec2) -> (String, Vec2, bool) {
-        super::spawn::reveal::spawn_reveal_controller(self).pick_spawn_position(size)
+        super::spawn::reveal::placement::pick_spawn_position(self, size)
     }
 
     pub(crate) fn spawn_target_monitor_for_intent(
         &self,
         intent: &super::spawn::rules::InitialWindowIntent,
     ) -> String {
-        super::spawn::reveal::spawn_reveal_controller(self).spawn_target_monitor_for_intent(intent)
+        super::spawn::reveal::placement::spawn_target_monitor_for_intent(self, intent)
     }
 
     pub(crate) fn pick_spawn_position_with_intent(
@@ -1526,22 +1526,20 @@ impl Halley {
         size: Vec2,
         intent: &super::spawn::rules::InitialWindowIntent,
     ) -> (String, Vec2, bool) {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .pick_spawn_position_with_intent(size, intent)
+        super::spawn::reveal::placement::pick_spawn_position_with_intent(self, size, intent)
     }
 
     pub(crate) fn finalize_initial_spawn_position(&mut self, id: NodeId, size: Vec2) -> bool {
-        super::spawn::reveal::spawn_reveal_controller(self)
-            .finalize_initial_spawn_position(id, size)
+        super::spawn::reveal::placement::finalize_initial_spawn_position(self, id, size)
     }
 
     #[allow(dead_code)]
     pub(crate) fn maybe_start_pending_spawn_pan(&mut self, now: Instant) {
-        super::spawn::reveal::spawn_reveal_controller(self).maybe_start_pending_spawn_pan(now)
+        super::spawn::reveal::maybe_start_pending_spawn_pan(self, now)
     }
 
     pub(crate) fn tick_pending_spawn_pan(&mut self, now: Instant, now_ms: u64) {
-        super::spawn::reveal::spawn_reveal_controller(self).tick_pending_spawn_pan(now, now_ms)
+        super::spawn::reveal::tick_pending_spawn_pan(self, now, now_ms)
     }
 
     pub(crate) fn reveal_new_toplevel_node(
@@ -1550,11 +1548,7 @@ impl Halley {
         is_transient: bool,
         now: Instant,
     ) {
-        super::spawn::reveal::spawn_reveal_controller(self).reveal_new_toplevel_node(
-            id,
-            is_transient,
-            now,
-        )
+        super::spawn::reveal::reveal_new_toplevel_node(self, id, is_transient, now)
     }
 
     pub(crate) fn remove_node_from_field(&mut self, id: NodeId, now_ms: u64) -> bool {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -815,8 +815,9 @@ impl Halley {
     pub(crate) fn assign_node_to_monitor(&mut self, id: NodeId, monitor: &str) {
         let previous_monitor = self.model.monitor_state.node_monitor.get(&id).cloned();
         super::monitor::state::assign_node_to_monitor(self, id, monitor);
-        super::clusters::system::cluster_system_controller(&mut *self)
-            .sync_cluster_name_for_node_monitor(id, monitor);
+        crate::compositor::clusters::system::sync_cluster_name_for_node_monitor(
+            &mut *self, id, monitor,
+        );
         if previous_monitor.as_deref() != Some(monitor)
             && super::workspace::state::abort_maximize_session_for_external_active_node_on_monitor(
                 self, monitor, id,
@@ -1552,14 +1553,14 @@ impl Halley {
     }
 
     pub(crate) fn remove_node_from_field(&mut self, id: NodeId, now_ms: u64) -> bool {
-        super::clusters::system::cluster_system_controller(self).remove_node_from_field(id, now_ms)
+        crate::compositor::clusters::system::remove_node_from_field(self, id, now_ms)
     }
 
     pub fn cluster_bloom_for_monitor(
         &mut self,
         monitor: &str,
     ) -> Option<halley_core::cluster::ClusterId> {
-        super::clusters::system::cluster_system_controller(self).cluster_bloom_for_monitor(monitor)
+        crate::compositor::clusters::system::cluster_bloom_for_monitor(self, monitor)
     }
 
     #[cfg(test)]
@@ -1568,8 +1569,7 @@ impl Halley {
         cid: halley_core::cluster::ClusterId,
         preferred: Option<&str>,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .sync_cluster_monitor(cid, preferred)
+        crate::compositor::clusters::system::sync_cluster_monitor(self, cid, preferred)
     }
 
     #[cfg(test)]
@@ -1579,8 +1579,9 @@ impl Halley {
         monitor: &str,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .enter_cluster_workspace_by_core(core_id, monitor, now)
+        crate::compositor::clusters::system::enter_cluster_workspace_by_core(
+            self, core_id, monitor, now,
+        )
     }
 
     pub fn open_cluster_bloom_for_monitor(
@@ -1588,13 +1589,11 @@ impl Halley {
         monitor: &str,
         cid: halley_core::cluster::ClusterId,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .open_cluster_bloom_for_monitor(monitor, cid)
+        crate::compositor::clusters::system::open_cluster_bloom_for_monitor(self, monitor, cid)
     }
 
     pub fn close_cluster_bloom_for_monitor(&mut self, monitor: &str) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .close_cluster_bloom_for_monitor(monitor)
+        crate::compositor::clusters::system::close_cluster_bloom_for_monitor(self, monitor)
     }
 
     pub fn detach_member_from_cluster(
@@ -1604,8 +1603,9 @@ impl Halley {
         world_pos: Vec2,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .detach_member_from_cluster(cid, member_id, world_pos, now)
+        crate::compositor::clusters::system::detach_member_from_cluster(
+            self, cid, member_id, world_pos, now,
+        )
     }
 
     #[allow(dead_code)]
@@ -1615,8 +1615,7 @@ impl Halley {
         node_id: NodeId,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .absorb_node_into_cluster(cid, node_id, now)
+        crate::compositor::clusters::system::absorb_node_into_cluster(self, cid, node_id, now)
     }
 
     pub(crate) fn commit_ready_cluster_join_for_node(
@@ -1624,8 +1623,7 @@ impl Halley {
         node_id: NodeId,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .commit_ready_cluster_join_for_node(node_id, now)
+        crate::compositor::clusters::system::commit_ready_cluster_join_for_node(self, node_id, now)
     }
 
     pub fn active_cluster_workspace_for_monitor(
@@ -1644,21 +1642,20 @@ impl Halley {
     }
 
     pub(crate) fn reveal_cluster_overflow_for_monitor(&mut self, monitor: &str, now_ms: u64) {
-        super::clusters::system::cluster_system_controller(self)
-            .reveal_cluster_overflow_for_monitor(monitor, now_ms)
+        crate::compositor::clusters::system::reveal_cluster_overflow_for_monitor(
+            self, monitor, now_ms,
+        )
     }
 
     pub(crate) fn hide_cluster_overflow_for_monitor(&mut self, monitor: &str) {
-        super::clusters::system::cluster_system_controller(self)
-            .hide_cluster_overflow_for_monitor(monitor)
+        crate::compositor::clusters::system::hide_cluster_overflow_for_monitor(self, monitor)
     }
 
     pub(crate) fn cluster_overflow_rect_for_monitor(
         &self,
         monitor: &str,
     ) -> Option<halley_core::tiling::Rect> {
-        super::clusters::system::cluster_system_controller(self)
-            .cluster_overflow_rect_for_monitor(monitor)
+        crate::compositor::clusters::system::cluster_overflow_rect_for_monitor(self, monitor)
     }
 
     pub(crate) fn cluster_overflow_slot_rect_for_monitor(
@@ -1667,8 +1664,12 @@ impl Halley {
         overflow_len: usize,
         slot_index: usize,
     ) -> Option<halley_core::tiling::Rect> {
-        super::clusters::system::cluster_system_controller(self)
-            .cluster_overflow_slot_rect_for_monitor(monitor, overflow_len, slot_index)
+        crate::compositor::clusters::system::cluster_overflow_slot_rect_for_monitor(
+            self,
+            monitor,
+            overflow_len,
+            slot_index,
+        )
     }
 
     pub(crate) fn active_cluster_tile_rect_for_member(
@@ -1676,8 +1677,9 @@ impl Halley {
         monitor: &str,
         member_id: NodeId,
     ) -> Option<halley_core::tiling::Rect> {
-        super::clusters::system::cluster_system_controller(self)
-            .active_cluster_tile_rect_for_member(monitor, member_id)
+        crate::compositor::clusters::system::active_cluster_tile_rect_for_member(
+            self, monitor, member_id,
+        )
     }
 
     pub(crate) fn adjust_cluster_overflow_scroll_for_monitor(
@@ -1685,8 +1687,9 @@ impl Halley {
         monitor: &str,
         delta: i32,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .adjust_cluster_overflow_scroll_for_monitor(monitor, delta)
+        crate::compositor::clusters::system::adjust_cluster_overflow_scroll_for_monitor(
+            self, monitor, delta,
+        )
     }
 
     pub(crate) fn cluster_spawn_rect_for_new_member(
@@ -1694,12 +1697,11 @@ impl Halley {
         monitor: &str,
         cid: halley_core::cluster::ClusterId,
     ) -> Option<halley_core::tiling::Rect> {
-        super::clusters::system::cluster_system_controller(self)
-            .cluster_spawn_rect_for_new_member(monitor, cid)
+        crate::compositor::clusters::system::cluster_spawn_rect_for_new_member(self, monitor, cid)
     }
 
     pub fn has_any_active_cluster_workspace(&self) -> bool {
-        super::clusters::system::cluster_system_controller(self).has_any_active_cluster_workspace()
+        crate::compositor::clusters::system::has_any_active_cluster_workspace(self)
     }
 
     pub(crate) fn swap_cluster_overflow_member_with_visible(
@@ -1710,14 +1712,14 @@ impl Halley {
         visible_member: NodeId,
         now_ms: u64,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .swap_cluster_overflow_member_with_visible(
-                monitor,
-                cid,
-                overflow_member,
-                visible_member,
-                now_ms,
-            )
+        crate::compositor::clusters::system::swap_cluster_overflow_member_with_visible(
+            self,
+            monitor,
+            cid,
+            overflow_member,
+            visible_member,
+            now_ms,
+        )
     }
 
     pub(crate) fn reorder_cluster_overflow_member(
@@ -1728,7 +1730,8 @@ impl Halley {
         target_overflow_index: usize,
         now_ms: u64,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self).reorder_cluster_overflow_member(
+        crate::compositor::clusters::system::reorder_cluster_overflow_member(
+            self,
             monitor,
             cid,
             member,
@@ -1744,8 +1747,9 @@ impl Halley {
         world_pos: Vec2,
         now_ms: u64,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .move_active_cluster_member_to_drop_tile(monitor, member, world_pos, now_ms)
+        crate::compositor::clusters::system::move_active_cluster_member_to_drop_tile(
+            self, monitor, member, world_pos, now_ms,
+        )
     }
 
     pub(crate) fn cycle_active_stack_for_monitor(
@@ -1754,44 +1758,41 @@ impl Halley {
         direction: halley_core::cluster_layout::ClusterCycleDirection,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .cycle_active_stack_for_monitor(monitor, direction, now)
+        crate::compositor::clusters::system::cycle_active_stack_for_monitor(
+            self, monitor, direction, now,
+        )
     }
 
     pub fn collapse_active_cluster_workspace(&mut self, now: Instant) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .collapse_active_cluster_workspace(now)
+        crate::compositor::clusters::system::collapse_active_cluster_workspace(self, now)
     }
 
     pub fn cluster_mode_active(&self) -> bool {
-        super::clusters::system::cluster_system_controller(self).cluster_mode_active()
+        crate::compositor::clusters::system::cluster_mode_active(self)
     }
 
     pub fn cluster_mode_active_for_monitor(&self, monitor: &str) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .cluster_mode_active_for_monitor(monitor)
+        crate::compositor::clusters::system::cluster_mode_active_for_monitor(self, monitor)
     }
 
     pub fn enter_cluster_mode(&mut self) -> bool {
-        super::clusters::system::cluster_system_controller(self).enter_cluster_mode()
+        crate::compositor::clusters::system::enter_cluster_mode(self)
     }
 
     pub fn exit_cluster_mode(&mut self) -> bool {
-        super::clusters::system::cluster_system_controller(self).exit_cluster_mode()
+        crate::compositor::clusters::system::exit_cluster_mode(self)
     }
 
     pub fn toggle_cluster_mode_selection(&mut self, node_id: NodeId) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .toggle_cluster_mode_selection(node_id)
+        crate::compositor::clusters::system::toggle_cluster_mode_selection(self, node_id)
     }
 
     pub fn confirm_cluster_mode(&mut self, now: Instant) -> bool {
-        super::clusters::system::cluster_system_controller(self).confirm_cluster_mode(now)
+        crate::compositor::clusters::system::confirm_cluster_mode(self, now)
     }
 
     pub fn toggle_cluster_workspace_by_core(&mut self, core_id: NodeId, now: Instant) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .toggle_cluster_workspace_by_core(core_id, now)
+        crate::compositor::clusters::system::toggle_cluster_workspace_by_core(self, core_id, now)
     }
 
     pub(crate) fn activate_cluster_slot_on_current_monitor(
@@ -1799,20 +1800,20 @@ impl Halley {
         slot: u8,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .activate_cluster_slot_on_current_monitor(slot, now)
+        crate::compositor::clusters::system::activate_cluster_slot_on_current_monitor(
+            self, slot, now,
+        )
     }
 
     pub(crate) fn process_pending_cluster_slot_transition_for_current_monitor(
         &mut self,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .process_pending_cluster_slot_transition_for_current_monitor(now)
+        crate::compositor::clusters::system::process_pending_cluster_slot_transition_for_current_monitor(self, now)
     }
 
     pub fn has_active_cluster_workspace(&self) -> bool {
-        super::clusters::system::cluster_system_controller(self).has_active_cluster_workspace()
+        crate::compositor::clusters::system::has_active_cluster_workspace(self)
     }
 
     pub(crate) fn layout_active_cluster_workspace_for_monitor(
@@ -1820,8 +1821,9 @@ impl Halley {
         monitor: &str,
         now_ms: u64,
     ) {
-        super::clusters::system::cluster_system_controller(self)
-            .layout_active_cluster_workspace_for_monitor(monitor, now_ms)
+        crate::compositor::clusters::system::layout_active_cluster_workspace_for_monitor(
+            self, monitor, now_ms,
+        )
     }
 
     pub(crate) fn focus_active_tiled_cluster_member_for_monitor(
@@ -1830,8 +1832,12 @@ impl Halley {
         preferred_index: Option<usize>,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .focus_active_tiled_cluster_member_for_monitor(monitor, preferred_index, now)
+        crate::compositor::clusters::system::focus_active_tiled_cluster_member_for_monitor(
+            self,
+            monitor,
+            preferred_index,
+            now,
+        )
     }
 
     pub(crate) fn tile_focus_active_cluster_member_for_monitor(
@@ -1840,8 +1846,9 @@ impl Halley {
         direction: halley_config::DirectionalAction,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .tile_focus_active_cluster_member_for_monitor(monitor, direction, now)
+        crate::compositor::clusters::system::tile_focus_active_cluster_member_for_monitor(
+            self, monitor, direction, now,
+        )
     }
 
     pub(crate) fn tile_swap_active_cluster_member_for_monitor(
@@ -1850,8 +1857,9 @@ impl Halley {
         direction: halley_config::DirectionalAction,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .tile_swap_active_cluster_member_for_monitor(monitor, direction, now)
+        crate::compositor::clusters::system::tile_swap_active_cluster_member_for_monitor(
+            self, monitor, direction, now,
+        )
     }
 
     pub(crate) fn cycle_active_cluster_layout_for_monitor(
@@ -1859,8 +1867,9 @@ impl Halley {
         monitor: &str,
         now: Instant,
     ) -> bool {
-        super::clusters::system::cluster_system_controller(self)
-            .cycle_active_cluster_layout_for_monitor(monitor, now)
+        crate::compositor::clusters::system::cycle_active_cluster_layout_for_monitor(
+            self, monitor, now,
+        )
     }
 }
 

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -439,6 +439,7 @@ impl Halley {
                     apogee_session: None,
                     apogee_live_preview_node: None,
                     apogee_live_preview_last_at: None,
+                    apogee_hover_node: None,
                     overlay_hover_target: None,
                     cursor_override_until_ms: None,
                     pending_core_hover: None,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1012,28 +1012,28 @@ impl Halley {
     }
 
     pub fn now_ms(&self, now: Instant) -> u64 {
-        super::runtime::runtime_controller(self).now_ms(now)
+        super::runtime::now_ms(self, now)
     }
 
     #[allow(dead_code)]
     pub(crate) fn debug_dump(&self) {
-        super::runtime::runtime_controller(self).debug_dump()
+        super::runtime::debug_dump(self)
     }
 
     pub fn apply_tuning(&mut self, tuning: RuntimeTuning) {
-        super::runtime::runtime_controller(self).apply_tuning(tuning)
+        super::runtime::apply_tuning(self, tuning)
     }
 
     pub fn request_exit(&mut self) {
-        super::runtime::runtime_controller(self).request_exit()
+        super::runtime::request_exit(self)
     }
 
     pub fn exit_requested(&self) -> bool {
-        super::runtime::runtime_controller(self).exit_requested()
+        super::runtime::exit_requested(self)
     }
 
     pub fn request_maintenance(&mut self) {
-        super::runtime::runtime_controller(self).request_maintenance()
+        super::runtime::request_maintenance(self)
     }
 
     pub fn request_tty_redraw_for_monitor(&mut self, monitor: &str) {
@@ -1063,16 +1063,16 @@ impl Halley {
 
     #[allow(dead_code)]
     pub fn next_maintenance_deadline(&self, now: Instant) -> Option<Instant> {
-        super::runtime::runtime_controller(self).next_maintenance_deadline(now)
+        super::runtime::next_maintenance_deadline(self, now)
     }
 
     pub fn run_maintenance_if_needed(&mut self, now: Instant) {
-        super::runtime::runtime_controller(self).run_maintenance_if_needed(now)
+        super::runtime::run_maintenance_if_needed(self, now)
     }
 
     #[allow(dead_code)]
     pub fn run_maintenance(&mut self, now: Instant) {
-        super::runtime::runtime_controller(self).run_maintenance(now)
+        super::runtime::run_maintenance(self, now)
     }
 
     pub(crate) fn record_focus_trail_visit(&mut self, id: NodeId) {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1237,11 +1237,11 @@ impl Halley {
     }
 
     pub fn set_app_focused(&mut self, focused: bool) {
-        super::focus::system::focus_system_controller(self).set_app_focused(focused)
+        super::focus::system::set_app_focused(self, focused)
     }
 
     pub(crate) fn clear_keyboard_focus(&mut self) {
-        super::focus::system::focus_system_controller(self).clear_keyboard_focus()
+        super::focus::system::clear_keyboard_focus(self)
     }
 
     pub fn wl_surface_for_node(
@@ -1264,29 +1264,27 @@ impl Halley {
     }
 
     pub fn apply_wayland_focus_state(&mut self, id: Option<NodeId>) {
-        super::focus::system::focus_system_controller(self).apply_wayland_focus_state(id)
+        super::focus::system::apply_wayland_focus_state(self, id)
     }
 
     pub fn update_focus_tracking_for_surface(&mut self, fid: NodeId, now_ms: u64) {
-        super::focus::system::focus_system_controller(self)
-            .update_focus_tracking_for_surface(fid, now_ms)
+        super::focus::system::update_focus_tracking_for_surface(self, fid, now_ms)
     }
 
     pub fn note_pan_activity(&mut self, now: Instant) {
-        super::focus::system::focus_system_controller(self).note_pan_activity(now)
+        super::focus::system::note_pan_activity(self, now)
     }
 
     pub(crate) fn note_pan_viewport_change(&mut self, now: Instant) {
-        super::focus::system::focus_system_controller(self).note_pan_viewport_change(now)
+        super::focus::system::note_pan_viewport_change(self, now)
     }
 
     pub fn set_pan_restore_focus_target(&mut self, id: NodeId) {
-        super::focus::system::focus_system_controller(self).set_pan_restore_focus_target(id)
+        super::focus::system::set_pan_restore_focus_target(self, id)
     }
 
     pub fn animate_viewport_center_to(&mut self, target_center: Vec2, now: Instant) -> bool {
-        super::focus::system::focus_system_controller(self)
-            .animate_viewport_center_to(target_center, now)
+        super::focus::system::animate_viewport_center_to(self, target_center, now)
     }
 
     pub fn animate_viewport_center_to_on_monitor(
@@ -1295,7 +1293,8 @@ impl Halley {
         target_center: Vec2,
         now: Instant,
     ) -> bool {
-        super::focus::system::focus_system_controller(self).animate_viewport_center_to_on_monitor(
+        super::focus::system::animate_viewport_center_to_on_monitor(
+            self,
             monitor,
             target_center,
             now,
@@ -1308,15 +1307,11 @@ impl Halley {
         now: Instant,
         delay_ms: u64,
     ) -> bool {
-        super::focus::system::focus_system_controller(self).animate_viewport_center_to_delayed(
-            target_center,
-            now,
-            delay_ms,
-        )
+        super::focus::system::animate_viewport_center_to_delayed(self, target_center, now, delay_ms)
     }
 
     pub(crate) fn tick_viewport_pan_animation(&mut self, now_ms: u64) {
-        super::focus::system::focus_system_controller(self).tick_viewport_pan_animation(now_ms)
+        super::focus::system::tick_viewport_pan_animation(self, now_ms)
     }
 
     pub(crate) fn surface_is_fully_visible_on_monitor(&self, monitor: &str, id: NodeId) -> bool {
@@ -1337,24 +1332,23 @@ impl Halley {
         id: NodeId,
         now: Instant,
     ) -> bool {
-        super::focus::system::focus_system_controller(self)
-            .maybe_pan_to_restored_focus_on_close(monitor, id, now)
+        super::focus::system::maybe_pan_to_restored_focus_on_close(self, monitor, id, now)
     }
 
     pub fn begin_resize_interaction(&mut self, id: NodeId, now: Instant) {
-        super::focus::system::focus_system_controller(self).begin_resize_interaction(id, now)
+        super::focus::system::begin_resize_interaction(self, id, now)
     }
 
     pub fn end_resize_interaction(&mut self, now: Instant) {
-        super::focus::system::focus_system_controller(self).end_resize_interaction(now)
+        super::focus::system::end_resize_interaction(self, now)
     }
 
     pub fn resolve_overlap_now(&mut self) {
-        super::focus::system::focus_system_controller(self).resolve_overlap_now()
+        super::focus::system::resolve_overlap_now(self)
     }
 
     pub fn set_last_active_size_now(&mut self, id: NodeId, size: Vec2) {
-        super::focus::system::focus_system_controller(self).set_last_active_size_now(id, size)
+        super::focus::system::set_last_active_size_now(self, id, size)
     }
 
     pub fn last_focused_surface_node(&self) -> Option<NodeId> {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -623,33 +623,12 @@ impl Halley {
         self.aperture.config()
     }
 
-    pub(crate) fn focus_ctx(&self) -> super::ctx::FocusCtx<'_> {
-        super::ctx::focus_ctx(self)
-    }
-
-    pub(crate) fn spawn_ctx(&mut self) -> super::ctx::SpawnCtx<'_> {
-        super::ctx::spawn_ctx(self)
-    }
-
     pub(crate) fn surface_lifecycle_ctx(&mut self) -> super::ctx::SurfaceLifecycleCtx<'_> {
         super::ctx::surface_lifecycle_ctx(self)
     }
 
     pub(crate) fn layer_shell_ctx(&mut self) -> super::ctx::LayerShellCtx<'_> {
         super::ctx::layer_shell_ctx(self)
-    }
-
-    pub(crate) fn pointer_ctx(&mut self) -> super::ctx::PointerCtx<'_> {
-        super::ctx::pointer_ctx(self)
-    }
-
-    pub(crate) fn fullscreen_ctx(&mut self) -> super::ctx::FullscreenCtx<'_> {
-        super::ctx::fullscreen_ctx(self)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn default_spawn_view_anchor_for_monitor(&self, monitor: &str) -> Vec2 {
-        super::spawn::state::default_spawn_view_anchor_for_monitor(self, monitor)
     }
 
     pub(crate) fn spawn_monitor_state(
@@ -664,10 +643,6 @@ impl Halley {
         monitor: &str,
     ) -> &mut super::spawn::state::MonitorSpawnState {
         super::spawn::state::spawn_monitor_state_mut(self, monitor)
-    }
-
-    pub(crate) fn process_pending_spawn_activations(&mut self, now: Instant, now_ms: u64) {
-        super::spawn::state::process_pending_spawn_activations(self, now, now_ms)
     }
 
     pub fn active_zoom_lock_scale(&self) -> f32 {
@@ -692,10 +667,6 @@ impl Halley {
 
     pub(crate) fn activate_monitor(&mut self, name: &str) -> bool {
         super::monitor::state::activate_monitor(self, name)
-    }
-
-    pub(crate) fn sync_xwayland_primary(&mut self, name: &str) {
-        super::monitor::state::sync_xwayland_primary(self, name)
     }
 
     pub(crate) fn begin_temporary_render_monitor(&mut self, name: &str) -> Option<String> {
@@ -781,14 +752,6 @@ impl Halley {
         super::monitor::state::monitor_for_screen_or_interaction(self, sx, sy)
     }
 
-    pub(crate) fn monitor_for_screen_clamped(
-        &self,
-        sx: f32,
-        sy: f32,
-    ) -> Option<(String, f32, f32)> {
-        super::monitor::state::monitor_for_screen_clamped(self, sx, sy)
-    }
-
     pub(crate) fn local_screen_in_monitor(
         &self,
         name: &str,
@@ -827,14 +790,6 @@ impl Halley {
         }
     }
 
-    pub(crate) fn assign_layer_surface_to_monitor(
-        &mut self,
-        surface: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
-        monitor: String,
-    ) {
-        super::monitor::state::assign_layer_surface_to_monitor(self, surface, monitor)
-    }
-
     pub(crate) fn output_transform_for(&self, name: &str) -> smithay::utils::Transform {
         super::monitor::state::output_transform_for(self, name)
     }
@@ -870,25 +825,10 @@ impl Halley {
         super::platform::apply_toplevel_tiled_hint(self, state)
     }
 
-    pub(crate) fn refresh_xdg_decoration_mode(&mut self) {
-        super::platform::refresh_xdg_decoration_mode(self)
-    }
-
     pub(crate) fn effective_cursor_image_status(
         &self,
     ) -> smithay::input::pointer::CursorImageStatus {
         super::platform::effective_cursor_image_status(self)
-    }
-
-    pub(crate) fn install_drm_syncobj_blocker(
-        &mut self,
-        surface: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface,
-    ) {
-        super::platform::install_drm_syncobj_blocker(self, surface)
-    }
-
-    pub(crate) fn drain_drm_syncobj_blockers(&mut self) {
-        super::platform::drain_drm_syncobj_blockers(self)
     }
 
     pub(crate) fn configure_dmabuf_importer(
@@ -915,10 +855,6 @@ impl Halley {
         >,
     ) {
         super::platform::configure_dmabuf_output_feedbacks(self, output_feedbacks)
-    }
-
-    pub fn note_input_activity(&mut self) {
-        super::platform::note_input_activity(self)
     }
 
     pub(crate) fn non_overlap_gap_world(&self) -> f32 {
@@ -977,10 +913,6 @@ impl Halley {
         super::overlap::system::collision_extents_for_node(self, n)
     }
 
-    pub(crate) fn collision_size_for_node(&self, n: &halley_core::field::Node) -> Vec2 {
-        super::overlap::system::collision_size_for_node(self, n)
-    }
-
     pub(crate) fn resolve_surface_overlap(&mut self) {
         super::overlap::system::resolve_surface_overlap(self)
     }
@@ -991,10 +923,6 @@ impl Halley {
 
     pub(crate) fn request_toplevel_resize(&mut self, node_id: NodeId, width: i32, height: i32) {
         super::overlap::system::request_toplevel_resize(self, node_id, width, height)
-    }
-
-    pub(crate) fn node_has_overlap_policy(&self, id: NodeId) -> bool {
-        super::spawn::state::node_has_overlap_policy(self, id)
     }
 
     pub(crate) fn node_draws_above_fullscreen_on_monitor(&self, id: NodeId, monitor: &str) -> bool {
@@ -1008,25 +936,12 @@ impl Halley {
         )
     }
 
-    pub(crate) fn monitor_has_visible_overlap_policy_window(&self, monitor: &str) -> bool {
-        super::spawn::state::monitor_has_visible_overlap_policy_window(self, monitor)
-    }
-
     pub fn now_ms(&self, now: Instant) -> u64 {
         super::runtime::now_ms(self, now)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn debug_dump(&self) {
-        super::runtime::debug_dump(self)
-    }
-
     pub fn apply_tuning(&mut self, tuning: RuntimeTuning) {
         super::runtime::apply_tuning(self, tuning)
-    }
-
-    pub fn request_exit(&mut self) {
-        super::runtime::request_exit(self)
     }
 
     pub fn exit_requested(&self) -> bool {
@@ -1062,18 +977,8 @@ impl Halley {
             .unwrap_or(0)
     }
 
-    #[allow(dead_code)]
-    pub fn next_maintenance_deadline(&self, now: Instant) -> Option<Instant> {
-        super::runtime::next_maintenance_deadline(self, now)
-    }
-
     pub fn run_maintenance_if_needed(&mut self, now: Instant) {
         super::runtime::run_maintenance_if_needed(self, now)
-    }
-
-    #[allow(dead_code)]
-    pub fn run_maintenance(&mut self, now: Instant) {
-        super::runtime::run_maintenance(self, now)
     }
 
     pub(crate) fn record_focus_trail_visit(&mut self, id: NodeId) {
@@ -1139,10 +1044,6 @@ impl Halley {
         )
     }
 
-    pub(crate) fn companion_surface_node(&self, now_ms: u64) -> Option<NodeId> {
-        super::focus::state::companion_surface_node(self, now_ms)
-    }
-
     pub fn active_focus_ring(&self) -> halley_core::viewport::FocusRing {
         super::focus::state::active_focus_ring(self)
     }
@@ -1163,28 +1064,9 @@ impl Halley {
         super::focus::state::set_interaction_focus(self, id, hold_ms, now)
     }
 
-    pub(crate) fn restore_pan_return_active_focus(&mut self, now: Instant) {
-        super::focus::state::restore_pan_return_active_focus(self, now)
-    }
-
-    #[allow(dead_code)]
-    pub fn reassert_wayland_keyboard_focus_if_drifted(&mut self, id: Option<NodeId>) {
-        super::focus::state::reassert_wayland_keyboard_focus_if_drifted(self, id)
-    }
-
     #[allow(dead_code)]
     pub(crate) fn focused_node_for_monitor(&self, monitor: &str) -> Option<NodeId> {
         super::focus::state::focused_node_for_monitor(self, monitor)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn focused_monitor_for_node(&self, id: NodeId) -> Option<String> {
-        super::focus::state::focused_monitor_for_node(self, id)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn set_monitor_focus(&mut self, monitor: &str, id: NodeId) {
-        super::focus::state::set_monitor_focus(self, monitor, id)
     }
 
     pub fn set_recent_top_node(&mut self, node_id: NodeId, until: Instant) {
@@ -1206,10 +1088,6 @@ impl Halley {
         now: Instant,
     ) -> NodeId {
         super::focus::system::focus_pointer_target(self, node_id, hold_ms, now)
-    }
-
-    pub fn recent_top_node_active(&mut self, now: Instant) -> Option<NodeId> {
-        super::focus::state::recent_top_node_active(self, now)
     }
 
     pub(crate) fn focus_cycle_session_active(&self) -> bool {
@@ -1243,13 +1121,6 @@ impl Halley {
 
     pub(crate) fn clear_keyboard_focus(&mut self) {
         super::focus::system::clear_keyboard_focus(self)
-    }
-
-    pub fn wl_surface_for_node(
-        &self,
-        id: NodeId,
-    ) -> Option<smithay::reexports::wayland_server::protocol::wl_surface::WlSurface> {
-        super::focus::system::wl_surface_for_node(self, id)
     }
 
     #[cfg(test)]
@@ -1302,15 +1173,6 @@ impl Halley {
         )
     }
 
-    pub fn animate_viewport_center_to_delayed(
-        &mut self,
-        target_center: Vec2,
-        now: Instant,
-        delay_ms: u64,
-    ) -> bool {
-        super::focus::system::animate_viewport_center_to_delayed(self, target_center, now, delay_ms)
-    }
-
     pub(crate) fn tick_viewport_pan_animation(&mut self, now_ms: u64) {
         super::focus::system::tick_viewport_pan_animation(self, now_ms)
     }
@@ -1325,23 +1187,6 @@ impl Halley {
         id: NodeId,
     ) -> Option<Vec2> {
         super::focus::system::minimal_reveal_center_for_surface_on_monitor(self, monitor, id)
-    }
-
-    pub(crate) fn maybe_pan_to_restored_focus_on_close(
-        &mut self,
-        monitor: &str,
-        id: NodeId,
-        now: Instant,
-    ) -> bool {
-        super::focus::system::maybe_pan_to_restored_focus_on_close(self, monitor, id, now)
-    }
-
-    pub fn begin_resize_interaction(&mut self, id: NodeId, now: Instant) {
-        super::focus::system::begin_resize_interaction(self, id, now)
-    }
-
-    pub fn end_resize_interaction(&mut self, now: Instant) {
-        super::focus::system::end_resize_interaction(self, now)
     }
 
     pub fn resolve_overlap_now(&mut self) {
@@ -1366,10 +1211,6 @@ impl Halley {
 
     pub fn last_input_surface_node_for_monitor(&self, monitor: &str) -> Option<NodeId> {
         super::focus::system::last_input_surface_node_for_monitor(self, monitor)
-    }
-
-    pub(crate) fn fullscreen_entry_scale(&self, node_id: NodeId, now_ms: u64) -> f32 {
-        super::fullscreen::system::fullscreen_entry_scale(self, node_id, now_ms)
     }
 
     pub(crate) fn fullscreen_monitor_for_node(&self, node_id: NodeId) -> Option<&str> {
@@ -1427,10 +1268,6 @@ impl Halley {
 
     pub(crate) fn exit_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
         super::fullscreen::system::exit_xdg_fullscreen(self, node_id, now)
-    }
-
-    pub(crate) fn drop_fullscreen_surface(&mut self, id: NodeId, now: Instant) {
-        super::fullscreen::system::drop_fullscreen_surface(self, id, now)
     }
 
     pub(crate) fn tick_fullscreen_motion(&mut self, now: Instant) {
@@ -1534,15 +1371,6 @@ impl Halley {
         super::spawn::reveal::placement::finalize_initial_spawn_position(self, id, size)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn maybe_start_pending_spawn_pan(&mut self, now: Instant) {
-        super::spawn::reveal::maybe_start_pending_spawn_pan(self, now)
-    }
-
-    pub(crate) fn tick_pending_spawn_pan(&mut self, now: Instant, now_ms: u64) {
-        super::spawn::reveal::tick_pending_spawn_pan(self, now, now_ms)
-    }
-
     pub(crate) fn reveal_new_toplevel_node(
         &mut self,
         id: NodeId,
@@ -1584,14 +1412,6 @@ impl Halley {
         )
     }
 
-    pub fn open_cluster_bloom_for_monitor(
-        &mut self,
-        monitor: &str,
-        cid: halley_core::cluster::ClusterId,
-    ) -> bool {
-        crate::compositor::clusters::system::open_cluster_bloom_for_monitor(self, monitor, cid)
-    }
-
     pub fn close_cluster_bloom_for_monitor(&mut self, monitor: &str) -> bool {
         crate::compositor::clusters::system::close_cluster_bloom_for_monitor(self, monitor)
     }
@@ -1618,14 +1438,6 @@ impl Halley {
         crate::compositor::clusters::system::absorb_node_into_cluster(self, cid, node_id, now)
     }
 
-    pub(crate) fn commit_ready_cluster_join_for_node(
-        &mut self,
-        node_id: NodeId,
-        now: Instant,
-    ) -> bool {
-        crate::compositor::clusters::system::commit_ready_cluster_join_for_node(self, node_id, now)
-    }
-
     pub fn active_cluster_workspace_for_monitor(
         &self,
         monitor: &str,
@@ -1633,22 +1445,10 @@ impl Halley {
         super::clusters::system::active_cluster_workspace_for_monitor(self, monitor)
     }
 
-    pub(crate) fn stack_layout_rects_for_members(
-        &self,
-        monitor: &str,
-        members: &[NodeId],
-    ) -> Option<std::collections::HashMap<NodeId, halley_core::tiling::Rect>> {
-        super::clusters::system::stack_layout_rects_for_members(self, monitor, members)
-    }
-
     pub(crate) fn reveal_cluster_overflow_for_monitor(&mut self, monitor: &str, now_ms: u64) {
         crate::compositor::clusters::system::reveal_cluster_overflow_for_monitor(
             self, monitor, now_ms,
         )
-    }
-
-    pub(crate) fn hide_cluster_overflow_for_monitor(&mut self, monitor: &str) {
-        crate::compositor::clusters::system::hide_cluster_overflow_for_monitor(self, monitor)
     }
 
     pub(crate) fn cluster_overflow_rect_for_monitor(
@@ -1698,10 +1498,6 @@ impl Halley {
         cid: halley_core::cluster::ClusterId,
     ) -> Option<halley_core::tiling::Rect> {
         crate::compositor::clusters::system::cluster_spawn_rect_for_new_member(self, monitor, cid)
-    }
-
-    pub fn has_any_active_cluster_workspace(&self) -> bool {
-        crate::compositor::clusters::system::has_any_active_cluster_workspace(self)
     }
 
     pub(crate) fn swap_cluster_overflow_member_with_visible(
@@ -1785,10 +1581,6 @@ impl Halley {
 
     pub fn toggle_cluster_mode_selection(&mut self, node_id: NodeId) -> bool {
         crate::compositor::clusters::system::toggle_cluster_mode_selection(self, node_id)
-    }
-
-    pub fn confirm_cluster_mode(&mut self, now: Instant) -> bool {
-        crate::compositor::clusters::system::confirm_cluster_mode(self, now)
     }
 
     pub fn toggle_cluster_workspace_by_core(&mut self, core_id: NodeId, now: Instant) -> bool {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1076,7 +1076,7 @@ impl Halley {
     }
 
     pub(crate) fn record_focus_trail_visit(&mut self, id: NodeId) {
-        super::focus::trail::focus_trail_controller(self).record_focus_trail_visit(id)
+        super::focus::trail::record_focus_trail_visit(self, id)
     }
 
     #[cfg(test)]
@@ -1092,7 +1092,7 @@ impl Halley {
         direction: halley_api::TrailDirection,
         now: Instant,
     ) -> bool {
-        super::focus::trail::focus_trail_controller(self).navigate_window_trail(direction, now)
+        super::focus::trail::navigate_window_trail(self, direction, now)
     }
 
     pub(crate) fn previous_window_from_trail_on_close(
@@ -1100,8 +1100,7 @@ impl Halley {
         monitor: &str,
         closing_id: NodeId,
     ) -> Option<NodeId> {
-        super::focus::trail::focus_trail_controller(self)
-            .previous_window_from_trail_on_close(monitor, closing_id)
+        super::focus::trail::previous_window_from_trail_on_close(self, monitor, closing_id)
     }
 
     pub(crate) fn restore_focus_to_node_after_close(
@@ -1111,12 +1110,7 @@ impl Halley {
         now: Instant,
         suppress_pan: bool,
     ) -> bool {
-        super::focus::trail::focus_trail_controller(self).restore_focus_to_node_after_close(
-            monitor,
-            id,
-            now,
-            suppress_pan,
-        )
+        super::focus::trail::restore_focus_to_node_after_close(self, monitor, id, now, suppress_pan)
     }
 
     pub(crate) fn enforce_single_primary_active_unit(&mut self) {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1232,15 +1232,15 @@ impl Halley {
         direction: halley_config::FocusCycleBindingAction,
         now: Instant,
     ) -> bool {
-        super::focus::cycle::focus_cycle_controller(self).start_or_step_focus_cycle(direction, now)
+        super::focus::cycle::start_or_step_focus_cycle(self, direction, now)
     }
 
     pub(crate) fn cancel_focus_cycle(&mut self) -> bool {
-        super::focus::cycle::focus_cycle_controller(self).cancel_focus_cycle()
+        super::focus::cycle::cancel_focus_cycle(self)
     }
 
     pub(crate) fn commit_focus_cycle(&mut self, now: Instant) -> bool {
-        super::focus::cycle::focus_cycle_controller(self).commit_focus_cycle(now)
+        super::focus::cycle::commit_focus_cycle(self, now)
     }
 
     pub fn set_app_focused(&mut self, focused: bool) {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -466,6 +466,7 @@ impl Halley {
                 exit_requested: false,
                 started_at: now,
                 maintenance_dirty: true,
+                skip_next_cluster_relayout: false,
                 screenshot_full_repaint_until_ms: 0,
                 maintenance_ping: None,
                 tty_redraw_all: true,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1139,64 +1139,63 @@ impl Halley {
     }
 
     pub(crate) fn companion_surface_node(&self, now_ms: u64) -> Option<NodeId> {
-        super::focus::state::focus_state_controller(self).companion_surface_node(now_ms)
+        super::focus::state::companion_surface_node(self, now_ms)
     }
 
     pub fn active_focus_ring(&self) -> halley_core::viewport::FocusRing {
-        super::focus::state::focus_state_controller(self).active_focus_ring()
+        super::focus::state::active_focus_ring(self)
     }
 
     pub fn focus_ring_for_monitor(&self, monitor: &str) -> halley_core::viewport::FocusRing {
-        super::focus::state::focus_state_controller(self).focus_ring_for_monitor(monitor)
+        super::focus::state::focus_ring_for_monitor(self, monitor)
     }
 
     pub fn should_draw_focus_ring_preview(&self, now: Instant) -> bool {
-        super::focus::state::focus_state_controller(self).should_draw_focus_ring_preview(now)
+        super::focus::state::should_draw_focus_ring_preview(self, now)
     }
 
     pub(crate) fn focus_monitor_view(&mut self, monitor: &str, now: Instant) {
-        super::focus::state::focus_state_controller(self).focus_monitor_view(monitor, now)
+        super::focus::state::focus_monitor_view(self, monitor, now)
     }
 
     pub fn set_interaction_focus(&mut self, id: Option<NodeId>, hold_ms: u64, now: Instant) {
-        super::focus::state::focus_state_controller(self).set_interaction_focus(id, hold_ms, now)
+        super::focus::state::set_interaction_focus(self, id, hold_ms, now)
     }
 
     pub(crate) fn restore_pan_return_active_focus(&mut self, now: Instant) {
-        super::focus::state::focus_state_controller(self).restore_pan_return_active_focus(now)
+        super::focus::state::restore_pan_return_active_focus(self, now)
     }
 
     #[allow(dead_code)]
     pub fn reassert_wayland_keyboard_focus_if_drifted(&mut self, id: Option<NodeId>) {
-        super::focus::state::focus_state_controller(self)
-            .reassert_wayland_keyboard_focus_if_drifted(id)
+        super::focus::state::reassert_wayland_keyboard_focus_if_drifted(self, id)
     }
 
     #[allow(dead_code)]
     pub(crate) fn focused_node_for_monitor(&self, monitor: &str) -> Option<NodeId> {
-        super::focus::state::focus_state_controller(self).focused_node_for_monitor(monitor)
+        super::focus::state::focused_node_for_monitor(self, monitor)
     }
 
     #[allow(dead_code)]
     pub(crate) fn focused_monitor_for_node(&self, id: NodeId) -> Option<String> {
-        super::focus::state::focus_state_controller(self).focused_monitor_for_node(id)
+        super::focus::state::focused_monitor_for_node(self, id)
     }
 
     #[allow(dead_code)]
     pub(crate) fn set_monitor_focus(&mut self, monitor: &str, id: NodeId) {
-        super::focus::state::focus_state_controller(self).set_monitor_focus(monitor, id)
+        super::focus::state::set_monitor_focus(self, monitor, id)
     }
 
     pub fn set_recent_top_node(&mut self, node_id: NodeId, until: Instant) {
-        super::focus::state::focus_state_controller(self).set_recent_top_node(node_id, until)
+        super::focus::state::set_recent_top_node(self, node_id, until)
     }
 
     pub fn raise_overlap_policy_node(&mut self, node_id: NodeId) -> bool {
-        super::focus::state::focus_state_controller(self).raise_overlap_policy_node(node_id)
+        super::focus::state::raise_overlap_policy_node(self, node_id)
     }
 
     pub fn overlap_policy_stack_rank(&self, node_id: NodeId) -> (u64, u64) {
-        super::focus::state::focus_state_controller(self).overlap_policy_stack_rank(node_id)
+        super::focus::state::overlap_policy_stack_rank(self, node_id)
     }
 
     pub(crate) fn focus_pointer_target(
@@ -1209,7 +1208,7 @@ impl Halley {
     }
 
     pub fn recent_top_node_active(&mut self, now: Instant) -> Option<NodeId> {
-        super::focus::state::focus_state_controller(self).recent_top_node_active(now)
+        super::focus::state::recent_top_node_active(self, now)
     }
 
     pub(crate) fn focus_cycle_session_active(&self) -> bool {

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1120,13 +1120,12 @@ impl Halley {
     }
 
     pub(crate) fn enforce_single_primary_active_unit(&mut self) {
-        super::focus::decay::focus_decay_controller(self).enforce_single_primary_active_unit()
+        super::focus::decay::enforce_single_primary_active_unit(self)
     }
 
     #[cfg(test)]
     pub(crate) fn surface_is_definitively_outside_focus_ring(&self, id: NodeId) -> bool {
-        super::focus::decay::focus_decay_controller(self)
-            .surface_is_definitively_outside_focus_ring(id)
+        super::focus::decay::surface_is_definitively_outside_focus_ring(self, id)
     }
 
     pub fn apply_single_surface_decay_policy(
@@ -1136,7 +1135,8 @@ impl Halley {
         active_delay_ms: u64,
         inactive_delay_ms: u64,
     ) {
-        super::focus::decay::focus_decay_controller(self).apply_single_surface_decay_policy(
+        super::focus::decay::apply_single_surface_decay_policy(
+            self,
             id,
             now_ms,
             active_delay_ms,

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -1410,8 +1410,7 @@ impl Halley {
     }
 
     pub(crate) fn soft_suspend_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        super::fullscreen::system::fullscreen_controller(self)
-            .soft_suspend_xdg_fullscreen(node_id, now)
+        super::fullscreen::system::soft_suspend_xdg_fullscreen(self, node_id, now)
     }
 
     pub(crate) fn enter_xdg_fullscreen(
@@ -1420,8 +1419,7 @@ impl Halley {
         output: Option<smithay::reexports::wayland_server::protocol::wl_output::WlOutput>,
         now: Instant,
     ) {
-        super::fullscreen::system::fullscreen_controller(self)
-            .enter_xdg_fullscreen(node_id, output, now)
+        super::fullscreen::system::enter_xdg_fullscreen(self, node_id, output, now)
     }
 
     pub(crate) fn enter_user_fullscreen(
@@ -1430,20 +1428,19 @@ impl Halley {
         output: Option<smithay::reexports::wayland_server::protocol::wl_output::WlOutput>,
         now: Instant,
     ) {
-        super::fullscreen::system::fullscreen_controller(self)
-            .enter_user_fullscreen(node_id, output, now)
+        super::fullscreen::system::enter_user_fullscreen(self, node_id, output, now)
     }
 
     pub(crate) fn exit_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
-        super::fullscreen::system::fullscreen_controller(self).exit_xdg_fullscreen(node_id, now)
+        super::fullscreen::system::exit_xdg_fullscreen(self, node_id, now)
     }
 
     pub(crate) fn drop_fullscreen_surface(&mut self, id: NodeId, now: Instant) {
-        super::fullscreen::system::fullscreen_controller(self).drop_fullscreen_surface(id, now)
+        super::fullscreen::system::drop_fullscreen_surface(self, id, now)
     }
 
     pub(crate) fn tick_fullscreen_motion(&mut self, now: Instant) {
-        super::fullscreen::system::fullscreen_controller(self).tick_fullscreen_motion(now)
+        super::fullscreen::system::tick_fullscreen_motion(self, now)
     }
 
     #[cfg(test)]

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -2,17 +2,15 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use calloop::ping::Ping;
-use eventline::warn;
-use halley_config::RuntimeTuning;
-use smithay::reexports::wayland_server::backend::ObjectId;
-
-use super::monitor::camera::camera_controller;
 use super::root::Halley;
 use super::screenshot;
 use crate::animation::AnimSpec;
 use crate::compositor::activity::CommitActivity;
 use crate::protocol::wayland::activation::ActivationRuntimeState;
+use calloop::ping::Ping;
+use eventline::warn;
+use halley_config::RuntimeTuning;
+use smithay::reexports::wayland_server::backend::ObjectId;
 
 const FIXED_ANIM_STATE_CHANGE_MS: u64 = 360;
 const FIXED_ANIM_BOUNCE: f32 = 1.45;
@@ -612,7 +610,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
         && !(st.input.interaction_state.resize_static_node.is_some()
             && now_ms < st.input.interaction_state.resize_static_until_ms)
     {
-        camera_controller(&mut *st).update_zoom_live_surface_sizes();
+        crate::compositor::monitor::camera::update_zoom_live_surface_sizes(&mut *st);
     }
     let cluster_policy = halley_core::cluster_policy::ClusterPolicy {
         enabled: false,

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -21,6 +21,7 @@ pub(crate) struct RuntimeState {
     pub(crate) exit_requested: bool,
     pub(crate) started_at: Instant,
     pub(crate) maintenance_dirty: bool,
+    pub(crate) skip_next_cluster_relayout: bool,
     pub(crate) screenshot_full_repaint_until_ms: u64,
     pub(crate) maintenance_ping: Option<Ping>,
     pub(crate) tty_redraw_all: bool,
@@ -447,7 +448,11 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
         st.input.interaction_state.cursor_override_until_ms = None;
         st.input.interaction_state.cursor_override_icon = None;
     }
-    if crate::compositor::clusters::system::has_any_active_cluster_workspace(st) {
+    let skip_cluster_relayout = st.runtime.skip_next_cluster_relayout;
+    st.runtime.skip_next_cluster_relayout = false;
+    if !skip_cluster_relayout
+        && crate::compositor::clusters::system::has_any_active_cluster_workspace(st)
+    {
         let active_monitors = st
             .model
             .cluster_state

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -35,60 +34,36 @@ pub(crate) struct RuntimeState {
     pub(crate) wayland_display: Option<String>,
 }
 
-pub(crate) struct RuntimeController<T> {
-    st: T,
+pub fn now_ms(st: &Halley, now: Instant) -> u64 {
+    now.duration_since(st.runtime.started_at).as_millis() as u64
 }
 
-pub(crate) fn runtime_controller<T>(st: T) -> RuntimeController<T> {
-    RuntimeController { st }
+pub(crate) fn debug_dump(_st: &Halley) {}
+
+pub fn exit_requested(st: &Halley) -> bool {
+    st.runtime.exit_requested
 }
 
-impl<T: Deref<Target = Halley>> Deref for RuntimeController<T> {
-    type Target = Halley;
-
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
-    }
-}
-
-impl<T: DerefMut<Target = Halley>> DerefMut for RuntimeController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
-    }
-}
-
-impl<T: Deref<Target = Halley>> RuntimeController<T> {
-    pub fn now_ms(&self, now: Instant) -> u64 {
-        now.duration_since(self.runtime.started_at).as_millis() as u64
+pub fn next_maintenance_deadline(st: &Halley, now: Instant) -> Option<Instant> {
+    if !st.model.focus_state.app_focused {
+        return None;
     }
 
-    pub(crate) fn debug_dump(&self) {}
-
-    pub fn exit_requested(&self) -> bool {
-        self.runtime.exit_requested
-    }
-
-    pub fn next_maintenance_deadline(&self, now: Instant) -> Option<Instant> {
-        if !self.model.focus_state.app_focused {
-            return None;
-        }
-
-        let now_ms = self.now_ms(now);
-        let next_ms = min_optional_deadlines([
-            focus_deadline_ms(self, now_ms),
-            resize_deadline_ms(self, now_ms),
-            spawn_deadline_ms(self, now_ms),
-            workspace_deadline_ms(self, now_ms),
-            interaction_deadline_ms(self, now_ms),
-            animation_deadline_ms(self, now_ms),
-        ]);
-        next_ms.map(|at_ms| {
-            now.checked_add(std::time::Duration::from_millis(
-                at_ms.saturating_sub(now_ms),
-            ))
-            .unwrap_or(now)
-        })
-    }
+    let now_ms = now_ms(st, now);
+    let next_ms = min_optional_deadlines([
+        focus_deadline_ms(st, now_ms),
+        resize_deadline_ms(st, now_ms),
+        spawn_deadline_ms(st, now_ms),
+        workspace_deadline_ms(st, now_ms),
+        interaction_deadline_ms(st, now_ms),
+        animation_deadline_ms(st, now_ms),
+    ]);
+    next_ms.map(|at_ms| {
+        now.checked_add(std::time::Duration::from_millis(
+            at_ms.saturating_sub(now_ms),
+        ))
+        .unwrap_or(now)
+    })
 }
 
 fn min_optional_deadlines<const N: usize>(deadlines: [Option<u64>; N]) -> Option<u64> {
@@ -262,409 +237,406 @@ fn animation_deadline_ms(st: &Halley, now_ms: u64) -> Option<u64> {
     ])
 }
 
-impl<T: DerefMut<Target = Halley>> RuntimeController<T> {
-    pub fn apply_tuning(&mut self, mut tuning: RuntimeTuning) {
-        let prev_runtime_viewport = self.model.viewport;
-        let prev_config_viewport = self.runtime.tuning.viewport();
-        let prev_decorations = self.runtime.tuning.decorations;
-        let prev_font = self.runtime.tuning.font.clone();
-        let prev_input = self.runtime.tuning.input.clone();
-        let prev_physics_enabled = self.runtime.tuning.physics_enabled;
-        let prev_focus = self.last_input_surface_node();
-        let previous_output_names: std::collections::HashSet<String> = self
-            .model
-            .monitor_state
-            .monitors
-            .keys()
-            .cloned()
-            .chain(
-                self.runtime
-                    .tuning
-                    .tty_viewports
-                    .iter()
-                    .map(|v| v.connector.clone()),
-            )
-            .collect();
+pub fn apply_tuning(st: &mut Halley, mut tuning: RuntimeTuning) {
+    let prev_runtime_viewport = st.model.viewport;
+    let prev_config_viewport = st.runtime.tuning.viewport();
+    let prev_decorations = st.runtime.tuning.decorations;
+    let prev_font = st.runtime.tuning.font.clone();
+    let prev_input = st.runtime.tuning.input.clone();
+    let prev_physics_enabled = st.runtime.tuning.physics_enabled;
+    let prev_focus = st.last_input_surface_node();
+    let previous_output_names: std::collections::HashSet<String> = st
+        .model
+        .monitor_state
+        .monitors
+        .keys()
+        .cloned()
+        .chain(
+            st.runtime
+                .tuning
+                .tty_viewports
+                .iter()
+                .map(|v| v.connector.clone()),
+        )
+        .collect();
 
-        tuning.enforce_guards();
-        tuning.apply_process_env();
+    tuning.enforce_guards();
+    tuning.apply_process_env();
 
-        let next_viewport = tuning.viewport();
-        let logical_viewport_changed = prev_config_viewport.center != next_viewport.center
-            || prev_config_viewport.size != next_viewport.size;
-        if logical_viewport_changed {
-            self.model.viewport = next_viewport;
-            self.model.zoom_ref_size = tuning.viewport_size;
-            self.model.camera_target_center = self.model.viewport.center;
-            self.model.camera_target_view_size = self.model.zoom_ref_size;
-            if prev_runtime_viewport.center != next_viewport.center
-                || prev_runtime_viewport.size != next_viewport.size
+    let next_viewport = tuning.viewport();
+    let logical_viewport_changed = prev_config_viewport.center != next_viewport.center
+        || prev_config_viewport.size != next_viewport.size;
+    if logical_viewport_changed {
+        st.model.viewport = next_viewport;
+        st.model.zoom_ref_size = tuning.viewport_size;
+        st.model.camera_target_center = st.model.viewport.center;
+        st.model.camera_target_view_size = st.model.zoom_ref_size;
+        if prev_runtime_viewport.center != next_viewport.center
+            || prev_runtime_viewport.size != next_viewport.size
+        {
+            st.input.interaction_state.viewport_pan_anim = None;
+        }
+    }
+
+    st.ui.render_state.animator.set_spec(AnimSpec {
+        state_change_ms: FIXED_ANIM_STATE_CHANGE_MS,
+        bounce: FIXED_ANIM_BOUNCE,
+    });
+
+    if prev_physics_enabled && !tuning.physics_enabled {
+        st.input.interaction_state.drag_authority_node = None;
+        st.input.interaction_state.physics_velocity.clear();
+        st.input.interaction_state.smoothed_render_pos.clear();
+        st.model.camera_target_center = st.model.viewport.center;
+        st.model.camera_target_view_size = st.model.zoom_ref_size;
+    }
+
+    let next_output_names: std::collections::HashSet<String> = previous_output_names
+        .iter()
+        .cloned()
+        .chain(tuning.tty_viewports.iter().map(|v| v.connector.clone()))
+        .collect();
+    let now = Instant::now();
+    let now_ms = now_ms(st, now);
+    if tuning.debug.show_ring_when_resizing {
+        for output_name in next_output_names {
+            if st
+                .runtime
+                .tuning
+                .focus_ring_for_output(output_name.as_str())
+                != tuning.focus_ring_for_output(output_name.as_str())
             {
-                self.input.interaction_state.viewport_pan_anim = None;
-            }
-        }
-
-        self.ui.render_state.animator.set_spec(AnimSpec {
-            state_change_ms: FIXED_ANIM_STATE_CHANGE_MS,
-            bounce: FIXED_ANIM_BOUNCE,
-        });
-
-        if prev_physics_enabled && !tuning.physics_enabled {
-            self.input.interaction_state.drag_authority_node = None;
-            self.input.interaction_state.physics_velocity.clear();
-            self.input.interaction_state.smoothed_render_pos.clear();
-            self.model.camera_target_center = self.model.viewport.center;
-            self.model.camera_target_view_size = self.model.zoom_ref_size;
-        }
-
-        let next_output_names: std::collections::HashSet<String> = previous_output_names
-            .iter()
-            .cloned()
-            .chain(tuning.tty_viewports.iter().map(|v| v.connector.clone()))
-            .collect();
-        let now = Instant::now();
-        let now_ms = self.now_ms(now);
-        if tuning.debug.show_ring_when_resizing {
-            for output_name in next_output_names {
-                if self
-                    .runtime
-                    .tuning
-                    .focus_ring_for_output(output_name.as_str())
-                    != tuning.focus_ring_for_output(output_name.as_str())
-                {
-                    self.model.focus_state.focus_ring_preview_until_ms.insert(
-                        output_name,
-                        now_ms
-                            .saturating_add(crate::compositor::focus::state::FOCUS_RING_PREVIEW_MS),
-                    );
-                }
-            }
-        } else {
-            self.model.focus_state.focus_ring_preview_until_ms.clear();
-        }
-
-        self.runtime.tuning = tuning;
-        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(&mut **self);
-        let repeat_changed = self.runtime.tuning.input.repeat_rate != prev_input.repeat_rate
-            || self.runtime.tuning.input.repeat_delay != prev_input.repeat_delay;
-        let keyboard_config_changed = self.runtime.tuning.input.keyboard != prev_input.keyboard;
-        if let Some(keyboard) = self.platform.seat.get_keyboard() {
-            if repeat_changed {
-                keyboard.change_repeat_info(
-                    self.runtime.tuning.input.repeat_rate,
-                    self.runtime.tuning.input.repeat_delay,
+                st.model.focus_state.focus_ring_preview_until_ms.insert(
+                    output_name,
+                    now_ms.saturating_add(crate::compositor::focus::state::FOCUS_RING_PREVIEW_MS),
                 );
             }
-            if keyboard_config_changed {
-                let xkb_config =
-                    crate::backend::ResolvedXkbConfig::from_input(&self.runtime.tuning.input);
-                if let Err(err) = keyboard.set_xkb_config(self, xkb_config.as_smithay()) {
-                    warn!(
-                        "failed to apply keyboard layout='{}' variant='{}' options='{}' on reload: {}",
-                        self.runtime.tuning.input.keyboard.layout,
-                        self.runtime.tuning.input.keyboard.variant,
-                        self.runtime.tuning.input.keyboard.options,
-                        err
-                    );
-                }
-            }
         }
-        let device_config_changed = self.runtime.tuning.input.touchpad != prev_input.touchpad
-            || self.runtime.tuning.input.mouse != prev_input.mouse
-            || self.runtime.tuning.input.devices != prev_input.devices;
-        if device_config_changed {
-            // Clone so the device loop borrows `self.input` mutably without holding a
-            // borrow on `self.runtime` (which deref splitting can't prove disjoint here).
-            let input_cfg = self.runtime.tuning.input.clone();
-            for device in self.input.devices.iter_mut() {
-                crate::input::device_config::apply_device_config(device, &input_cfg);
-            }
-        }
-        if self.runtime.tuning.font != prev_font {
-            self.ui.render_state.invalidate_ui_text_cache();
-        }
-        if self.runtime.tuning.decorations != prev_decorations {
-            self.ui.render_state.clear_window_offscreen_caches();
-        }
-        if !self.runtime.tuning.cursor.hide_while_typing {
-            self.input.interaction_state.cursor_hidden_by_typing = false;
-        }
-        self.refresh_xdg_decoration_mode();
-        self.request_maintenance();
-
-        if let Some(id) = prev_focus {
-            self.set_interaction_focus(Some(id), 30_000, now);
-        }
+    } else {
+        st.model.focus_state.focus_ring_preview_until_ms.clear();
     }
 
-    pub fn request_exit(&mut self) {
-        self.runtime.exit_requested = true;
-    }
-
-    #[inline]
-    pub fn request_maintenance(&mut self) {
-        self.runtime.maintenance_dirty = true;
-        self.runtime.tty_redraw_all = true;
-        if let Some(ping) = &self.runtime.maintenance_ping {
-            ping.ping();
-        }
-    }
-
-    #[inline]
-    pub fn run_maintenance_if_needed(&mut self, now: Instant) {
-        let due = self
-            .next_maintenance_deadline(now)
-            .is_some_and(|deadline| deadline <= now);
-        if self.runtime.maintenance_dirty || due {
-            self.run_maintenance(now);
-        }
-    }
-
-    #[inline]
-    pub fn run_maintenance(&mut self, now: Instant) {
-        self.runtime.maintenance_dirty = false;
-        if !self.model.focus_state.app_focused {
-            return;
-        }
-        crate::compositor::workspace::lifecycle::reconcile_surface_bindings(self);
-        let now_ms = now.duration_since(self.runtime.started_at).as_millis() as u64;
-        crate::protocol::wayland::activation::prune_expired(self, now, now_ms);
-        let _ = self.recent_top_node_active(now);
-        let pointer_contents_changed =
-            crate::compositor::interaction::pointer::update_pointer_contents_at_last_screen(
-                self, None, now,
+    st.runtime.tuning = tuning;
+    crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(st);
+    let repeat_changed = st.runtime.tuning.input.repeat_rate != prev_input.repeat_rate
+        || st.runtime.tuning.input.repeat_delay != prev_input.repeat_delay;
+    let keyboard_config_changed = st.runtime.tuning.input.keyboard != prev_input.keyboard;
+    if let Some(keyboard) = st.platform.seat.get_keyboard() {
+        if repeat_changed {
+            keyboard.change_repeat_info(
+                st.runtime.tuning.input.repeat_rate,
+                st.runtime.tuning.input.repeat_delay,
             );
-        if pointer_contents_changed {
-            if let Some((sx, sy)) = self.input.interaction_state.last_pointer_screen_global
-                && let Some(output_name) = self.monitor_for_screen(sx, sy)
-            {
-                self.request_tty_redraw_for_monitor(output_name.as_str());
-            } else {
-                self.runtime.tty_redraw_all = true;
+        }
+        if keyboard_config_changed {
+            let xkb_config =
+                crate::backend::ResolvedXkbConfig::from_input(&st.runtime.tuning.input);
+            if let Err(err) = keyboard.set_xkb_config(st, xkb_config.as_smithay()) {
+                warn!(
+                    "failed to apply keyboard layout='{}' variant='{}' options='{}' on reload: {}",
+                    st.runtime.tuning.input.keyboard.layout,
+                    st.runtime.tuning.input.keyboard.variant,
+                    st.runtime.tuning.input.keyboard.options,
+                    err
+                );
             }
         }
-        if let Some(pending) = self.input.interaction_state.pending_core_click.clone()
-            && now_ms >= pending.deadline_ms
+    }
+    let device_config_changed = st.runtime.tuning.input.touchpad != prev_input.touchpad
+        || st.runtime.tuning.input.mouse != prev_input.mouse
+        || st.runtime.tuning.input.devices != prev_input.devices;
+    if device_config_changed {
+        // Clone so the device loop borrows `st.input` mutably without holding a
+        // borrow on `st.runtime` (which deref splitting can't prove disjoint here).
+        let input_cfg = st.runtime.tuning.input.clone();
+        for device in st.input.devices.iter_mut() {
+            crate::input::device_config::apply_device_config(device, &input_cfg);
+        }
+    }
+    if st.runtime.tuning.font != prev_font {
+        st.ui.render_state.invalidate_ui_text_cache();
+    }
+    if st.runtime.tuning.decorations != prev_decorations {
+        st.ui.render_state.clear_window_offscreen_caches();
+    }
+    if !st.runtime.tuning.cursor.hide_while_typing {
+        st.input.interaction_state.cursor_hidden_by_typing = false;
+    }
+    st.refresh_xdg_decoration_mode();
+    request_maintenance(st);
+
+    if let Some(id) = prev_focus {
+        st.set_interaction_focus(Some(id), 30_000, now);
+    }
+}
+
+pub fn request_exit(st: &mut Halley) {
+    st.runtime.exit_requested = true;
+}
+
+#[inline]
+pub fn request_maintenance(st: &mut Halley) {
+    st.runtime.maintenance_dirty = true;
+    st.runtime.tty_redraw_all = true;
+    if let Some(ping) = &st.runtime.maintenance_ping {
+        ping.ping();
+    }
+}
+
+#[inline]
+pub fn run_maintenance_if_needed(st: &mut Halley, now: Instant) {
+    let due = next_maintenance_deadline(st, now).is_some_and(|deadline| deadline <= now);
+    if st.runtime.maintenance_dirty || due {
+        run_maintenance(st, now);
+    }
+}
+
+#[inline]
+pub fn run_maintenance(st: &mut Halley, now: Instant) {
+    st.runtime.maintenance_dirty = false;
+    if !st.model.focus_state.app_focused {
+        return;
+    }
+    crate::compositor::workspace::lifecycle::reconcile_surface_bindings(st);
+    let now_ms = now.duration_since(st.runtime.started_at).as_millis() as u64;
+    crate::protocol::wayland::activation::prune_expired(st, now, now_ms);
+    let _ = st.recent_top_node_active(now);
+    let pointer_contents_changed =
+        crate::compositor::interaction::pointer::update_pointer_contents_at_last_screen(
+            st, None, now,
+        );
+    if pointer_contents_changed {
+        if let Some((sx, sy)) = st.input.interaction_state.last_pointer_screen_global
+            && let Some(output_name) = st.monitor_for_screen(sx, sy)
         {
-            self.input.interaction_state.pending_core_click = None;
+            st.request_tty_redraw_for_monitor(output_name.as_str());
+        } else {
+            st.runtime.tty_redraw_all = true;
         }
-        if let Some(pending) = self
-            .input
-            .interaction_state
-            .pending_collapsed_node_click
-            .clone()
-            && now_ms >= pending.deadline_ms
-        {
-            self.input.interaction_state.pending_collapsed_node_click = None;
-        }
-        let _ = crate::compositor::clusters::system::cluster_system_controller(&mut **self)
-            .repeat_cluster_name_prompt_input_if_due(now_ms);
-        screenshot_controller(&mut **self).run_pending_screenshot_capture_if_due(now_ms);
-        if let Some(pending) = self
-            .input
-            .interaction_state
-            .pending_modal_focus_restore
-            .clone()
-            && now_ms >= pending.restore_at_ms
-        {
-            self.input.interaction_state.pending_modal_focus_restore = None;
-            self.apply_wayland_focus_state(pending.target);
-        }
-        if self
-            .input
-            .interaction_state
-            .cursor_override_until_ms
-            .is_some_and(|until_ms| now_ms >= until_ms)
-        {
-            self.input.interaction_state.cursor_override_until_ms = None;
-            self.input.interaction_state.cursor_override_icon = None;
-        }
-        if self.has_any_active_cluster_workspace() {
-            let active_monitors = self
-                .model
-                .cluster_state
-                .active_cluster_workspaces
-                .keys()
-                .cloned()
-                .collect::<Vec<_>>();
-            for monitor in active_monitors {
-                self.layout_active_cluster_workspace_for_monitor(monitor.as_str(), now_ms);
-            }
-        }
-        // Flush any aperture work-area change deferred while a layout session was
-        // active. `refresh` re-checks each monitor: a monitor whose session has
-        // ended applies its true reservation, while a still-locked one stays
-        // frozen for the whole session (so no end-of-slide snap). Only run when a
-        // pending monitor is actually unlocked — otherwise the refresh would
-        // re-defer every entry and needlessly invalidate the aperture mode cache
-        // each tick for the whole session.
-        if crate::compositor::monitor::layer_shell::any_pending_workarea_unlocked(self) {
-            crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(self);
-        }
-        if let Some(fid) = self.model.focus_state.primary_interaction_focus
-            && now_ms >= self.model.focus_state.interaction_focus_until_ms
-        {
-            let keep = self.model.field.node(fid).is_some_and(|n| {
-                self.model.field.is_visible(fid) && n.kind == halley_core::field::NodeKind::Surface
-            });
-            if keep {
-                self.model.focus_state.interaction_focus_until_ms = now_ms.saturating_add(30_000);
-            } else {
-                self.set_interaction_focus(None, 0, now);
-            }
-        }
-        if crate::protocol::wayland::session_lock::session_lock_active(self) {
-            crate::protocol::wayland::session_lock::reassert_keyboard_focus_if_drifted(self);
-        } else if self.model.focus_state.primary_interaction_focus.is_none()
-            && self.model.monitor_state.layer_keyboard_focus.is_some()
-        {
-            crate::compositor::monitor::layer_shell::reassert_layer_surface_keyboard_focus_if_drifted(self);
-        }
-        self.model
-            .workspace_state
-            .active_transitions
-            .retain(|_, transition| transition.is_active(now_ms));
-        self.model
-            .workspace_state
-            .primary_promote_cooldown_until_ms
-            .retain(|_, &mut until| until > now_ms);
-        let expired_silent_close = self
+    }
+    if let Some(pending) = st.input.interaction_state.pending_core_click.clone()
+        && now_ms >= pending.deadline_ms
+    {
+        st.input.interaction_state.pending_core_click = None;
+    }
+    if let Some(pending) = st
+        .input
+        .interaction_state
+        .pending_collapsed_node_click
+        .clone()
+        && now_ms >= pending.deadline_ms
+    {
+        st.input.interaction_state.pending_collapsed_node_click = None;
+    }
+    let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
+        .repeat_cluster_name_prompt_input_if_due(now_ms);
+    screenshot_controller(&mut *st).run_pending_screenshot_capture_if_due(now_ms);
+    if let Some(pending) = st
+        .input
+        .interaction_state
+        .pending_modal_focus_restore
+        .clone()
+        && now_ms >= pending.restore_at_ms
+    {
+        st.input.interaction_state.pending_modal_focus_restore = None;
+        st.apply_wayland_focus_state(pending.target);
+    }
+    if st
+        .input
+        .interaction_state
+        .cursor_override_until_ms
+        .is_some_and(|until_ms| now_ms >= until_ms)
+    {
+        st.input.interaction_state.cursor_override_until_ms = None;
+        st.input.interaction_state.cursor_override_icon = None;
+    }
+    if st.has_any_active_cluster_workspace() {
+        let active_monitors = st
             .model
+            .cluster_state
+            .active_cluster_workspaces
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for monitor in active_monitors {
+            st.layout_active_cluster_workspace_for_monitor(monitor.as_str(), now_ms);
+        }
+    }
+    // Flush any aperture work-area change deferred while a layout session was
+    // active. `refresh` re-checks each monitor: a monitor whose session has
+    // ended applies its true reservation, while a still-locked one stays
+    // frozen for the whole session (so no end-of-slide snap). Only run when a
+    // pending monitor is actually unlocked — otherwise the refresh would
+    // re-defer every entry and needlessly invalidate the aperture mode cache
+    // each tick for the whole session.
+    if crate::compositor::monitor::layer_shell::any_pending_workarea_unlocked(st) {
+        crate::compositor::monitor::layer_shell::refresh_monitor_usable_viewports(st);
+    }
+    if let Some(fid) = st.model.focus_state.primary_interaction_focus
+        && now_ms >= st.model.focus_state.interaction_focus_until_ms
+    {
+        let keep = st.model.field.node(fid).is_some_and(|n| {
+            st.model.field.is_visible(fid) && n.kind == halley_core::field::NodeKind::Surface
+        });
+        if keep {
+            st.model.focus_state.interaction_focus_until_ms = now_ms.saturating_add(30_000);
+        } else {
+            st.set_interaction_focus(None, 0, now);
+        }
+    }
+    if crate::protocol::wayland::session_lock::session_lock_active(st) {
+        crate::protocol::wayland::session_lock::reassert_keyboard_focus_if_drifted(st);
+    } else if st.model.focus_state.primary_interaction_focus.is_none()
+        && st.model.monitor_state.layer_keyboard_focus.is_some()
+    {
+        crate::compositor::monitor::layer_shell::reassert_layer_surface_keyboard_focus_if_drifted(
+            st,
+        );
+    }
+    st.model
+        .workspace_state
+        .active_transitions
+        .retain(|_, transition| transition.is_active(now_ms));
+    st.model
+        .workspace_state
+        .primary_promote_cooldown_until_ms
+        .retain(|_, &mut until| until > now_ms);
+    let expired_silent_close = st
+        .model
+        .workspace_state
+        .pending_silent_close_until_ms
+        .iter()
+        .filter_map(|(&id, &until)| (until <= now_ms).then_some(id))
+        .collect::<Vec<_>>();
+    for id in expired_silent_close {
+        st.model
             .workspace_state
             .pending_silent_close_until_ms
-            .iter()
-            .filter_map(|(&id, &until)| (until <= now_ms).then_some(id))
-            .collect::<Vec<_>>();
-        for id in expired_silent_close {
-            self.model
-                .workspace_state
-                .pending_silent_close_until_ms
-                .remove(&id);
-            if !self.model.field.is_cluster_member(id)
-                && let Some(node) = self.model.field.node_mut(id)
-            {
-                node.visibility
-                    .clear(halley_core::field::Visibility::HIDDEN_BY_CLUSTER);
-            }
+            .remove(&id);
+        if !st.model.field.is_cluster_member(id)
+            && let Some(node) = st.model.field.node_mut(id)
+        {
+            node.visibility
+                .clear(halley_core::field::Visibility::HIDDEN_BY_CLUSTER);
         }
-        let alive_ids: std::collections::HashSet<_> =
-            self.model.field.node_ids_all().into_iter().collect();
-        self.model
-            .carry_state
-            .carry_zone_hint
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .carry_state
-            .carry_zone_last_change_ms
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .carry_state
-            .carry_zone_pending
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .carry_state
-            .carry_zone_pending_since_ms
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .carry_state
-            .carry_activation_anim_armed
-            .retain(|id| alive_ids.contains(id));
-        self.model
-            .carry_state
-            .carry_state_hold
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .focus_state
-            .last_surface_focus_ms
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .focus_state
-            .overlap_raise_order
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .workspace_state
-            .manual_collapsed_nodes
-            .retain(|id| alive_ids.contains(id));
-        self.model
-            .spawn_state
-            .pending_tiled_insert_reveal_at_ms
-            .retain(|id, _| alive_ids.contains(id));
-        self.model
-            .spawn_state
-            .pending_tiled_insert_preserve_focus
-            .retain(|id| alive_ids.contains(id));
-        self.model
-            .cluster_state
-            .cluster_overflow_promotion_anim
-            .retain(|_, anim| alive_ids.contains(&anim.member_id) && now_ms < anim.reveal_at_ms);
+    }
+    let alive_ids: std::collections::HashSet<_> =
+        st.model.field.node_ids_all().into_iter().collect();
+    st.model
+        .carry_state
+        .carry_zone_hint
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .carry_state
+        .carry_zone_last_change_ms
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .carry_state
+        .carry_zone_pending
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .carry_state
+        .carry_zone_pending_since_ms
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .carry_state
+        .carry_activation_anim_armed
+        .retain(|id| alive_ids.contains(id));
+    st.model
+        .carry_state
+        .carry_state_hold
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .focus_state
+        .last_surface_focus_ms
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .focus_state
+        .overlap_raise_order
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .workspace_state
+        .manual_collapsed_nodes
+        .retain(|id| alive_ids.contains(id));
+    st.model
+        .spawn_state
+        .pending_tiled_insert_reveal_at_ms
+        .retain(|id, _| alive_ids.contains(id));
+    st.model
+        .spawn_state
+        .pending_tiled_insert_preserve_focus
+        .retain(|id| alive_ids.contains(id));
+    st.model
+        .cluster_state
+        .cluster_overflow_promotion_anim
+        .retain(|_, anim| alive_ids.contains(&anim.member_id) && now_ms < anim.reveal_at_ms);
 
-        self.process_pending_spawn_activations(now, now_ms);
-        let resize_settling = self
-            .input
-            .interaction_state
-            .resize_static_node
-            .is_some_and(|_| now_ms < self.input.interaction_state.resize_static_until_ms);
-        if resize_settling
-            && let (Some(id), Some(lock_pos)) = (
-                self.input.interaction_state.resize_static_node,
-                self.input.interaction_state.resize_static_lock_pos,
-            )
-            && let Some(n) = self.model.field.node(id)
-            && ((n.pos.x - lock_pos.x).abs() > 0.05 || (n.pos.y - lock_pos.y).abs() > 0.05)
-        {
-            let _ = self.model.field.carry(id, lock_pos);
-        }
-        if self
-            .input
-            .interaction_state
-            .resize_static_node
-            .is_some_and(|_| now_ms >= self.input.interaction_state.resize_static_until_ms)
-        {
-            self.input.interaction_state.resize_static_node = None;
-            self.input.interaction_state.resize_static_lock_pos = None;
-            self.input.interaction_state.resize_static_until_ms = 0;
-        }
-        if !self.input.interaction_state.suspend_state_checks {
-            crate::compositor::interaction::state::enforce_pan_dominant_zone_states(self, now_ms);
-            crate::compositor::carry::state::enforce_carry_zone_states(self);
-        }
-        if let Some(id) = self.input.interaction_state.resize_active {
-            let _ = self.model.field.touch(id, now_ms);
-            let _ = self
-                .model
-                .field
-                .set_decay_level(id, halley_core::decay::DecayLevel::Hot);
-        }
-        if self.input.interaction_state.resize_active.is_none()
-            && !(self.input.interaction_state.resize_static_node.is_some()
-                && now_ms < self.input.interaction_state.resize_static_until_ms)
-        {
-            camera_controller(&mut **self).update_zoom_live_surface_sizes();
-        }
-        let cluster_policy = halley_core::cluster_policy::ClusterPolicy {
-            enabled: false,
-            distance_px: self.runtime.tuning.cluster_distance_px,
-            dwell_ms: self.runtime.tuning.cluster_dwell_ms,
-            ..Default::default()
-        };
-        let model = &mut self.model;
-        let _ = halley_core::cluster_policy::tick_cluster_formation(
-            &mut model.field,
-            now_ms,
-            cluster_policy,
-            &mut model.cluster_state.cluster_form_state,
-        );
-        self.enforce_single_primary_active_unit();
-        if !self.input.interaction_state.suspend_state_checks
-            && self.input.interaction_state.resize_active.is_none()
-        {
-            self.resolve_surface_overlap();
-        }
-        self.restore_pan_return_active_focus(now);
-        let animations_enabled = self.runtime.tuning.animations_enabled();
-        let crate::compositor::root::Halley { model, ui, .. } = &mut **self;
-        if animations_enabled {
-            ui.render_state.animator.observe_field(&model.field, now);
-        }
+    st.process_pending_spawn_activations(now, now_ms);
+    let resize_settling = st
+        .input
+        .interaction_state
+        .resize_static_node
+        .is_some_and(|_| now_ms < st.input.interaction_state.resize_static_until_ms);
+    if resize_settling
+        && let (Some(id), Some(lock_pos)) = (
+            st.input.interaction_state.resize_static_node,
+            st.input.interaction_state.resize_static_lock_pos,
+        )
+        && let Some(n) = st.model.field.node(id)
+        && ((n.pos.x - lock_pos.x).abs() > 0.05 || (n.pos.y - lock_pos.y).abs() > 0.05)
+    {
+        let _ = st.model.field.carry(id, lock_pos);
+    }
+    if st
+        .input
+        .interaction_state
+        .resize_static_node
+        .is_some_and(|_| now_ms >= st.input.interaction_state.resize_static_until_ms)
+    {
+        st.input.interaction_state.resize_static_node = None;
+        st.input.interaction_state.resize_static_lock_pos = None;
+        st.input.interaction_state.resize_static_until_ms = 0;
+    }
+    if !st.input.interaction_state.suspend_state_checks {
+        crate::compositor::interaction::state::enforce_pan_dominant_zone_states(st, now_ms);
+        crate::compositor::carry::state::enforce_carry_zone_states(st);
+    }
+    if let Some(id) = st.input.interaction_state.resize_active {
+        let _ = st.model.field.touch(id, now_ms);
+        let _ = st
+            .model
+            .field
+            .set_decay_level(id, halley_core::decay::DecayLevel::Hot);
+    }
+    if st.input.interaction_state.resize_active.is_none()
+        && !(st.input.interaction_state.resize_static_node.is_some()
+            && now_ms < st.input.interaction_state.resize_static_until_ms)
+    {
+        camera_controller(&mut *st).update_zoom_live_surface_sizes();
+    }
+    let cluster_policy = halley_core::cluster_policy::ClusterPolicy {
+        enabled: false,
+        distance_px: st.runtime.tuning.cluster_distance_px,
+        dwell_ms: st.runtime.tuning.cluster_dwell_ms,
+        ..Default::default()
+    };
+    let model = &mut st.model;
+    let _ = halley_core::cluster_policy::tick_cluster_formation(
+        &mut model.field,
+        now_ms,
+        cluster_policy,
+        &mut model.cluster_state.cluster_form_state,
+    );
+    st.enforce_single_primary_active_unit();
+    if !st.input.interaction_state.suspend_state_checks
+        && st.input.interaction_state.resize_active.is_none()
+    {
+        st.resolve_surface_overlap();
+    }
+    st.restore_pan_return_active_focus(now);
+    let animations_enabled = st.runtime.tuning.animations_enabled();
+    let crate::compositor::root::Halley { model, ui, .. } = st;
+    if animations_enabled {
+        ui.render_state.animator.observe_field(&model.field, now);
     }
 }

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -9,7 +9,7 @@ use smithay::reexports::wayland_server::backend::ObjectId;
 
 use super::monitor::camera::camera_controller;
 use super::root::Halley;
-use super::screenshot::screenshot_controller;
+use super::screenshot;
 use crate::animation::AnimSpec;
 use crate::compositor::activity::CommitActivity;
 use crate::protocol::wayland::activation::ActivationRuntimeState;
@@ -430,7 +430,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
     }
     let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
         .repeat_cluster_name_prompt_input_if_due(now_ms);
-    screenshot_controller(&mut *st).run_pending_screenshot_capture_if_due(now_ms);
+    screenshot::run_pending_screenshot_capture_if_due(&mut *st, now_ms);
     if let Some(pending) = st
         .input
         .interaction_state

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -426,8 +426,9 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
     {
         st.input.interaction_state.pending_collapsed_node_click = None;
     }
-    let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-        .repeat_cluster_name_prompt_input_if_due(now_ms);
+    let _ = crate::compositor::clusters::system::repeat_cluster_name_prompt_input_if_due(
+        &mut *st, now_ms,
+    );
     screenshot::run_pending_screenshot_capture_if_due(&mut *st, now_ms);
     if let Some(pending) = st
         .input

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -36,8 +36,6 @@ pub fn now_ms(st: &Halley, now: Instant) -> u64 {
     now.duration_since(st.runtime.started_at).as_millis() as u64
 }
 
-pub(crate) fn debug_dump(_st: &Halley) {}
-
 pub fn exit_requested(st: &Halley) -> bool {
     st.runtime.exit_requested
 }
@@ -360,7 +358,7 @@ pub fn apply_tuning(st: &mut Halley, mut tuning: RuntimeTuning) {
     if !st.runtime.tuning.cursor.hide_while_typing {
         st.input.interaction_state.cursor_hidden_by_typing = false;
     }
-    st.refresh_xdg_decoration_mode();
+    crate::compositor::platform::refresh_xdg_decoration_mode(st);
     request_maintenance(st);
 
     if let Some(id) = prev_focus {
@@ -398,7 +396,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
     crate::compositor::workspace::lifecycle::reconcile_surface_bindings(st);
     let now_ms = now.duration_since(st.runtime.started_at).as_millis() as u64;
     crate::protocol::wayland::activation::prune_expired(st, now, now_ms);
-    let _ = st.recent_top_node_active(now);
+    let _ = crate::compositor::focus::state::recent_top_node_active(st, now);
     let pointer_contents_changed =
         crate::compositor::interaction::pointer::update_pointer_contents_at_last_screen(
             st, None, now,
@@ -449,7 +447,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
         st.input.interaction_state.cursor_override_until_ms = None;
         st.input.interaction_state.cursor_override_icon = None;
     }
-    if st.has_any_active_cluster_workspace() {
+    if crate::compositor::clusters::system::has_any_active_cluster_workspace(st) {
         let active_monitors = st
             .model
             .cluster_state
@@ -570,7 +568,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
         .cluster_overflow_promotion_anim
         .retain(|_, anim| alive_ids.contains(&anim.member_id) && now_ms < anim.reveal_at_ms);
 
-    st.process_pending_spawn_activations(now, now_ms);
+    crate::compositor::spawn::state::process_pending_spawn_activations(st, now, now_ms);
     let resize_settling = st
         .input
         .interaction_state
@@ -632,7 +630,7 @@ pub fn run_maintenance(st: &mut Halley, now: Instant) {
     {
         st.resolve_surface_overlap();
     }
-    st.restore_pan_return_active_focus(now);
+    crate::compositor::focus::state::restore_pan_return_active_focus(st, now);
     let animations_enabled = st.runtime.tuning.animations_enabled();
     let crate::compositor::root::Halley { model, ui, .. } = st;
     if animations_enabled {

--- a/crates/halley-wl/src/compositor/screenshot/mod.rs
+++ b/crates/halley-wl/src/compositor/screenshot/mod.rs
@@ -1,7 +1,6 @@
 mod region;
 pub(crate) mod state;
 
-use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::mpsc;
 use std::time::Instant;
@@ -21,532 +20,497 @@ use state::{
     ScreenshotCaptureResult, ScreenshotRegionDragMode, ScreenshotSessionState,
 };
 
-pub(crate) struct ScreenshotController<T> {
-    st: T,
+pub(crate) fn screenshot_session_active(st: &Halley) -> bool {
+    st.input.interaction_state.screenshot_session.is_some()
 }
 
-pub(crate) fn screenshot_controller<T>(st: T) -> ScreenshotController<T> {
-    ScreenshotController { st }
+pub(crate) fn start_screenshot_session(
+    st: &mut Halley,
+    mode: CaptureMode,
+    output: Option<&str>,
+    _now: Instant,
+) -> bool {
+    if screenshot_session_active(st) {
+        return false;
+    }
+    let monitor = screenshot_session_monitor(st, output);
+    let serial = st.input.interaction_state.screenshot_next_serial;
+    st.input.interaction_state.screenshot_next_serial = serial.saturating_add(1);
+    st.input.interaction_state.last_screenshot_result = None;
+    let (selected_window, initial_selection) =
+        initial_screenshot_selection(st, mode, monitor.as_str());
+    let keyboard_captured = true;
+    st.begin_modal_keyboard_capture();
+    if let Some(enter) = halley_config::keybinds::key_name_to_evdev("return") {
+        crate::compositor::interaction::state::trap_modal_key_release(st, enter + 8);
+    }
+    st.input.interaction_state.screenshot_session = Some(ScreenshotSessionState {
+        mode,
+        monitor: monitor.clone(),
+        selected_window,
+        keyboard_captured,
+        menu_selected: 0,
+        menu_hovered: None,
+        drag_anchor: None,
+        drag_current: None,
+        selection_rect: initial_selection,
+        region_drag_mode: ScreenshotRegionDragMode::None,
+        region_grab_cursor: (0, 0),
+        region_grab_rect: initial_selection,
+    });
+    st.request_maintenance();
+    true
 }
 
-impl<T: Deref<Target = Halley>> Deref for ScreenshotController<T> {
-    type Target = Halley;
+pub(crate) fn move_screenshot_menu_selection(st: &mut Halley, delta: i32) -> bool {
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return false;
+    };
+    if session.mode != CaptureMode::Menu {
+        return false;
+    }
+    let start = session.menu_selected as i32;
+    let modes = screenshot_menu_modes();
+    let len = modes.len() as i32;
+    let step = if delta >= 0 { 1 } else { -1 };
+    let session_monitor = session.monitor.clone();
+    // Step over any disabled (blanked) entries, e.g. Window with no targets.
+    let mut next = start;
+    for _ in 0..len {
+        next = (next + step).rem_euclid(len);
+        let mode = modes[next as usize];
+        let enabled = mode != CaptureMode::Window
+            || has_screenshot_window_target_for_monitor(st, session_monitor.as_str());
+        if enabled {
+            break;
+        }
+    }
+    let next = next as usize;
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return false;
+    };
+    session.menu_selected = next;
+    session.menu_hovered = Some(next);
+    st.request_maintenance();
+    true
+}
 
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
+pub(crate) fn hover_screenshot_menu_item(st: &mut Halley, index: Option<usize>) {
+    let monitor = match st.input.interaction_state.screenshot_session.as_ref() {
+        Some(session) if session.mode == CaptureMode::Menu => session.monitor.clone(),
+        _ => return,
+    };
+    // Ignore hover on a blanked (disabled) entry, e.g. Window with no targets.
+    let index = index.filter(|&idx| {
+        screenshot_menu_modes().get(idx).is_some_and(|&mode| {
+            mode != CaptureMode::Window
+                || has_screenshot_window_target_for_monitor(st, monitor.as_str())
+        })
+    });
+    if let Some(session) = st.input.interaction_state.screenshot_session.as_mut() {
+        session.menu_hovered = index;
+        if let Some(index) = index {
+            session.menu_selected = index;
+        }
+        st.request_maintenance();
     }
 }
 
-impl<T: DerefMut<Target = Halley>> DerefMut for ScreenshotController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
+pub(crate) fn activate_screenshot_menu_item(st: &mut Halley, index: usize) -> bool {
+    let monitor = match st
+        .input
+        .interaction_state
+        .screenshot_session
+        .as_ref()
+        .map(|session| session.monitor.clone())
+    {
+        Some(monitor) => monitor,
+        None => return false,
+    };
+    let modes = screenshot_menu_modes();
+    let Some(&mode) = modes.get(index) else {
+        return false;
+    };
+    // Window capture is disabled (blanked) when there is nothing to target.
+    if mode == CaptureMode::Window
+        && !has_screenshot_window_target_for_monitor(st, monitor.as_str())
+    {
+        return false;
     }
+    let (selected_window, initial_selection) =
+        initial_screenshot_selection(st, mode, monitor.as_str());
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return false;
+    };
+    if session.mode != CaptureMode::Menu {
+        return false;
+    }
+    session.mode = mode;
+    session.selected_window = selected_window;
+    session.menu_selected = index;
+    session.menu_hovered = Some(index);
+    session.selection_rect = initial_selection;
+    session.region_drag_mode = ScreenshotRegionDragMode::None;
+    session.region_grab_rect = session.selection_rect;
+    session.drag_anchor = None;
+    session.drag_current = None;
+    st.request_maintenance();
+    true
 }
 
-impl<T: Deref<Target = Halley>> ScreenshotController<T> {
-    pub(crate) fn screenshot_session_active(&self) -> bool {
-        self.input.interaction_state.screenshot_session.is_some()
+pub(crate) fn return_screenshot_session_to_menu(st: &mut Halley) -> bool {
+    let (mode, monitor) = match st
+        .input
+        .interaction_state
+        .screenshot_session
+        .as_ref()
+        .map(|session| (session.mode, session.monitor.clone()))
+    {
+        Some(state) => state,
+        None => return false,
+    };
+    if mode == CaptureMode::Menu {
+        return false;
     }
+
+    let menu_selected = screenshot_menu_index(mode).unwrap_or(0);
+    let (selected_window, selection_rect) =
+        initial_screenshot_selection(st, CaptureMode::Menu, monitor.as_str());
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return false;
+    };
+    session.mode = CaptureMode::Menu;
+    session.monitor = monitor;
+    session.selected_window = selected_window;
+    session.menu_selected = menu_selected;
+    session.menu_hovered = Some(menu_selected);
+    session.selection_rect = selection_rect;
+    session.region_drag_mode = ScreenshotRegionDragMode::None;
+    session.region_grab_rect = selection_rect;
+    session.drag_anchor = None;
+    session.drag_current = None;
+    st.request_maintenance();
+    true
 }
 
-impl<T: DerefMut<Target = Halley>> ScreenshotController<T> {
-    pub(crate) fn start_screenshot_session(
-        &mut self,
-        mode: CaptureMode,
-        output: Option<&str>,
-        _now: Instant,
-    ) -> bool {
-        if self.screenshot_session_active() {
-            return false;
-        }
-        let monitor = screenshot_session_monitor(self, output);
-        let serial = self.input.interaction_state.screenshot_next_serial;
-        self.input.interaction_state.screenshot_next_serial = serial.saturating_add(1);
-        self.input.interaction_state.last_screenshot_result = None;
-        let (selected_window, initial_selection) =
-            initial_screenshot_selection(self, mode, monitor.as_str());
-        let keyboard_captured = true;
-        self.begin_modal_keyboard_capture();
-        if let Some(enter) = halley_config::keybinds::key_name_to_evdev("return") {
-            crate::compositor::interaction::state::trap_modal_key_release(self, enter + 8);
-        }
-        self.input.interaction_state.screenshot_session = Some(ScreenshotSessionState {
-            mode,
-            monitor: monitor.clone(),
-            selected_window,
-            keyboard_captured,
-            menu_selected: 0,
-            menu_hovered: None,
-            drag_anchor: None,
-            drag_current: None,
-            selection_rect: initial_selection,
-            region_drag_mode: ScreenshotRegionDragMode::None,
-            region_grab_cursor: (0, 0),
-            region_grab_rect: initial_selection,
-        });
-        self.request_maintenance();
-        true
+pub(crate) fn clear_screenshot_session_state(st: &mut Halley) -> bool {
+    let Some(session) = st.input.interaction_state.screenshot_session.take() else {
+        return false;
+    };
+    if session.keyboard_captured {
+        let restore_focus = st
+            .last_input_surface_node_for_monitor(st.model.monitor_state.current_monitor.as_str())
+            .or(st.last_input_surface_node());
+        st.schedule_modal_focus_restore_after(restore_focus, Instant::now(), 260);
     }
+    st.runtime.screenshot_full_repaint_until_ms = st.now_ms(Instant::now()).saturating_add(120);
+    st.request_maintenance();
+    true
+}
 
-    pub(crate) fn move_screenshot_menu_selection(&mut self, delta: i32) -> bool {
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return false;
-        };
-        if session.mode != CaptureMode::Menu {
-            return false;
-        }
-        let start = session.menu_selected as i32;
-        let modes = screenshot_menu_modes();
-        let len = modes.len() as i32;
-        let step = if delta >= 0 { 1 } else { -1 };
-        let session_monitor = session.monitor.clone();
-        // Step over any disabled (blanked) entries, e.g. Window with no targets.
-        let mut next = start;
-        for _ in 0..len {
-            next = (next + step).rem_euclid(len);
-            let mode = modes[next as usize];
-            let enabled = mode != CaptureMode::Window
-                || has_screenshot_window_target_for_monitor(self, session_monitor.as_str());
-            if enabled {
-                break;
-            }
-        }
-        let next = next as usize;
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return false;
-        };
-        session.menu_selected = next;
-        session.menu_hovered = Some(next);
-        self.request_maintenance();
-        true
+pub(crate) fn cancel_screenshot_session(st: &mut Halley) -> bool {
+    if !clear_screenshot_session_state(st) {
+        return false;
     }
-
-    pub(crate) fn hover_screenshot_menu_item(&mut self, index: Option<usize>) {
-        let monitor = match self.input.interaction_state.screenshot_session.as_ref() {
-            Some(session) if session.mode == CaptureMode::Menu => session.monitor.clone(),
-            _ => return,
-        };
-        // Ignore hover on a blanked (disabled) entry, e.g. Window with no targets.
-        let index = index.filter(|&idx| {
-            screenshot_menu_modes().get(idx).is_some_and(|&mode| {
-                mode != CaptureMode::Window
-                    || has_screenshot_window_target_for_monitor(self, monitor.as_str())
-            })
-        });
-        if let Some(session) = self.input.interaction_state.screenshot_session.as_mut() {
-            session.menu_hovered = index;
-            if let Some(index) = index {
-                session.menu_selected = index;
-            }
-            self.request_maintenance();
-        }
-    }
-
-    pub(crate) fn activate_screenshot_menu_item(&mut self, index: usize) -> bool {
-        let monitor = match self
+    st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+        serial: st
             .input
             .interaction_state
-            .screenshot_session
-            .as_ref()
-            .map(|session| session.monitor.clone())
-        {
-            Some(monitor) => monitor,
-            None => return false,
-        };
-        let modes = screenshot_menu_modes();
-        let Some(&mode) = modes.get(index) else {
-            return false;
-        };
-        // Window capture is disabled (blanked) when there is nothing to target.
-        if mode == CaptureMode::Window
-            && !has_screenshot_window_target_for_monitor(self, monitor.as_str())
-        {
-            return false;
-        }
-        let (selected_window, initial_selection) =
-            initial_screenshot_selection(self, mode, monitor.as_str());
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return false;
-        };
-        if session.mode != CaptureMode::Menu {
-            return false;
-        }
-        session.mode = mode;
-        session.selected_window = selected_window;
-        session.menu_selected = index;
-        session.menu_hovered = Some(index);
-        session.selection_rect = initial_selection;
-        session.region_drag_mode = ScreenshotRegionDragMode::None;
-        session.region_grab_rect = session.selection_rect;
-        session.drag_anchor = None;
-        session.drag_current = None;
-        self.request_maintenance();
-        true
-    }
+            .screenshot_next_serial
+            .saturating_sub(1),
+        saved_path: None,
+        error: Some("cancelled".to_string()),
+    });
+    true
+}
 
-    pub(crate) fn return_screenshot_session_to_menu(&mut self) -> bool {
-        let (mode, monitor) = match self
-            .input
-            .interaction_state
-            .screenshot_session
-            .as_ref()
-            .map(|session| (session.mode, session.monitor.clone()))
-        {
-            Some(state) => state,
-            None => return false,
-        };
-        if mode == CaptureMode::Menu {
-            return false;
-        }
-
-        let menu_selected = screenshot_menu_index(mode).unwrap_or(0);
-        let (selected_window, selection_rect) =
-            initial_screenshot_selection(self, CaptureMode::Menu, monitor.as_str());
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return false;
-        };
-        session.mode = CaptureMode::Menu;
+pub(crate) fn update_screenshot_session_monitor(st: &mut Halley, monitor: String) {
+    if let Some(session) = st.input.interaction_state.screenshot_session.as_mut() {
         session.monitor = monitor;
+    }
+}
+
+pub(crate) fn update_screenshot_window_selection_from_pointer(
+    st: &mut Halley,
+    monitor: &str,
+    screen_w: i32,
+    screen_h: i32,
+    sx: f32,
+    sy: f32,
+    now: Instant,
+) {
+    let previous_monitor = st.begin_temporary_render_monitor(monitor);
+    let selected_window = crate::spatial::pick_hit_node_at(
+        st, screen_w, screen_h, sx, sy, now, None,
+    )
+    .and_then(|hit| screenshot_window_crop_for_node(st, hit.node_id, monitor).map(|_| hit.node_id));
+    st.end_temporary_render_monitor(previous_monitor);
+    let selection_rect =
+        selected_window.and_then(|node_id| screenshot_window_crop_for_node(st, node_id, monitor));
+    if let Some(session) = st.input.interaction_state.screenshot_session.as_mut()
+        && session.mode == CaptureMode::Window
+    {
+        session.monitor = monitor.to_string();
         session.selected_window = selected_window;
-        session.menu_selected = menu_selected;
-        session.menu_hovered = Some(menu_selected);
         session.selection_rect = selection_rect;
-        session.region_drag_mode = ScreenshotRegionDragMode::None;
         session.region_grab_rect = selection_rect;
         session.drag_anchor = None;
         session.drag_current = None;
-        self.request_maintenance();
-        true
+        st.request_maintenance();
     }
+}
 
-    fn clear_screenshot_session_state(&mut self) -> bool {
-        let Some(session) = self.input.interaction_state.screenshot_session.take() else {
-            return false;
-        };
-        if session.keyboard_captured {
-            let restore_focus = self
-                .last_input_surface_node_for_monitor(
-                    self.model.monitor_state.current_monitor.as_str(),
-                )
-                .or(self.last_input_surface_node());
-            self.schedule_modal_focus_restore_after(restore_focus, Instant::now(), 260);
-        }
-        self.runtime.screenshot_full_repaint_until_ms =
-            self.now_ms(Instant::now()).saturating_add(120);
-        self.request_maintenance();
-        true
+pub(crate) fn begin_screenshot_region_drag(st: &mut Halley, x: i32, y: i32) -> bool {
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return false;
+    };
+    if session.mode != CaptureMode::Region {
+        return false;
     }
+    let selection = session.selection_rect.unwrap_or(halley_capit::CaptureCrop {
+        x,
+        y,
+        w: 320,
+        h: 220,
+    });
+    session.region_drag_mode = screenshot_region_hit_test(selection, x, y);
+    session.region_grab_cursor = (x, y);
+    session.region_grab_rect = Some(selection);
+    session.drag_anchor = Some((x, y));
+    session.drag_current = Some((x, y));
+    st.request_maintenance();
+    true
+}
 
-    pub(crate) fn cancel_screenshot_session(&mut self) -> bool {
-        if !self.clear_screenshot_session_state() {
-            return false;
+pub(crate) fn update_screenshot_region_drag(st: &mut Halley, x: i32, y: i32) {
+    let desktop_bounds = screenshot_desktop_bounds(st);
+    let Some(session) = st.input.interaction_state.screenshot_session.as_mut() else {
+        return;
+    };
+    if session.mode != CaptureMode::Region {
+        return;
+    }
+    let Some((ax, ay)) = session.drag_anchor else {
+        return;
+    };
+    session.drag_current = Some((x, y));
+    let grab_rect = session
+        .region_grab_rect
+        .unwrap_or(halley_capit::CaptureCrop {
+            x: ax,
+            y: ay,
+            w: 1,
+            h: 1,
+        });
+    session.selection_rect = Some(screenshot_region_apply_drag(
+        session.region_drag_mode,
+        (x, y),
+        session.region_grab_cursor,
+        grab_rect,
+        desktop_bounds,
+    ));
+    st.request_maintenance();
+}
+
+pub(crate) fn end_screenshot_region_drag(st: &mut Halley) {
+    if let Some(session) = st.input.interaction_state.screenshot_session.as_mut()
+        && session.mode == CaptureMode::Region
+    {
+        session.drag_anchor = None;
+        session.region_drag_mode = ScreenshotRegionDragMode::None;
+    }
+    st.request_maintenance();
+}
+
+pub(crate) fn confirm_screenshot_session(st: &mut Halley, now: Instant) -> bool {
+    let Some(session) = st.input.interaction_state.screenshot_session.clone() else {
+        return false;
+    };
+    let kind = match session.mode {
+        CaptureMode::Menu => {
+            return activate_screenshot_menu_item(st, session.menu_selected);
         }
-        self.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
-            serial: self
+        CaptureMode::Region => match session.selection_rect {
+            Some(rect) if rect.w > 0 && rect.h > 0 => PendingScreenshotKind::Crop(rect),
+            _ => return false,
+        },
+        CaptureMode::Screen => {
+            let Some(space) = st
+                .model
+                .monitor_state
+                .monitors
+                .get(session.monitor.as_str())
+            else {
+                return false;
+            };
+            PendingScreenshotKind::Crop(halley_capit::CaptureCrop {
+                x: space.offset_x,
+                y: space.offset_y,
+                w: space.width.max(1),
+                h: space.height.max(1),
+            })
+        }
+        CaptureMode::Window => match session.selected_window {
+            Some(node_id) => PendingScreenshotKind::Window { node_id },
+            None => return false,
+        },
+    };
+    let output_path = default_output_path_in(
+        expand_screenshot_directory(st.runtime.tuning.screenshot.directory.as_str()),
+        match session.mode {
+            CaptureMode::Menu => "halley-capture",
+            CaptureMode::Region => "halley-region",
+            CaptureMode::Screen => "halley-screen",
+            CaptureMode::Window => "halley-window",
+        },
+    );
+    if let Err(err) = ensure_screenshot_output_directory(output_path.as_path()) {
+        st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+            serial: st
                 .input
                 .interaction_state
                 .screenshot_next_serial
                 .saturating_sub(1),
             saved_path: None,
-            error: Some("cancelled".to_string()),
+            error: Some(err),
         });
-        true
+        return false;
     }
+    let monitor = session.monitor.clone();
+    let serial = st
+        .input
+        .interaction_state
+        .screenshot_next_serial
+        .saturating_sub(1);
+    let _ = clear_screenshot_session_state(st);
+    st.input.interaction_state.pending_screenshot_capture = Some(PendingScreenshotCapture {
+        monitor,
+        serial,
+        kind,
+        output_path,
+        execute_at_ms: st.now_ms(now).saturating_add(24),
+    });
+    st.request_maintenance();
+    true
+}
 
-    pub(crate) fn update_screenshot_session_monitor(&mut self, monitor: String) {
-        if let Some(session) = self.input.interaction_state.screenshot_session.as_mut() {
-            session.monitor = monitor;
-        }
-    }
-
-    pub(crate) fn update_screenshot_window_selection_from_pointer(
-        &mut self,
-        monitor: &str,
-        screen_w: i32,
-        screen_h: i32,
-        sx: f32,
-        sy: f32,
-        now: Instant,
-    ) {
-        let previous_monitor = self.begin_temporary_render_monitor(monitor);
-        let selected_window = crate::spatial::pick_hit_node_at(
-            self, screen_w, screen_h, sx, sy, now, None,
-        )
-        .and_then(|hit| {
-            screenshot_window_crop_for_node(self, hit.node_id, monitor).map(|_| hit.node_id)
-        });
-        self.end_temporary_render_monitor(previous_monitor);
-        let selection_rect = selected_window
-            .and_then(|node_id| screenshot_window_crop_for_node(self, node_id, monitor));
-        if let Some(session) = self.input.interaction_state.screenshot_session.as_mut()
-            && session.mode == CaptureMode::Window
-        {
-            session.monitor = monitor.to_string();
-            session.selected_window = selected_window;
-            session.selection_rect = selection_rect;
-            session.region_grab_rect = selection_rect;
-            session.drag_anchor = None;
-            session.drag_current = None;
-            self.request_maintenance();
-        }
-    }
-
-    pub(crate) fn begin_screenshot_region_drag(&mut self, x: i32, y: i32) -> bool {
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return false;
-        };
-        if session.mode != CaptureMode::Region {
-            return false;
-        }
-        let selection = session.selection_rect.unwrap_or(halley_capit::CaptureCrop {
-            x,
-            y,
-            w: 320,
-            h: 220,
-        });
-        session.region_drag_mode = screenshot_region_hit_test(selection, x, y);
-        session.region_grab_cursor = (x, y);
-        session.region_grab_rect = Some(selection);
-        session.drag_anchor = Some((x, y));
-        session.drag_current = Some((x, y));
-        self.request_maintenance();
-        true
-    }
-
-    pub(crate) fn update_screenshot_region_drag(&mut self, x: i32, y: i32) {
-        let desktop_bounds = screenshot_desktop_bounds(self);
-        let Some(session) = self.input.interaction_state.screenshot_session.as_mut() else {
-            return;
-        };
-        if session.mode != CaptureMode::Region {
-            return;
-        }
-        let Some((ax, ay)) = session.drag_anchor else {
-            return;
-        };
-        session.drag_current = Some((x, y));
-        let grab_rect = session
-            .region_grab_rect
-            .unwrap_or(halley_capit::CaptureCrop {
-                x: ax,
-                y: ay,
-                w: 1,
-                h: 1,
-            });
-        session.selection_rect = Some(screenshot_region_apply_drag(
-            session.region_drag_mode,
-            (x, y),
-            session.region_grab_cursor,
-            grab_rect,
-            desktop_bounds,
-        ));
-        self.request_maintenance();
-    }
-
-    pub(crate) fn end_screenshot_region_drag(&mut self) {
-        if let Some(session) = self.input.interaction_state.screenshot_session.as_mut()
-            && session.mode == CaptureMode::Region
-        {
-            session.drag_anchor = None;
-            session.region_drag_mode = ScreenshotRegionDragMode::None;
-        }
-        self.request_maintenance();
-    }
-
-    pub(crate) fn confirm_screenshot_session(&mut self, now: Instant) -> bool {
-        let Some(session) = self.input.interaction_state.screenshot_session.clone() else {
-            return false;
-        };
-        let kind = match session.mode {
-            CaptureMode::Menu => {
-                return self.activate_screenshot_menu_item(session.menu_selected);
-            }
-            CaptureMode::Region => match session.selection_rect {
-                Some(rect) if rect.w > 0 && rect.h > 0 => PendingScreenshotKind::Crop(rect),
-                _ => return false,
-            },
-            CaptureMode::Screen => {
-                let Some(space) = self
-                    .model
-                    .monitor_state
-                    .monitors
-                    .get(session.monitor.as_str())
-                else {
-                    return false;
-                };
-                PendingScreenshotKind::Crop(halley_capit::CaptureCrop {
-                    x: space.offset_x,
-                    y: space.offset_y,
-                    w: space.width.max(1),
-                    h: space.height.max(1),
-                })
-            }
-            CaptureMode::Window => match session.selected_window {
-                Some(node_id) => PendingScreenshotKind::Window { node_id },
-                None => return false,
-            },
-        };
-        let output_path = default_output_path_in(
-            expand_screenshot_directory(self.runtime.tuning.screenshot.directory.as_str()),
-            match session.mode {
-                CaptureMode::Menu => "halley-capture",
-                CaptureMode::Region => "halley-region",
-                CaptureMode::Screen => "halley-screen",
-                CaptureMode::Window => "halley-window",
-            },
-        );
-        if let Err(err) = ensure_screenshot_output_directory(output_path.as_path()) {
-            self.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
-                serial: self
-                    .input
-                    .interaction_state
-                    .screenshot_next_serial
-                    .saturating_sub(1),
-                saved_path: None,
-                error: Some(err),
-            });
-            return false;
-        }
-        let monitor = session.monitor.clone();
-        let serial = self
-            .input
-            .interaction_state
-            .screenshot_next_serial
-            .saturating_sub(1);
-        let _ = self.clear_screenshot_session_state();
-        self.input.interaction_state.pending_screenshot_capture = Some(PendingScreenshotCapture {
-            monitor,
-            serial,
-            kind,
-            output_path,
-            execute_at_ms: self.now_ms(now).saturating_add(24),
-        });
-        self.request_maintenance();
-        true
-    }
-
-    pub(crate) fn run_pending_screenshot_capture_if_due(&mut self, now_ms: u64) {
-        if let Some(pending) = self
-            .input
-            .interaction_state
-            .pending_screenshot_capture
-            .clone()
-            && now_ms >= pending.execute_at_ms
-        {
-            self.input.interaction_state.pending_screenshot_capture = None;
-            match pending.kind {
-                PendingScreenshotKind::Crop(crop) => {
-                    let (tx, rx) = mpsc::channel();
-                    let output_path = pending.output_path.clone();
-                    std::thread::spawn(move || {
-                        let result = capture_crop_to_png(output_path.as_path(), crop)
-                            .map(|_| output_path.clone());
-                        let _ = tx.send(result);
+pub(crate) fn run_pending_screenshot_capture_if_due(st: &mut Halley, now_ms: u64) {
+    if let Some(pending) = st
+        .input
+        .interaction_state
+        .pending_screenshot_capture
+        .clone()
+        && now_ms >= pending.execute_at_ms
+    {
+        st.input.interaction_state.pending_screenshot_capture = None;
+        match pending.kind {
+            PendingScreenshotKind::Crop(crop) => {
+                let (tx, rx) = mpsc::channel();
+                let output_path = pending.output_path.clone();
+                std::thread::spawn(move || {
+                    let result = capture_crop_to_png(output_path.as_path(), crop)
+                        .map(|_| output_path.clone());
+                    let _ = tx.send(result);
+                });
+                st.input.interaction_state.inflight_screenshot_capture =
+                    Some(InflightScreenshotCapture {
+                        monitor: pending.monitor,
+                        serial: pending.serial,
+                        rx,
                     });
-                    self.input.interaction_state.inflight_screenshot_capture =
-                        Some(InflightScreenshotCapture {
-                            monitor: pending.monitor,
-                            serial: pending.serial,
-                            rx,
-                        });
-                }
-                PendingScreenshotKind::Window { node_id } => {
-                    let result = self
-                        .portal
-                        .capture_backend
-                        .clone()
-                        .ok_or_else(|| "no capture backend configured".to_string())
-                        .and_then(|backend| {
-                            backend
-                                .capture_window_png(
-                                    self,
-                                    pending.monitor.as_str(),
-                                    node_id,
-                                    pending.output_path.as_path(),
-                                )
-                                .map_err(|err| err.to_string())
-                        });
-                    match &result {
-                        Ok(_) => {
-                            let message =
-                                format!("Saved screenshot\n{}", pending.output_path.display());
-                            self.ui.render_state.show_overlay_toast(
-                                pending.monitor.as_str(),
-                                message.as_str(),
-                                4200,
-                                now_ms,
-                            );
-                        }
-                        Err(err) => {
-                            let message = format!("Capture failed\n{err}");
-                            self.ui.render_state.show_overlay_toast(
-                                pending.monitor.as_str(),
-                                message.as_str(),
-                                5000,
-                                now_ms,
-                            );
-                        }
-                    }
-                    self.input.interaction_state.last_screenshot_result =
-                        Some(ScreenshotCaptureResult {
-                            serial: pending.serial,
-                            saved_path: result.as_ref().ok().map(|_| pending.output_path.clone()),
-                            error: result.err(),
-                        });
-                }
             }
-            self.request_maintenance();
+            PendingScreenshotKind::Window { node_id } => {
+                let result = st
+                    .portal
+                    .capture_backend
+                    .clone()
+                    .ok_or_else(|| "no capture backend configured".to_string())
+                    .and_then(|backend| {
+                        backend
+                            .capture_window_png(
+                                st,
+                                pending.monitor.as_str(),
+                                node_id,
+                                pending.output_path.as_path(),
+                            )
+                            .map_err(|err| err.to_string())
+                    });
+                match &result {
+                    Ok(_) => {
+                        let message =
+                            format!("Saved screenshot\n{}", pending.output_path.display());
+                        st.ui.render_state.show_overlay_toast(
+                            pending.monitor.as_str(),
+                            message.as_str(),
+                            4200,
+                            now_ms,
+                        );
+                    }
+                    Err(err) => {
+                        let message = format!("Capture failed\n{err}");
+                        st.ui.render_state.show_overlay_toast(
+                            pending.monitor.as_str(),
+                            message.as_str(),
+                            5000,
+                            now_ms,
+                        );
+                    }
+                }
+                st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+                    serial: pending.serial,
+                    saved_path: result.as_ref().ok().map(|_| pending.output_path.clone()),
+                    error: result.err(),
+                });
+            }
         }
+        st.request_maintenance();
+    }
 
-        if let Some(inflight) = self
-            .input
-            .interaction_state
-            .inflight_screenshot_capture
-            .take()
-        {
-            match inflight.rx.try_recv() {
-                Ok(Ok(path)) => {
-                    self.input.interaction_state.last_screenshot_result =
-                        Some(ScreenshotCaptureResult {
-                            serial: inflight.serial,
-                            saved_path: Some(path.clone()),
-                            error: None,
-                        });
-                    let message = format!("Saved screenshot\n{}", path.display());
-                    self.ui.render_state.show_overlay_toast(
-                        inflight.monitor.as_str(),
-                        message.as_str(),
-                        4200,
-                        now_ms,
-                    );
-                }
-                Ok(Err(err)) => {
-                    self.input.interaction_state.last_screenshot_result =
-                        Some(ScreenshotCaptureResult {
-                            serial: inflight.serial,
-                            saved_path: None,
-                            error: Some(err.clone()),
-                        });
-                    let message = format!("Capture failed\n{err}");
-                    self.ui.render_state.show_overlay_toast(
-                        inflight.monitor.as_str(),
-                        message.as_str(),
-                        5000,
-                        now_ms,
-                    );
-                }
-                Err(mpsc::TryRecvError::Empty) => {
-                    self.input.interaction_state.inflight_screenshot_capture = Some(inflight);
-                    self.request_maintenance();
-                }
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.input.interaction_state.last_screenshot_result =
-                        Some(ScreenshotCaptureResult {
-                            serial: inflight.serial,
-                            saved_path: None,
-                            error: Some("capture worker disconnected".to_string()),
-                        });
-                }
+    if let Some(inflight) = st
+        .input
+        .interaction_state
+        .inflight_screenshot_capture
+        .take()
+    {
+        match inflight.rx.try_recv() {
+            Ok(Ok(path)) => {
+                st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+                    serial: inflight.serial,
+                    saved_path: Some(path.clone()),
+                    error: None,
+                });
+                let message = format!("Saved screenshot\n{}", path.display());
+                st.ui.render_state.show_overlay_toast(
+                    inflight.monitor.as_str(),
+                    message.as_str(),
+                    4200,
+                    now_ms,
+                );
+            }
+            Ok(Err(err)) => {
+                st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+                    serial: inflight.serial,
+                    saved_path: None,
+                    error: Some(err.clone()),
+                });
+                let message = format!("Capture failed\n{err}");
+                st.ui.render_state.show_overlay_toast(
+                    inflight.monitor.as_str(),
+                    message.as_str(),
+                    5000,
+                    now_ms,
+                );
+            }
+            Err(mpsc::TryRecvError::Empty) => {
+                st.input.interaction_state.inflight_screenshot_capture = Some(inflight);
+                st.request_maintenance();
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                st.input.interaction_state.last_screenshot_result = Some(ScreenshotCaptureResult {
+                    serial: inflight.serial,
+                    saved_path: None,
+                    error: Some("capture worker disconnected".to_string()),
+                });
             }
         }
     }
@@ -618,7 +582,8 @@ mod tests {
         let mut state = Halley::new_for_test(&dh, two_monitor_tuning());
         state.input.interaction_state.last_pointer_screen_global = Some((1200.0, 300.0));
 
-        assert!(screenshot_controller(&mut state).start_screenshot_session(
+        assert!(super::start_screenshot_session(
+            &mut state,
             CaptureMode::Menu,
             None,
             Instant::now()
@@ -639,12 +604,13 @@ mod tests {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut state = Halley::new_for_test(&dh, RuntimeTuning::default());
 
-        assert!(screenshot_controller(&mut state).start_screenshot_session(
+        assert!(super::start_screenshot_session(
+            &mut state,
             CaptureMode::Menu,
             None,
             Instant::now()
         ));
-        assert!(screenshot_controller(&mut state).activate_screenshot_menu_item(0));
+        assert!(super::activate_screenshot_menu_item(&mut state, 0));
         assert_eq!(
             state
                 .input
@@ -655,7 +621,7 @@ mod tests {
             Some(CaptureMode::Region)
         );
 
-        assert!(screenshot_controller(&mut state).return_screenshot_session_to_menu());
+        assert!(super::return_screenshot_session_to_menu(&mut state));
         let session = state
             .input
             .interaction_state

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
-mod placement;
+pub(crate) mod placement;
 
 use eventline::debug;
 use halley_config::{InitialWindowOverlapPolicy, InitialWindowSpawnPlacement, PanToNewMode};
@@ -156,7 +155,7 @@ pub(crate) fn initial_toplevel_size(
     }
 }
 
-pub(crate) fn reveal_new_toplevel_node(
+pub(crate) fn reveal_new_toplevel_node_via_ctx(
     ctx: &mut SpawnCtx<'_>,
     id: NodeId,
     is_transient: bool,
@@ -165,325 +164,311 @@ pub(crate) fn reveal_new_toplevel_node(
     ctx.reveal_new_toplevel_node(id, is_transient, now);
 }
 
-pub(crate) struct SpawnRevealController<T> {
-    st: T,
+pub(crate) fn spawn_pan_active(st: &Halley) -> bool {
+    st.model.spawn_state.active_spawn_pan.is_some()
 }
 
-pub(crate) fn spawn_reveal_controller<T>(st: T) -> SpawnRevealController<T> {
-    SpawnRevealController { st }
+pub(crate) fn active_spawn_pan(st: &Halley) -> Option<ActiveSpawnPan> {
+    st.model.spawn_state.active_spawn_pan
 }
 
-impl<T: Deref<Target = Halley>> Deref for SpawnRevealController<T> {
-    type Target = Halley;
+pub(crate) fn set_active_spawn_pan(st: &mut Halley, active: ActiveSpawnPan) {
+    st.model.spawn_state.active_spawn_pan = Some(active);
+}
 
-    fn deref(&self) -> &Self::Target {
-        self.st.deref()
+pub(crate) fn clear_active_spawn_pan(st: &mut Halley) {
+    st.model.spawn_state.active_spawn_pan = None;
+}
+
+pub(crate) fn pop_pending_spawn_pan(st: &mut Halley) -> Option<PendingSpawnPan> {
+    st.model.spawn_state.pending_spawn_pan_queue.pop_front()
+}
+
+pub(crate) fn node_exists(st: &Halley, id: NodeId) -> bool {
+    st.model.field.node(id).is_some()
+}
+
+pub(crate) fn current_monitor_name(st: &Halley) -> String {
+    st.model.monitor_state.current_monitor.clone()
+}
+
+pub(crate) fn monitor_for_node(st: &Halley, id: NodeId) -> Option<String> {
+    st.model.monitor_state.node_monitor.get(&id).cloned()
+}
+
+pub(crate) fn monitor_for_node_or_current(st: &Halley, id: NodeId) -> String {
+    monitor_for_node(st, id).unwrap_or_else(|| current_monitor_name(st))
+}
+
+pub(crate) fn activate_node_monitor_for_spawn_pan(
+    st: &mut Halley,
+    node_id: NodeId,
+) -> Option<String> {
+    let previous_monitor = current_monitor_name(st);
+    let Some(spawn_monitor) = monitor_for_node(st, node_id) else {
+        return None;
+    };
+    if spawn_monitor == previous_monitor {
+        return None;
+    }
+    let _ = st.activate_monitor(spawn_monitor.as_str());
+    Some(previous_monitor)
+}
+
+pub(crate) fn restore_spawn_pan_monitor(st: &mut Halley, previous_monitor: Option<String>) {
+    if let Some(previous_monitor) = previous_monitor {
+        let _ = st.activate_monitor(previous_monitor.as_str());
     }
 }
 
-impl<T: DerefMut<Target = Halley>> DerefMut for SpawnRevealController<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.st.deref_mut()
+pub(crate) fn build_active_spawn_pan(
+    node_id: NodeId,
+    did_pan: bool,
+    now_ms: u64,
+) -> ActiveSpawnPan {
+    ActiveSpawnPan {
+        node_id,
+        pan_start_at_ms: now_ms.saturating_add(if did_pan {
+            Halley::VIEWPORT_PAN_PRELOAD_MS
+        } else {
+            0
+        }),
+        reveal_at_ms: now_ms.saturating_add(if did_pan {
+            Halley::VIEWPORT_PAN_PRELOAD_MS + Halley::VIEWPORT_PAN_DURATION_MS
+        } else {
+            0
+        }),
     }
 }
 
-impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
-    fn spawn_pan_active(&self) -> bool {
-        self.model.spawn_state.active_spawn_pan.is_some()
+pub(crate) fn complete_due_pending_pan_activation(st: &mut Halley, now: Instant, now_ms: u64) {
+    let Some((id, at_ms)) = st.model.spawn_state.pending_pan_activate else {
+        return;
+    };
+    if now_ms < at_ms {
+        return;
+    }
+    st.model.spawn_state.pending_pan_activate = None;
+    if node_exists(st, id) {
+        st.set_interaction_focus(Some(id), 30_000, now);
+    }
+}
+
+pub(crate) fn viewport_pan_finished_for_spawn(
+    st: &Halley,
+    active: ActiveSpawnPan,
+    now_ms: u64,
+) -> bool {
+    now_ms >= active.reveal_at_ms
+        || (now_ms >= active.pan_start_at_ms
+            && st.input.interaction_state.viewport_pan_anim.is_none())
+}
+
+pub(crate) fn reveal_spawn_node(st: &mut Halley, id: NodeId) {
+    let _ = st.model.field.set_detached(id, false);
+    st.resolve_landmarks_overlapped_by_active_window(id);
+}
+
+pub(crate) fn remember_spawn_node_size(st: &mut Halley, id: NodeId) {
+    if let Some(intrinsic_size) = st.model.field.node(id).map(|n| n.intrinsic_size) {
+        st.model
+            .workspace_state
+            .last_active_size
+            .insert(id, intrinsic_size);
+    }
+}
+
+pub(crate) fn mark_spawn_node_hot(st: &mut Halley, id: NodeId) {
+    let _ = st.model.field.set_decay_level(id, DecayLevel::Hot);
+}
+
+pub(crate) fn mark_spawn_open_transition(st: &mut Halley, id: NodeId, now: Instant) {
+    let duration_ms = st.runtime.tuning.window_open_duration_ms();
+    if st.runtime.tuning.window_open_animation_enabled() {
+        crate::compositor::workspace::state::mark_active_transition(&mut *st, id, now, duration_ms);
+    }
+}
+
+pub(crate) fn remove_pending_spawn_activation(st: &mut Halley, id: NodeId) {
+    st.model
+        .spawn_state
+        .pending_spawn_activate_at_ms
+        .remove(&id);
+}
+
+pub(crate) fn suppress_next_focus_trail_record(st: &mut Halley) {
+    st.model.focus_state.suppress_trail_record_once = true;
+}
+
+pub(crate) fn activate_revealed_spawn_node(
+    st: &mut Halley,
+    id: NodeId,
+    now: Instant,
+    record_trail: bool,
+    set_recent_top: bool,
+) {
+    reveal_spawn_node(st, id);
+    if set_recent_top {
+        st.set_recent_top_node(id, now + std::time::Duration::from_millis(1200));
+    }
+    if record_trail {
+        st.record_focus_trail_visit(id);
+        suppress_next_focus_trail_record(st);
+    }
+    st.set_interaction_focus(Some(id), 30_000, now);
+    remove_pending_spawn_activation(st, id);
+    mark_spawn_open_transition(st, id, now);
+}
+
+pub(crate) fn queue_spawn_pan(st: &mut Halley, id: NodeId, target_center: Vec2) {
+    let _ = st.model.field.set_detached(id, true);
+    remove_pending_spawn_activation(st, id);
+    st.model
+        .spawn_state
+        .pending_spawn_pan_queue
+        .push_back(PendingSpawnPan {
+            node_id: id,
+            target_center,
+        });
+}
+
+pub(crate) fn pending_tiled_insert_reveal(st: &Halley, id: NodeId) -> bool {
+    st.model
+        .spawn_state
+        .pending_tiled_insert_reveal_at_ms
+        .contains_key(&id)
+}
+
+pub(crate) fn pending_initial_reveal(st: &Halley, id: NodeId) -> bool {
+    st.model.spawn_state.pending_initial_reveal.contains(&id)
+}
+
+pub(crate) fn suppress_reveal_pan_rule(st: &Halley, id: NodeId) -> bool {
+    st.model
+        .spawn_state
+        .applied_window_rules
+        .get(&id)
+        .is_some_and(|rule| rule.suppress_reveal_pan)
+}
+
+pub(crate) fn node_is_local_active_cluster_member(st: &Halley, id: NodeId, monitor: &str) -> bool {
+    st.model
+        .field
+        .cluster_id_for_member_public(id)
+        .is_some_and(|cid| st.active_cluster_workspace_for_monitor(monitor) == Some(cid))
+}
+
+pub(crate) fn maybe_start_pending_spawn_pan(st: &mut Halley, now: Instant) {
+    if spawn_pan_active(st) {
+        return;
     }
 
-    fn active_spawn_pan(&self) -> Option<ActiveSpawnPan> {
-        self.model.spawn_state.active_spawn_pan
-    }
-
-    fn set_active_spawn_pan(&mut self, active: ActiveSpawnPan) {
-        self.model.spawn_state.active_spawn_pan = Some(active);
-    }
-
-    fn clear_active_spawn_pan(&mut self) {
-        self.model.spawn_state.active_spawn_pan = None;
-    }
-
-    fn pop_pending_spawn_pan(&mut self) -> Option<PendingSpawnPan> {
-        self.model.spawn_state.pending_spawn_pan_queue.pop_front()
-    }
-
-    fn node_exists(&self, id: NodeId) -> bool {
-        self.model.field.node(id).is_some()
-    }
-
-    fn current_monitor_name(&self) -> String {
-        self.model.monitor_state.current_monitor.clone()
-    }
-
-    fn monitor_for_node(&self, id: NodeId) -> Option<String> {
-        self.model.monitor_state.node_monitor.get(&id).cloned()
-    }
-
-    fn monitor_for_node_or_current(&self, id: NodeId) -> String {
-        self.monitor_for_node(id)
-            .unwrap_or_else(|| self.current_monitor_name())
-    }
-
-    fn activate_node_monitor_for_spawn_pan(&mut self, node_id: NodeId) -> Option<String> {
-        let previous_monitor = self.current_monitor_name();
-        let Some(spawn_monitor) = self.monitor_for_node(node_id) else {
-            return None;
-        };
-        if spawn_monitor == previous_monitor {
-            return None;
-        }
-        let _ = self.activate_monitor(spawn_monitor.as_str());
-        Some(previous_monitor)
-    }
-
-    fn restore_spawn_pan_monitor(&mut self, previous_monitor: Option<String>) {
-        if let Some(previous_monitor) = previous_monitor {
-            let _ = self.activate_monitor(previous_monitor.as_str());
-        }
-    }
-
-    fn build_active_spawn_pan(node_id: NodeId, did_pan: bool, now_ms: u64) -> ActiveSpawnPan {
-        ActiveSpawnPan {
-            node_id,
-            pan_start_at_ms: now_ms.saturating_add(if did_pan {
-                Halley::VIEWPORT_PAN_PRELOAD_MS
-            } else {
-                0
-            }),
-            reveal_at_ms: now_ms.saturating_add(if did_pan {
-                Halley::VIEWPORT_PAN_PRELOAD_MS + Halley::VIEWPORT_PAN_DURATION_MS
-            } else {
-                0
-            }),
-        }
-    }
-
-    fn complete_due_pending_pan_activation(&mut self, now: Instant, now_ms: u64) {
-        let Some((id, at_ms)) = self.model.spawn_state.pending_pan_activate else {
-            return;
-        };
-        if now_ms < at_ms {
-            return;
-        }
-        self.model.spawn_state.pending_pan_activate = None;
-        if self.node_exists(id) {
-            self.set_interaction_focus(Some(id), 30_000, now);
-        }
-    }
-
-    fn viewport_pan_finished_for_spawn(&self, active: ActiveSpawnPan, now_ms: u64) -> bool {
-        now_ms >= active.reveal_at_ms
-            || (now_ms >= active.pan_start_at_ms
-                && self.input.interaction_state.viewport_pan_anim.is_none())
-    }
-
-    fn reveal_spawn_node(&mut self, id: NodeId) {
-        let _ = self.model.field.set_detached(id, false);
-        self.resolve_landmarks_overlapped_by_active_window(id);
-    }
-
-    fn remember_spawn_node_size(&mut self, id: NodeId) {
-        if let Some(intrinsic_size) = self.model.field.node(id).map(|n| n.intrinsic_size) {
-            self.model
-                .workspace_state
-                .last_active_size
-                .insert(id, intrinsic_size);
-        }
-    }
-
-    fn mark_spawn_node_hot(&mut self, id: NodeId) {
-        let _ = self.model.field.set_decay_level(id, DecayLevel::Hot);
-    }
-
-    fn mark_spawn_open_transition(&mut self, id: NodeId, now: Instant) {
-        let duration_ms = self.runtime.tuning.window_open_duration_ms();
-        if self.runtime.tuning.window_open_animation_enabled() {
-            crate::compositor::workspace::state::mark_active_transition(
-                &mut **self,
-                id,
-                now,
-                duration_ms,
-            );
-        }
-    }
-
-    fn remove_pending_spawn_activation(&mut self, id: NodeId) {
-        self.model
-            .spawn_state
-            .pending_spawn_activate_at_ms
-            .remove(&id);
-    }
-
-    fn suppress_next_focus_trail_record(&mut self) {
-        self.model.focus_state.suppress_trail_record_once = true;
-    }
-
-    fn activate_revealed_spawn_node(
-        &mut self,
-        id: NodeId,
-        now: Instant,
-        record_trail: bool,
-        set_recent_top: bool,
-    ) {
-        self.reveal_spawn_node(id);
-        if set_recent_top {
-            self.set_recent_top_node(id, now + std::time::Duration::from_millis(1200));
-        }
-        if record_trail {
-            self.record_focus_trail_visit(id);
-            self.suppress_next_focus_trail_record();
-        }
-        self.set_interaction_focus(Some(id), 30_000, now);
-        self.remove_pending_spawn_activation(id);
-        self.mark_spawn_open_transition(id, now);
-    }
-
-    fn queue_spawn_pan(&mut self, id: NodeId, target_center: Vec2) {
-        let _ = self.model.field.set_detached(id, true);
-        self.remove_pending_spawn_activation(id);
-        self.model
-            .spawn_state
-            .pending_spawn_pan_queue
-            .push_back(PendingSpawnPan {
-                node_id: id,
-                target_center,
-            });
-    }
-
-    fn pending_tiled_insert_reveal(&self, id: NodeId) -> bool {
-        self.model
-            .spawn_state
-            .pending_tiled_insert_reveal_at_ms
-            .contains_key(&id)
-    }
-
-    fn pending_initial_reveal(&self, id: NodeId) -> bool {
-        self.model.spawn_state.pending_initial_reveal.contains(&id)
-    }
-
-    fn suppress_reveal_pan_rule(&self, id: NodeId) -> bool {
-        self.model
-            .spawn_state
-            .applied_window_rules
-            .get(&id)
-            .is_some_and(|rule| rule.suppress_reveal_pan)
-    }
-
-    fn node_is_local_active_cluster_member(&self, id: NodeId, monitor: &str) -> bool {
-        self.model
-            .field
-            .cluster_id_for_member_public(id)
-            .is_some_and(|cid| self.active_cluster_workspace_for_monitor(monitor) == Some(cid))
-    }
-
-    pub(crate) fn maybe_start_pending_spawn_pan(&mut self, now: Instant) {
-        if self.spawn_pan_active() {
-            return;
+    let now_ms = st.now_ms(now);
+    while let Some(next) = pop_pending_spawn_pan(st) {
+        if !node_exists(st, next.node_id) {
+            continue;
         }
 
-        let now_ms = self.now_ms(now);
-        while let Some(next) = self.pop_pending_spawn_pan() {
-            if !self.node_exists(next.node_id) {
-                continue;
-            }
+        let previous_monitor = activate_node_monitor_for_spawn_pan(st, next.node_id);
 
-            let previous_monitor = self.activate_node_monitor_for_spawn_pan(next.node_id);
+        let did_pan = st.animate_viewport_center_to_delayed(
+            next.target_center,
+            now,
+            Halley::VIEWPORT_PAN_PRELOAD_MS,
+        );
 
-            let did_pan = self.animate_viewport_center_to_delayed(
-                next.target_center,
-                now,
-                Halley::VIEWPORT_PAN_PRELOAD_MS,
-            );
+        restore_spawn_pan_monitor(st, previous_monitor);
 
-            self.restore_spawn_pan_monitor(previous_monitor);
-
-            let active = Self::build_active_spawn_pan(next.node_id, did_pan, now_ms);
-            if did_pan {
-                self.set_active_spawn_pan(active);
-                self.request_maintenance();
-            } else {
-                self.reveal_completed_spawn_pan(active, now, now_ms);
-            }
-            break;
+        let active = build_active_spawn_pan(next.node_id, did_pan, now_ms);
+        if did_pan {
+            set_active_spawn_pan(st, active);
+            st.request_maintenance();
+        } else {
+            reveal_completed_spawn_pan(st, active, now, now_ms);
         }
+        break;
+    }
+}
+
+pub(crate) fn tick_pending_spawn_pan(st: &mut Halley, now: Instant, now_ms: u64) {
+    complete_due_pending_pan_activation(st, now, now_ms);
+
+    let Some(active) = active_spawn_pan(st) else {
+        maybe_start_pending_spawn_pan(st, now);
+        return;
+    };
+
+    if !node_exists(st, active.node_id) {
+        clear_active_spawn_pan(st);
+        maybe_start_pending_spawn_pan(st, now);
+        return;
     }
 
-    pub(crate) fn tick_pending_spawn_pan(&mut self, now: Instant, now_ms: u64) {
-        self.complete_due_pending_pan_activation(now, now_ms);
-
-        let Some(active) = self.active_spawn_pan() else {
-            self.maybe_start_pending_spawn_pan(now);
-            return;
-        };
-
-        if !self.node_exists(active.node_id) {
-            self.clear_active_spawn_pan();
-            self.maybe_start_pending_spawn_pan(now);
-            return;
-        }
-
-        if !self.viewport_pan_finished_for_spawn(active, now_ms) {
-            return;
-        }
-
-        self.reveal_completed_spawn_pan(active, now, now_ms);
-        self.clear_active_spawn_pan();
-        self.maybe_start_pending_spawn_pan(now);
+    if !viewport_pan_finished_for_spawn(st, active, now_ms) {
+        return;
     }
 
-    fn reveal_completed_spawn_pan(&mut self, active: ActiveSpawnPan, now: Instant, now_ms: u64) {
-        self.reveal_spawn_node(active.node_id);
-        self.mark_spawn_node_hot(active.node_id);
-        self.remember_spawn_node_size(active.node_id);
-        self.mark_spawn_open_transition(active.node_id, now);
-        self.record_focus_trail_visit(active.node_id);
-        self.suppress_next_focus_trail_record();
-        self.model.spawn_state.pending_pan_activate = Some((active.node_id, now_ms + 16));
-        self.request_maintenance();
-    }
+    reveal_completed_spawn_pan(st, active, now, now_ms);
+    clear_active_spawn_pan(st);
+    maybe_start_pending_spawn_pan(st, now);
+}
 
-    pub(crate) fn reveal_new_toplevel_node(
-        &mut self,
-        id: NodeId,
-        is_transient: bool,
-        now: Instant,
-    ) {
-        let node_monitor = self.monitor_for_node_or_current(id);
-        let cluster_local = self.node_is_local_active_cluster_member(id, node_monitor.as_str());
-        if self.pending_tiled_insert_reveal(id) {
-            return;
-        }
-        if cluster_local {
-            self.activate_revealed_spawn_node(id, now, false, true);
-            return;
-        }
-        if self.pending_initial_reveal(id) {
-            return;
-        }
-        if self.suppress_reveal_pan_rule(id) {
-            self.activate_revealed_spawn_node(id, now, true, true);
-            return;
-        }
-        match self.resolve_spawn_reveal_plan(id, is_transient) {
-            RevealNewToplevelPlan::AlreadyQueued => {}
-            RevealNewToplevelPlan::ActivateNow => {
-                self.activate_revealed_spawn_node(id, now, true, false);
-            }
-            RevealNewToplevelPlan::QueuePan { target_center } => {
-                self.queue_spawn_pan(id, target_center);
-                self.maybe_start_pending_spawn_pan(now);
-            }
-        }
-    }
+pub(crate) fn reveal_completed_spawn_pan(
+    st: &mut Halley,
+    active: ActiveSpawnPan,
+    now: Instant,
+    now_ms: u64,
+) {
+    reveal_spawn_node(st, active.node_id);
+    mark_spawn_node_hot(st, active.node_id);
+    remember_spawn_node_size(st, active.node_id);
+    mark_spawn_open_transition(st, active.node_id, now);
+    st.record_focus_trail_visit(active.node_id);
+    suppress_next_focus_trail_record(st);
+    st.model.spawn_state.pending_pan_activate = Some((active.node_id, now_ms + 16));
+    st.request_maintenance();
+}
 
-    fn resolve_spawn_reveal_plan(
-        &self,
-        id: NodeId,
-        is_transient: bool,
-    ) -> read::RevealNewToplevelPlan {
-        read::spawn_read_context(self).reveal_new_toplevel_plan(self, id, is_transient)
+pub(crate) fn reveal_new_toplevel_node(
+    st: &mut Halley,
+    id: NodeId,
+    is_transient: bool,
+    now: Instant,
+) {
+    let node_monitor = monitor_for_node_or_current(st, id);
+    let cluster_local = node_is_local_active_cluster_member(st, id, node_monitor.as_str());
+    if pending_tiled_insert_reveal(st, id) {
+        return;
     }
+    if cluster_local {
+        activate_revealed_spawn_node(st, id, now, false, true);
+        return;
+    }
+    if pending_initial_reveal(st, id) {
+        return;
+    }
+    if suppress_reveal_pan_rule(st, id) {
+        activate_revealed_spawn_node(st, id, now, true, true);
+        return;
+    }
+    match resolve_spawn_reveal_plan(st, id, is_transient) {
+        RevealNewToplevelPlan::AlreadyQueued => {}
+        RevealNewToplevelPlan::ActivateNow => {
+            activate_revealed_spawn_node(st, id, now, true, false);
+        }
+        RevealNewToplevelPlan::QueuePan { target_center } => {
+            queue_spawn_pan(st, id, target_center);
+            maybe_start_pending_spawn_pan(st, now);
+        }
+    }
+}
+
+pub(crate) fn resolve_spawn_reveal_plan(
+    st: &Halley,
+    id: NodeId,
+    is_transient: bool,
+) -> read::RevealNewToplevelPlan {
+    read::spawn_read_context(st).reveal_new_toplevel_plan(st, id, is_transient)
 }
 
 #[cfg(test)]

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -370,7 +370,8 @@ pub(crate) fn maybe_start_pending_spawn_pan(st: &mut Halley, now: Instant) {
 
         let previous_monitor = activate_node_monitor_for_spawn_pan(st, next.node_id);
 
-        let did_pan = st.animate_viewport_center_to_delayed(
+        let did_pan = crate::compositor::focus::system::animate_viewport_center_to_delayed(
+            st,
             next.target_center,
             now,
             Halley::VIEWPORT_PAN_PRELOAD_MS,

--- a/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/mod.rs
@@ -14,7 +14,6 @@ use smithay::wayland::shell::xdg::{SurfaceCachedState, ToplevelSurface};
 
 use crate::compositor::ctx::SpawnCtx;
 use crate::compositor::focus::state::FocusState;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::monitor::state::MonitorState;
 use crate::compositor::overlap::system::CollisionExtents;
 use crate::compositor::root::Halley;

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -1,17 +1,15 @@
 use std::time::Instant;
 
-use eventline::debug;
-use halley_config::{InitialWindowOverlapPolicy, InitialWindowSpawnPlacement};
-use halley_core::field::{NodeId, Vec2};
-use halley_core::viewport::Viewport;
-
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::overlap::system::CollisionExtents;
 use crate::compositor::root::Halley;
 use crate::compositor::spawn::read;
 use crate::compositor::spawn::rules::{InitialWindowIntent, ResolvedInitialWindowRule};
 use crate::compositor::spawn::state::{InitialSpawnPlacement, SpawnPlacementExtents};
 use crate::window::active_window_frame_pad_px;
+use eventline::debug;
+use halley_config::{InitialWindowOverlapPolicy, InitialWindowSpawnPlacement};
+use halley_core::field::{NodeId, Vec2};
+use halley_core::viewport::Viewport;
 
 const SPAWN_COLLISION_SAFETY_SCALE: f32 = 1.08;
 const SPAWN_CONTACT_MARGIN: f32 = 4.0;
@@ -254,7 +252,7 @@ pub(crate) fn viewport_for_monitor(st: &Halley, monitor: &str) -> Option<Viewpor
     if st.model.monitor_state.current_monitor == monitor {
         return Some(Viewport::new(
             st.model.viewport.center,
-            camera_controller(&*st).view_size(),
+            crate::compositor::monitor::camera::camera_view_size(&*st),
         ));
     }
     st.model

--- a/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
+++ b/crates/halley-wl/src/compositor/spawn/reveal/placement.rs
@@ -1,4 +1,3 @@
-use std::ops::{Deref, DerefMut};
 use std::time::Instant;
 
 use eventline::debug;
@@ -13,8 +12,6 @@ use crate::compositor::spawn::read;
 use crate::compositor::spawn::rules::{InitialWindowIntent, ResolvedInitialWindowRule};
 use crate::compositor::spawn::state::{InitialSpawnPlacement, SpawnPlacementExtents};
 use crate::window::active_window_frame_pad_px;
-
-use super::SpawnRevealController;
 
 const SPAWN_COLLISION_SAFETY_SCALE: f32 = 1.08;
 const SPAWN_CONTACT_MARGIN: f32 = 4.0;
@@ -127,574 +124,606 @@ fn spawn_candidate_for_snapshot_dir(
     }
 }
 
-impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
-    const SPAWN_STAR_RINGS: usize = 24;
+const SPAWN_STAR_RINGS: usize = 24;
 
-    fn default_window_rule() -> ResolvedInitialWindowRule {
-        ResolvedInitialWindowRule::default()
+pub(crate) fn default_window_rule() -> ResolvedInitialWindowRule {
+    ResolvedInitialWindowRule::default()
+}
+
+pub(crate) fn has_default_window_rule(intent: &InitialWindowIntent) -> bool {
+    intent.rule == default_window_rule()
+        && intent.parent_node.is_none()
+        && !intent.prefer_app_intent
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn viewport_center_for_monitor(st: &Halley, monitor: &str) -> Vec2 {
+    read::spawn_read_context(st).viewport_center_for_monitor(monitor)
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn resolve_spawn_target_monitor(st: &Halley) -> String {
+    read::spawn_read_context(st).resolve_spawn_target_monitor()
+}
+
+#[cfg(test)]
+pub(crate) fn current_spawn_focus(st: &Halley, monitor: &str) -> (Option<NodeId>, Vec2) {
+    read::spawn_read_context(st).current_spawn_focus(monitor)
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn viewport_fully_contains_surface_on_monitor(
+    st: &Halley,
+    monitor: &str,
+    id: NodeId,
+) -> bool {
+    st.surface_is_fully_visible_on_monitor(monitor, id)
+}
+
+#[cfg(test)]
+pub(crate) fn right_spawn_candidate_for_focus(st: &Halley, id: NodeId, size: Vec2) -> Option<Vec2> {
+    spawn_candidate_for_focus_dir(st, id, size, Vec2 { x: 1.0, y: 0.0 })
+}
+
+pub(crate) fn spawn_candidate_for_focus_dir(
+    st: &Halley,
+    id: NodeId,
+    size: Vec2,
+    dir: Vec2,
+) -> Option<Vec2> {
+    let node = st.model.field.node(id)?;
+    let focus_ext = spawn_safe_obstacle_extents_for_node(st, node);
+    let candidate_ext =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    let gap = st.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+    let pos = if dir.x > 0.0 {
+        Vec2 {
+            x: node.pos.x + focus_ext.right + candidate_ext.left + gap,
+            y: node.pos.y,
+        }
+    } else if dir.x < 0.0 {
+        Vec2 {
+            x: node.pos.x - focus_ext.left - candidate_ext.right - gap,
+            y: node.pos.y,
+        }
+    } else if dir.y > 0.0 {
+        Vec2 {
+            x: node.pos.x,
+            y: node.pos.y + focus_ext.bottom + candidate_ext.top + gap,
+        }
+    } else {
+        Vec2 {
+            x: node.pos.x,
+            y: node.pos.y - focus_ext.top - candidate_ext.bottom - gap,
+        }
+    };
+    let pos = if dir.x == 0.0 && dir.y != 0.0 {
+        let monitor = st
+            .model
+            .monitor_state
+            .node_monitor
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone());
+        adjust_vertical_candidate_to_row(st, monitor.as_str(), node.pos, pos, size)
+    } else {
+        pos
+    };
+    Some(pos)
+}
+
+pub(crate) fn spawn_star_step_x(st: &Halley, size: Vec2) -> f32 {
+    spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32)
+        .size()
+        .x
+        + st.non_overlap_gap_world()
+        + SPAWN_CONTACT_MARGIN
+}
+
+pub(crate) fn spawn_star_step_y(st: &Halley, size: Vec2) -> f32 {
+    spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32)
+        .size()
+        .y
+        + st.non_overlap_gap_world()
+        + SPAWN_CONTACT_MARGIN
+}
+
+pub(crate) fn star_candidate_offsets(st: &Halley, size: Vec2) -> Vec<Vec2> {
+    let step_x = spawn_star_step_x(st, size);
+    let step_y = spawn_star_step_y(st, size);
+    let mut out = Vec::with_capacity(1 + SPAWN_STAR_RINGS * spawn_cardinal_dirs().len());
+
+    out.push(Vec2 { x: 0.0, y: 0.0 });
+
+    for ring in 1..=SPAWN_STAR_RINGS {
+        for dir in spawn_cardinal_dirs() {
+            out.push(Vec2 {
+                x: dir.x * step_x * ring as f32,
+                y: dir.y * step_y * ring as f32,
+            });
+        }
     }
 
-    fn has_default_window_rule(intent: &InitialWindowIntent) -> bool {
-        intent.rule == Self::default_window_rule()
-            && intent.parent_node.is_none()
-            && !intent.prefer_app_intent
-    }
+    out
+}
 
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn viewport_center_for_monitor(&self, monitor: &str) -> Vec2 {
-        read::spawn_read_context(self).viewport_center_for_monitor(monitor)
+pub(crate) fn viewport_for_monitor(st: &Halley, monitor: &str) -> Option<Viewport> {
+    if st.model.monitor_state.current_monitor == monitor {
+        return Some(Viewport::new(
+            st.model.viewport.center,
+            camera_controller(&*st).view_size(),
+        ));
     }
+    st.model
+        .monitor_state
+        .monitors
+        .get(monitor)
+        .map(|space| Viewport::new(space.viewport.center, space.zoom_ref_size))
+}
 
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn resolve_spawn_target_monitor(&self) -> String {
-        read::spawn_read_context(self).resolve_spawn_target_monitor()
-    }
+pub(crate) fn world_from_monitor_screen(
+    st: &Halley,
+    monitor: &str,
+    sx: f32,
+    sy: f32,
+) -> Option<Vec2> {
+    let (w, h, local_sx, local_sy) = st.local_screen_in_monitor(monitor, sx, sy);
+    let viewport = viewport_for_monitor(st, monitor)?;
+    let w = (w as f32).max(1.0);
+    let h = (h as f32).max(1.0);
+    let nx = (local_sx / w) - 0.5;
+    let ny = (local_sy / h) - 0.5;
+    Some(Vec2 {
+        x: viewport.center.x + nx * viewport.size.x.max(1.0),
+        y: viewport.center.y + ny * viewport.size.y.max(1.0),
+    })
+}
 
-    #[cfg(test)]
-    pub(crate) fn current_spawn_focus(&self, monitor: &str) -> (Option<NodeId>, Vec2) {
-        read::spawn_read_context(self).current_spawn_focus(monitor)
-    }
+pub(crate) fn spawn_candidate_fits(
+    st: &Halley,
+    monitor: &str,
+    pos: Vec2,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+) -> bool {
+    spawn_candidate_fits_with_policy(
+        st,
+        monitor,
+        pos,
+        size,
+        skip_node,
+        InitialWindowOverlapPolicy::None,
+        None,
+    )
+}
 
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn viewport_fully_contains_surface_on_monitor(
-        &self,
-        monitor: &str,
-        id: NodeId,
-    ) -> bool {
-        self.surface_is_fully_visible_on_monitor(monitor, id)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn right_spawn_candidate_for_focus(&self, id: NodeId, size: Vec2) -> Option<Vec2> {
-        self.spawn_candidate_for_focus_dir(id, size, Vec2 { x: 1.0, y: 0.0 })
-    }
-
-    pub(crate) fn spawn_candidate_for_focus_dir(
-        &self,
-        id: NodeId,
-        size: Vec2,
-        dir: Vec2,
-    ) -> Option<Vec2> {
-        let node = self.model.field.node(id)?;
-        let focus_ext = self.spawn_safe_obstacle_extents_for_node(node);
-        let candidate_ext = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-        let pos = if dir.x > 0.0 {
-            Vec2 {
-                x: node.pos.x + focus_ext.right + candidate_ext.left + gap,
-                y: node.pos.y,
-            }
-        } else if dir.x < 0.0 {
-            Vec2 {
-                x: node.pos.x - focus_ext.left - candidate_ext.right - gap,
-                y: node.pos.y,
-            }
-        } else if dir.y > 0.0 {
-            Vec2 {
-                x: node.pos.x,
-                y: node.pos.y + focus_ext.bottom + candidate_ext.top + gap,
-            }
-        } else {
-            Vec2 {
-                x: node.pos.x,
-                y: node.pos.y - focus_ext.top - candidate_ext.bottom - gap,
-            }
+pub(crate) fn spawn_candidate_fits_with_policy(
+    st: &Halley,
+    monitor: &str,
+    pos: Vec2,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+    _overlap_policy: InitialWindowOverlapPolicy,
+    _parent_node: Option<NodeId>,
+) -> bool {
+    let pair_gap = st.non_overlap_gap_world();
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    !st.model.field.nodes().values().any(|other| {
+        if Some(other.id) == skip_node {
+            return false;
+        }
+        let Some((other_pos, other_ext)) = visible_spawn_obstacle(st, monitor, other.id) else {
+            return false;
         };
-        let pos = if dir.x == 0.0 && dir.y != 0.0 {
-            let monitor = self
+        let req_x = st.required_sep_x(pos.x, candidate, other_pos.x, other_ext, pair_gap);
+        let req_y = st.required_sep_y(pos.y, candidate, other_pos.y, other_ext, pair_gap);
+        (pos.x - other_pos.x).abs() < req_x && (pos.y - other_pos.y).abs() < req_y
+    })
+}
+
+pub(crate) fn spawn_candidate_fits_with_view_obstacles(
+    st: &Halley,
+    monitor: &str,
+    pos: Vec2,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+) -> bool {
+    let pair_gap = st.non_overlap_gap_world();
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    !st.model.field.nodes().values().any(|other| {
+        if Some(other.id) == skip_node {
+            return false;
+        }
+        let Some((other_pos, other_ext)) = visible_spawn_obstacle(st, monitor, other.id) else {
+            return false;
+        };
+        if !obstacle_intersects_current_view(st, monitor, other_pos, other_ext) {
+            return false;
+        }
+        let req_x = st.required_sep_x(pos.x, candidate, other_pos.x, other_ext, pair_gap);
+        let req_y = st.required_sep_y(pos.y, candidate, other_pos.y, other_ext, pair_gap);
+        (pos.x - other_pos.x).abs() < req_x && (pos.y - other_pos.y).abs() < req_y
+    })
+}
+
+pub(crate) fn obstacle_intersects_current_view(
+    st: &Halley,
+    monitor: &str,
+    pos: Vec2,
+    ext: CollisionExtents,
+) -> bool {
+    let view = st.usable_viewport_for_monitor(monitor);
+    let left = view.center.x - view.size.x * 0.5;
+    let right = view.center.x + view.size.x * 0.5;
+    let top = view.center.y - view.size.y * 0.5;
+    let bottom = view.center.y + view.size.y * 0.5;
+    let obstacle_left = pos.x - ext.left;
+    let obstacle_right = pos.x + ext.right;
+    let obstacle_top = pos.y - ext.top;
+    let obstacle_bottom = pos.y + ext.bottom;
+
+    obstacle_right >= left
+        && obstacle_left <= right
+        && obstacle_bottom >= top
+        && obstacle_top <= bottom
+}
+
+pub(crate) fn visible_spawn_obstacle(
+    st: &Halley,
+    monitor: &str,
+    id: NodeId,
+) -> Option<(Vec2, CollisionExtents)> {
+    let other = st.model.field.node(id)?;
+    let is_pinned_landmark = other.pinned
+        && matches!(
+            other.state,
+            halley_core::field::NodeState::Node | halley_core::field::NodeState::Core
+        );
+    if !is_pinned_landmark
+        || !st.model.field.is_visible(id)
+        || st
+            .model
+            .monitor_state
+            .node_monitor
+            .get(&id)
+            .is_some_and(|other_monitor| other_monitor != monitor)
+    {
+        return None;
+    }
+
+    Some((other.pos, spawn_safe_obstacle_extents_for_node(st, other)))
+}
+
+fn spawn_anchor_for_node(st: &Halley, id: NodeId) -> Option<SpawnAnchor> {
+    st.model.field.node(id).map(|node| SpawnAnchor {
+        node: Some(id),
+        pos: node.pos,
+        ext: Some(spawn_safe_obstacle_extents_for_node(st, node)),
+    })
+}
+
+fn spawn_anchor_at(pos: Vec2) -> SpawnAnchor {
+    SpawnAnchor {
+        node: None,
+        pos,
+        ext: None,
+    }
+}
+
+pub(crate) fn spawn_safe_obstacle_extents_for_node(
+    st: &Halley,
+    node: &halley_core::field::Node,
+) -> CollisionExtents {
+    spawn_safe_obstacle_extents(st.spawn_obstacle_extents_for_node(node))
+}
+
+pub(crate) fn view_center_hits_spawn_node(st: &Halley, monitor: &str, id: NodeId) -> bool {
+    let Some(node) = st.model.field.node(id) else {
+        return false;
+    };
+    let center = st.usable_viewport_for_monitor(monitor).center;
+    let ext = spawn_safe_obstacle_extents_for_node(st, node);
+    center.x >= node.pos.x - ext.left
+        && center.x <= node.pos.x + ext.right
+        && center.y >= node.pos.y - ext.top
+        && center.y <= node.pos.y + ext.bottom
+}
+
+pub(crate) fn view_center_hits_spawn_snapshot(
+    st: &Halley,
+    monitor: &str,
+    pos: Vec2,
+    size: Vec2,
+) -> bool {
+    let center = st.usable_viewport_for_monitor(monitor).center;
+    let frame_pad = active_window_frame_pad_px(&st.runtime.tuning) as f32;
+    let ext = spawn_safe_obstacle_extents(CollisionExtents {
+        left: size.x * 0.5 + frame_pad,
+        right: size.x * 0.5 + frame_pad,
+        top: size.y * 0.5 + frame_pad,
+        bottom: size.y * 0.5 + frame_pad,
+    });
+    center.x >= pos.x - ext.left
+        && center.x <= pos.x + ext.right
+        && center.y >= pos.y - ext.top
+        && center.y <= pos.y + ext.bottom
+}
+
+pub(crate) fn point_is_spawn_view_center(st: &Halley, monitor: &str, pos: Vec2) -> bool {
+    let center = st.usable_viewport_for_monitor(monitor).center;
+    (pos.x - center.x).abs() <= 0.5 && (pos.y - center.y).abs() <= 0.5
+}
+
+pub(crate) fn monitor_has_visible_spawn_surface(st: &Halley, monitor: &str) -> bool {
+    st.model.field.nodes().values().any(|node| {
+        node.kind == halley_core::field::NodeKind::Surface
+            && st.model.field.is_visible(node.id)
+            && st
                 .model
                 .monitor_state
                 .node_monitor
-                .get(&id)
-                .cloned()
-                .unwrap_or_else(|| self.model.monitor_state.current_monitor.clone());
-            self.adjust_vertical_candidate_to_row(monitor.as_str(), node.pos, pos, size)
-        } else {
-            pos
+                .get(&node.id)
+                .is_some_and(|node_monitor| node_monitor == monitor)
+    })
+}
+
+pub(crate) fn occupied_spawn_bounds(
+    st: &Halley,
+    monitor: &str,
+    skip_node: Option<NodeId>,
+) -> Option<(f32, f32, f32, f32)> {
+    let mut bounds: Option<(f32, f32, f32, f32)> = None;
+    for other in st.model.field.nodes().values() {
+        if Some(other.id) == skip_node {
+            continue;
+        }
+        let Some((pos, ext)) = visible_spawn_obstacle(st, monitor, other.id) else {
+            continue;
         };
-        Some(pos)
+        let left = pos.x - ext.left;
+        let right = pos.x + ext.right;
+        let top = pos.y - ext.top;
+        let bottom = pos.y + ext.bottom;
+        bounds = Some(match bounds {
+            Some((current_left, current_right, current_top, current_bottom)) => (
+                current_left.min(left),
+                current_right.max(right),
+                current_top.min(top),
+                current_bottom.max(bottom),
+            ),
+            None => (left, right, top, bottom),
+        });
+    }
+    bounds
+}
+
+pub(crate) fn safe_spawn_fallback_outside_occupied(
+    st: &Halley,
+    monitor: &str,
+    anchor: Vec2,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+    overlap_policy: InitialWindowOverlapPolicy,
+    parent_node: Option<NodeId>,
+) -> Vec2 {
+    let Some((left, right, top, bottom)) = occupied_spawn_bounds(st, monitor, skip_node) else {
+        return anchor;
+    };
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    let gap = st.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+    let candidates = [
+        Vec2 {
+            x: right + candidate.left + gap,
+            y: anchor.y,
+        },
+        Vec2 {
+            x: left - candidate.right - gap,
+            y: anchor.y,
+        },
+        Vec2 {
+            x: anchor.x,
+            y: top - candidate.bottom - gap,
+        },
+        Vec2 {
+            x: anchor.x,
+            y: bottom + candidate.top + gap,
+        },
+    ];
+
+    candidates
+        .into_iter()
+        .find(|pos| {
+            spawn_candidate_fits_with_policy(
+                st,
+                monitor,
+                *pos,
+                size,
+                skip_node,
+                overlap_policy,
+                parent_node,
+            )
+        })
+        .unwrap_or(candidates[0])
+}
+
+pub(crate) fn adjust_vertical_candidate_to_row(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    mut pos: Vec2,
+    size: Vec2,
+) -> Vec2 {
+    let dy = pos.y - center.y;
+    let dir_y = if dy > 0.0 {
+        1.0
+    } else if dy < 0.0 {
+        -1.0
+    } else {
+        0.0
+    };
+    if dir_y == 0.0 || pos.x != center.x {
+        return pos;
     }
 
-    pub(crate) fn spawn_star_step_x(&self, size: Vec2) -> f32 {
-        spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        )
-        .size()
-        .x + self.non_overlap_gap_world()
-            + SPAWN_CONTACT_MARGIN
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    let gap = st.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
+    let mut row_top: Option<f32> = None;
+    let mut row_bottom: Option<f32> = None;
+
+    for other in st.model.field.nodes().values() {
+        let Some((other_pos, other_ext)) = visible_spawn_obstacle(st, monitor, other.id) else {
+            continue;
+        };
+        let top = other_pos.y - other_ext.top;
+        let bottom = other_pos.y + other_ext.bottom;
+        if center.y < top || center.y > bottom {
+            continue;
+        }
+
+        row_top = Some(row_top.map_or(top, |current| current.min(top)));
+        row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
     }
 
-    pub(crate) fn spawn_star_step_y(&self, size: Vec2) -> f32 {
-        spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        )
-        .size()
-        .y + self.non_overlap_gap_world()
-            + SPAWN_CONTACT_MARGIN
-    }
-
-    pub(crate) fn star_candidate_offsets(&self, size: Vec2) -> Vec<Vec2> {
-        let step_x = self.spawn_star_step_x(size);
-        let step_y = self.spawn_star_step_y(size);
-        let mut out = Vec::with_capacity(1 + Self::SPAWN_STAR_RINGS * spawn_cardinal_dirs().len());
-
-        out.push(Vec2 { x: 0.0, y: 0.0 });
-
-        for ring in 1..=Self::SPAWN_STAR_RINGS {
-            for dir in spawn_cardinal_dirs() {
-                out.push(Vec2 {
-                    x: dir.x * step_x * ring as f32,
-                    y: dir.y * step_y * ring as f32,
-                });
+    if dir_y < 0.0 {
+        if let Some(row_top) = row_top {
+            let y = row_top - gap - candidate.bottom;
+            if pos.y > y {
+                pos.y = y;
             }
         }
-
-        out
-    }
-
-    fn viewport_for_monitor(&self, monitor: &str) -> Option<Viewport> {
-        if self.model.monitor_state.current_monitor == monitor {
-            return Some(Viewport::new(
-                self.model.viewport.center,
-                camera_controller(&**self).view_size(),
-            ));
+    } else if let Some(row_bottom) = row_bottom {
+        let y = row_bottom + gap + candidate.top;
+        if pos.y < y {
+            pos.y = y;
         }
-        self.model
-            .monitor_state
-            .monitors
-            .get(monitor)
-            .map(|space| Viewport::new(space.viewport.center, space.zoom_ref_size))
     }
 
-    fn world_from_monitor_screen(&self, monitor: &str, sx: f32, sy: f32) -> Option<Vec2> {
-        let (w, h, local_sx, local_sy) = self.local_screen_in_monitor(monitor, sx, sy);
-        let viewport = self.viewport_for_monitor(monitor)?;
-        let w = (w as f32).max(1.0);
-        let h = (h as f32).max(1.0);
-        let nx = (local_sx / w) - 0.5;
-        let ny = (local_sy / h) - 0.5;
-        Some(Vec2 {
-            x: viewport.center.x + nx * viewport.size.x.max(1.0),
-            y: viewport.center.y + ny * viewport.size.y.max(1.0),
-        })
+    pos
+}
+
+pub(crate) fn vertical_row_center_for_candidate(
+    st: &Halley,
+    monitor: &str,
+    anchor_pos: Vec2,
+    dir_y: f32,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+) -> Option<f32> {
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    let gap = st.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
+    let mut row_top: Option<f32> = None;
+    let mut row_bottom: Option<f32> = None;
+
+    for other in st.model.field.nodes().values() {
+        if Some(other.id) == skip_node {
+            continue;
+        }
+        let Some((other_pos, other_ext)) = visible_spawn_obstacle(st, monitor, other.id) else {
+            continue;
+        };
+        let top = other_pos.y - other_ext.top;
+        let bottom = other_pos.y + other_ext.bottom;
+        if anchor_pos.y < top || anchor_pos.y > bottom {
+            continue;
+        }
+
+        row_top = Some(row_top.map_or(top, |current| current.min(top)));
+        row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
     }
 
-    fn spawn_candidate_fits(
-        &self,
-        monitor: &str,
-        pos: Vec2,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-    ) -> bool {
-        self.spawn_candidate_fits_with_policy(
+    if dir_y < 0.0 {
+        row_top.map(|top| top - gap - candidate.bottom)
+    } else if dir_y > 0.0 {
+        row_bottom.map(|bottom| bottom + gap + candidate.top)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn try_spawn_star_with_policy(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+    overlap_policy: InitialWindowOverlapPolicy,
+    parent_node: Option<NodeId>,
+) -> Option<Vec2> {
+    try_spawn_star_with_policy_skip(st, monitor, center, size, overlap_policy, parent_node, None)
+}
+
+pub(crate) fn try_spawn_star_with_policy_skip(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+    overlap_policy: InitialWindowOverlapPolicy,
+    parent_node: Option<NodeId>,
+    skip_node: Option<NodeId>,
+) -> Option<Vec2> {
+    for offset in star_candidate_offsets(st, size) {
+        let pos = Vec2 {
+            x: center.x + offset.x,
+            y: center.y + offset.y,
+        };
+        let pos = adjust_vertical_candidate_to_row(st, monitor, center, pos, size);
+        if spawn_candidate_fits_with_policy(
+            st,
             monitor,
             pos,
             size,
             skip_node,
-            InitialWindowOverlapPolicy::None,
-            None,
-        )
-    }
-
-    fn spawn_candidate_fits_with_policy(
-        &self,
-        monitor: &str,
-        pos: Vec2,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-        _overlap_policy: InitialWindowOverlapPolicy,
-        _parent_node: Option<NodeId>,
-    ) -> bool {
-        let pair_gap = self.non_overlap_gap_world();
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        !self.model.field.nodes().values().any(|other| {
-            if Some(other.id) == skip_node {
-                return false;
-            }
-            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
-            else {
-                return false;
-            };
-            let req_x = self.required_sep_x(pos.x, candidate, other_pos.x, other_ext, pair_gap);
-            let req_y = self.required_sep_y(pos.y, candidate, other_pos.y, other_ext, pair_gap);
-            (pos.x - other_pos.x).abs() < req_x && (pos.y - other_pos.y).abs() < req_y
-        })
-    }
-
-    fn spawn_candidate_fits_with_view_obstacles(
-        &self,
-        monitor: &str,
-        pos: Vec2,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-    ) -> bool {
-        let pair_gap = self.non_overlap_gap_world();
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        !self.model.field.nodes().values().any(|other| {
-            if Some(other.id) == skip_node {
-                return false;
-            }
-            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
-            else {
-                return false;
-            };
-            if !self.obstacle_intersects_current_view(monitor, other_pos, other_ext) {
-                return false;
-            }
-            let req_x = self.required_sep_x(pos.x, candidate, other_pos.x, other_ext, pair_gap);
-            let req_y = self.required_sep_y(pos.y, candidate, other_pos.y, other_ext, pair_gap);
-            (pos.x - other_pos.x).abs() < req_x && (pos.y - other_pos.y).abs() < req_y
-        })
-    }
-
-    fn obstacle_intersects_current_view(
-        &self,
-        monitor: &str,
-        pos: Vec2,
-        ext: CollisionExtents,
-    ) -> bool {
-        let view = self.usable_viewport_for_monitor(monitor);
-        let left = view.center.x - view.size.x * 0.5;
-        let right = view.center.x + view.size.x * 0.5;
-        let top = view.center.y - view.size.y * 0.5;
-        let bottom = view.center.y + view.size.y * 0.5;
-        let obstacle_left = pos.x - ext.left;
-        let obstacle_right = pos.x + ext.right;
-        let obstacle_top = pos.y - ext.top;
-        let obstacle_bottom = pos.y + ext.bottom;
-
-        obstacle_right >= left
-            && obstacle_left <= right
-            && obstacle_bottom >= top
-            && obstacle_top <= bottom
-    }
-
-    fn visible_spawn_obstacle(
-        &self,
-        monitor: &str,
-        id: NodeId,
-    ) -> Option<(Vec2, CollisionExtents)> {
-        let other = self.model.field.node(id)?;
-        let is_pinned_landmark = other.pinned
-            && matches!(
-                other.state,
-                halley_core::field::NodeState::Node | halley_core::field::NodeState::Core
-            );
-        if !is_pinned_landmark
-            || !self.model.field.is_visible(id)
-            || self
-                .model
-                .monitor_state
-                .node_monitor
-                .get(&id)
-                .is_some_and(|other_monitor| other_monitor != monitor)
-        {
-            return None;
-        }
-
-        Some((other.pos, self.spawn_safe_obstacle_extents_for_node(other)))
-    }
-
-    fn spawn_anchor_for_node(&self, id: NodeId) -> Option<SpawnAnchor> {
-        self.model.field.node(id).map(|node| SpawnAnchor {
-            node: Some(id),
-            pos: node.pos,
-            ext: Some(self.spawn_safe_obstacle_extents_for_node(node)),
-        })
-    }
-
-    fn spawn_anchor_at(&self, pos: Vec2) -> SpawnAnchor {
-        SpawnAnchor {
-            node: None,
-            pos,
-            ext: None,
-        }
-    }
-
-    fn spawn_safe_obstacle_extents_for_node(
-        &self,
-        node: &halley_core::field::Node,
-    ) -> CollisionExtents {
-        spawn_safe_obstacle_extents(self.spawn_obstacle_extents_for_node(node))
-    }
-
-    fn view_center_hits_spawn_node(&self, monitor: &str, id: NodeId) -> bool {
-        let Some(node) = self.model.field.node(id) else {
-            return false;
-        };
-        let center = self.usable_viewport_for_monitor(monitor).center;
-        let ext = self.spawn_safe_obstacle_extents_for_node(node);
-        center.x >= node.pos.x - ext.left
-            && center.x <= node.pos.x + ext.right
-            && center.y >= node.pos.y - ext.top
-            && center.y <= node.pos.y + ext.bottom
-    }
-
-    fn view_center_hits_spawn_snapshot(&self, monitor: &str, pos: Vec2, size: Vec2) -> bool {
-        let center = self.usable_viewport_for_monitor(monitor).center;
-        let frame_pad = active_window_frame_pad_px(&self.runtime.tuning) as f32;
-        let ext = spawn_safe_obstacle_extents(CollisionExtents {
-            left: size.x * 0.5 + frame_pad,
-            right: size.x * 0.5 + frame_pad,
-            top: size.y * 0.5 + frame_pad,
-            bottom: size.y * 0.5 + frame_pad,
-        });
-        center.x >= pos.x - ext.left
-            && center.x <= pos.x + ext.right
-            && center.y >= pos.y - ext.top
-            && center.y <= pos.y + ext.bottom
-    }
-
-    fn point_is_spawn_view_center(&self, monitor: &str, pos: Vec2) -> bool {
-        let center = self.usable_viewport_for_monitor(monitor).center;
-        (pos.x - center.x).abs() <= 0.5 && (pos.y - center.y).abs() <= 0.5
-    }
-
-    fn monitor_has_visible_spawn_surface(&self, monitor: &str) -> bool {
-        self.model.field.nodes().values().any(|node| {
-            node.kind == halley_core::field::NodeKind::Surface
-                && self.model.field.is_visible(node.id)
-                && self
-                    .model
-                    .monitor_state
-                    .node_monitor
-                    .get(&node.id)
-                    .is_some_and(|node_monitor| node_monitor == monitor)
-        })
-    }
-
-    fn occupied_spawn_bounds(
-        &self,
-        monitor: &str,
-        skip_node: Option<NodeId>,
-    ) -> Option<(f32, f32, f32, f32)> {
-        let mut bounds: Option<(f32, f32, f32, f32)> = None;
-        for other in self.model.field.nodes().values() {
-            if Some(other.id) == skip_node {
-                continue;
-            }
-            let Some((pos, ext)) = self.visible_spawn_obstacle(monitor, other.id) else {
-                continue;
-            };
-            let left = pos.x - ext.left;
-            let right = pos.x + ext.right;
-            let top = pos.y - ext.top;
-            let bottom = pos.y + ext.bottom;
-            bounds = Some(match bounds {
-                Some((current_left, current_right, current_top, current_bottom)) => (
-                    current_left.min(left),
-                    current_right.max(right),
-                    current_top.min(top),
-                    current_bottom.max(bottom),
-                ),
-                None => (left, right, top, bottom),
-            });
-        }
-        bounds
-    }
-
-    fn safe_spawn_fallback_outside_occupied(
-        &self,
-        monitor: &str,
-        anchor: Vec2,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-        overlap_policy: InitialWindowOverlapPolicy,
-        parent_node: Option<NodeId>,
-    ) -> Vec2 {
-        let Some((left, right, top, bottom)) = self.occupied_spawn_bounds(monitor, skip_node)
-        else {
-            return anchor;
-        };
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-        let candidates = [
-            Vec2 {
-                x: right + candidate.left + gap,
-                y: anchor.y,
-            },
-            Vec2 {
-                x: left - candidate.right - gap,
-                y: anchor.y,
-            },
-            Vec2 {
-                x: anchor.x,
-                y: top - candidate.bottom - gap,
-            },
-            Vec2 {
-                x: anchor.x,
-                y: bottom + candidate.top + gap,
-            },
-        ];
-
-        candidates
-            .into_iter()
-            .find(|pos| {
-                self.spawn_candidate_fits_with_policy(
-                    monitor,
-                    *pos,
-                    size,
-                    skip_node,
-                    overlap_policy,
-                    parent_node,
-                )
-            })
-            .unwrap_or(candidates[0])
-    }
-
-    fn adjust_vertical_candidate_to_row(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        mut pos: Vec2,
-        size: Vec2,
-    ) -> Vec2 {
-        let dy = pos.y - center.y;
-        let dir_y = if dy > 0.0 {
-            1.0
-        } else if dy < 0.0 {
-            -1.0
-        } else {
-            0.0
-        };
-        if dir_y == 0.0 || pos.x != center.x {
-            return pos;
-        }
-
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let gap = self.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
-        let mut row_top: Option<f32> = None;
-        let mut row_bottom: Option<f32> = None;
-
-        for other in self.model.field.nodes().values() {
-            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
-            else {
-                continue;
-            };
-            let top = other_pos.y - other_ext.top;
-            let bottom = other_pos.y + other_ext.bottom;
-            if center.y < top || center.y > bottom {
-                continue;
-            }
-
-            row_top = Some(row_top.map_or(top, |current| current.min(top)));
-            row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
-        }
-
-        if dir_y < 0.0 {
-            if let Some(row_top) = row_top {
-                let y = row_top - gap - candidate.bottom;
-                if pos.y > y {
-                    pos.y = y;
-                }
-            }
-        } else if let Some(row_bottom) = row_bottom {
-            let y = row_bottom + gap + candidate.top;
-            if pos.y < y {
-                pos.y = y;
-            }
-        }
-
-        pos
-    }
-
-    fn vertical_row_center_for_candidate(
-        &self,
-        monitor: &str,
-        anchor_pos: Vec2,
-        dir_y: f32,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-    ) -> Option<f32> {
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let gap = self.non_overlap_gap_world() * 2.0 + SPAWN_CONTACT_MARGIN;
-        let mut row_top: Option<f32> = None;
-        let mut row_bottom: Option<f32> = None;
-
-        for other in self.model.field.nodes().values() {
-            if Some(other.id) == skip_node {
-                continue;
-            }
-            let Some((other_pos, other_ext)) = self.visible_spawn_obstacle(monitor, other.id)
-            else {
-                continue;
-            };
-            let top = other_pos.y - other_ext.top;
-            let bottom = other_pos.y + other_ext.bottom;
-            if anchor_pos.y < top || anchor_pos.y > bottom {
-                continue;
-            }
-
-            row_top = Some(row_top.map_or(top, |current| current.min(top)));
-            row_bottom = Some(row_bottom.map_or(bottom, |current| current.max(bottom)));
-        }
-
-        if dir_y < 0.0 {
-            row_top.map(|top| top - gap - candidate.bottom)
-        } else if dir_y > 0.0 {
-            row_bottom.map(|bottom| bottom + gap + candidate.top)
-        } else {
-            None
-        }
-    }
-
-    fn try_spawn_star_with_policy(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        size: Vec2,
-        overlap_policy: InitialWindowOverlapPolicy,
-        parent_node: Option<NodeId>,
-    ) -> Option<Vec2> {
-        self.try_spawn_star_with_policy_skip(
-            monitor,
-            center,
-            size,
             overlap_policy,
             parent_node,
-            None,
-        )
+        ) {
+            return Some(pos);
+        }
     }
 
-    fn try_spawn_star_with_policy_skip(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        size: Vec2,
-        overlap_policy: InitialWindowOverlapPolicy,
-        parent_node: Option<NodeId>,
-        skip_node: Option<NodeId>,
-    ) -> Option<Vec2> {
-        for offset in self.star_candidate_offsets(size) {
-            let pos = Vec2 {
-                x: center.x + offset.x,
-                y: center.y + offset.y,
-            };
-            let pos = self.adjust_vertical_candidate_to_row(monitor, center, pos, size);
-            if self.spawn_candidate_fits_with_policy(
+    Some(safe_spawn_fallback_outside_occupied(
+        st,
+        monitor,
+        center,
+        size,
+        skip_node,
+        overlap_policy,
+        parent_node,
+    ))
+}
+
+pub(crate) fn try_strict_spawn_star_with_policy_skip(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+    overlap_policy: InitialWindowOverlapPolicy,
+    parent_node: Option<NodeId>,
+    skip_node: Option<NodeId>,
+) -> Option<Vec2> {
+    if spawn_candidate_fits_with_policy(
+        st,
+        monitor,
+        center,
+        size,
+        skip_node,
+        overlap_policy,
+        parent_node,
+    ) {
+        return Some(center);
+    }
+
+    for ring in 1..=SPAWN_STAR_RINGS {
+        for dir in spawn_cardinal_dirs() {
+            let pos = strict_spawn_arm_candidate(st, monitor, center, size, dir, ring);
+            if spawn_candidate_fits_with_policy(
+                st,
                 monitor,
                 pos,
                 size,
@@ -705,491 +734,430 @@ impl<T: Deref<Target = Halley>> SpawnRevealController<T> {
                 return Some(pos);
             }
         }
-
-        Some(self.safe_spawn_fallback_outside_occupied(
-            monitor,
-            center,
-            size,
-            skip_node,
-            overlap_policy,
-            parent_node,
-        ))
     }
 
-    fn try_strict_spawn_star_with_policy_skip(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        size: Vec2,
-        overlap_policy: InitialWindowOverlapPolicy,
-        parent_node: Option<NodeId>,
-        skip_node: Option<NodeId>,
-    ) -> Option<Vec2> {
-        if self.spawn_candidate_fits_with_policy(
-            monitor,
-            center,
-            size,
-            skip_node,
-            overlap_policy,
-            parent_node,
-        ) {
-            return Some(center);
-        }
+    Some(safe_spawn_fallback_outside_occupied(
+        st,
+        monitor,
+        center,
+        size,
+        skip_node,
+        overlap_policy,
+        parent_node,
+    ))
+}
 
-        for ring in 1..=Self::SPAWN_STAR_RINGS {
-            for dir in spawn_cardinal_dirs() {
-                let pos = self.strict_spawn_arm_candidate(monitor, center, size, dir, ring);
-                if self.spawn_candidate_fits_with_policy(
-                    monitor,
-                    pos,
-                    size,
-                    skip_node,
-                    overlap_policy,
-                    parent_node,
-                ) {
-                    return Some(pos);
-                }
-            }
-        }
-
-        Some(self.safe_spawn_fallback_outside_occupied(
-            monitor,
-            center,
-            size,
-            skip_node,
-            overlap_policy,
-            parent_node,
-        ))
-    }
-
-    fn try_view_center_spawn_star(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        size: Vec2,
-        skip_node: Option<NodeId>,
-    ) -> Option<Vec2> {
-        for offset in self.star_candidate_offsets(size) {
-            let pos = Vec2 {
-                x: center.x + offset.x,
-                y: center.y + offset.y,
-            };
-            if self.spawn_candidate_fits_with_view_obstacles(monitor, pos, size, skip_node) {
-                return Some(pos);
-            }
-        }
-
-        None
-    }
-
-    fn strict_spawn_arm_candidate(
-        &self,
-        monitor: &str,
-        center: Vec2,
-        size: Vec2,
-        dir: Vec2,
-        occurrence: usize,
-    ) -> Vec2 {
-        let candidate = spawn_candidate_extents(
-            size,
-            active_window_frame_pad_px(&self.runtime.tuning) as f32,
-        );
-        let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-        let mut bases: Vec<(Vec2, CollisionExtents)> = self
-            .model
-            .field
-            .nodes()
-            .values()
-            .filter_map(|other| self.visible_spawn_obstacle(monitor, other.id))
-            .filter(|(pos, ext)| {
-                if dir.x > 0.0 {
-                    pos.x >= center.x - 0.5
-                        && center.y >= pos.y - ext.top
-                        && center.y <= pos.y + ext.bottom
-                } else if dir.x < 0.0 {
-                    pos.x <= center.x + 0.5
-                        && center.y >= pos.y - ext.top
-                        && center.y <= pos.y + ext.bottom
-                } else if dir.y < 0.0 {
-                    pos.y <= center.y + 0.5
-                        && center.x >= pos.x - ext.left
-                        && center.x <= pos.x + ext.right
-                } else {
-                    pos.y >= center.y - 0.5
-                        && center.x >= pos.x - ext.left
-                        && center.x <= pos.x + ext.right
-                }
-            })
-            .collect();
-
-        bases.sort_by(|(a, _), (b, _)| {
-            let ordering = if dir.x > 0.0 {
-                a.x.partial_cmp(&b.x)
-            } else if dir.x < 0.0 {
-                b.x.partial_cmp(&a.x)
-            } else if dir.y < 0.0 {
-                b.y.partial_cmp(&a.y)
-            } else {
-                a.y.partial_cmp(&b.y)
-            };
-            ordering.unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        if let Some((base_pos, base_ext)) = bases.get(occurrence.saturating_sub(1)).copied() {
-            if dir.x > 0.0 {
-                return Vec2 {
-                    x: base_pos.x + base_ext.right + candidate.left + gap,
-                    y: center.y,
-                };
-            }
-            if dir.x < 0.0 {
-                return Vec2 {
-                    x: base_pos.x - base_ext.left - candidate.right - gap,
-                    y: center.y,
-                };
-            }
-            if dir.y < 0.0 {
-                return Vec2 {
-                    x: center.x,
-                    y: base_pos.y - base_ext.top - candidate.bottom - gap,
-                };
-            }
-            return Vec2 {
-                x: center.x,
-                y: base_pos.y + base_ext.bottom + candidate.top + gap,
-            };
-        }
-
-        let offset = Vec2 {
-            x: dir.x * self.spawn_star_step_x(size) * occurrence as f32,
-            y: dir.y * self.spawn_star_step_y(size) * occurrence as f32,
-        };
-        Vec2 {
+pub(crate) fn try_view_center_spawn_star(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+    skip_node: Option<NodeId>,
+) -> Option<Vec2> {
+    for offset in star_candidate_offsets(st, size) {
+        let pos = Vec2 {
             x: center.x + offset.x,
             y: center.y + offset.y,
+        };
+        if spawn_candidate_fits_with_view_obstacles(st, monitor, pos, size, skip_node) {
+            return Some(pos);
         }
     }
 
-    fn try_strict_spawn_star(&self, monitor: &str, center: Vec2, size: Vec2) -> Option<Vec2> {
-        self.try_strict_spawn_star_with_policy_skip(
-            monitor,
-            center,
-            size,
-            InitialWindowOverlapPolicy::None,
-            None,
-            None,
-        )
-    }
+    None
+}
 
-    fn resolve_parent_monitor(&self, parent_node: Option<NodeId>) -> Option<String> {
-        parent_node.and_then(|id| self.model.monitor_state.node_monitor.get(&id).cloned())
-    }
-
-    fn fullscreen_anchor_for_monitor(&self, monitor: &str) -> Option<(NodeId, Vec2)> {
-        let fullscreen_id = self
-            .model
-            .fullscreen_state
-            .fullscreen_active_node
-            .get(monitor)
-            .copied()?;
-        let pos = self.model.field.node(fullscreen_id).map(|node| node.pos)?;
-        Some((fullscreen_id, pos))
-    }
-
-    pub(crate) fn spawn_target_monitor_for_intent(&self, intent: &InitialWindowIntent) -> String {
-        let default_monitor = read::spawn_read_context(self).resolve_spawn_target_monitor();
-        match intent.effective_spawn_placement() {
-            InitialWindowSpawnPlacement::Default
-            | InitialWindowSpawnPlacement::Center
-            | InitialWindowSpawnPlacement::Adjacent
-            | InitialWindowSpawnPlacement::App => self
-                .resolve_parent_monitor(intent.parent_node)
-                .unwrap_or(default_monitor),
-            InitialWindowSpawnPlacement::Cursor => {
-                if let Some((sx, sy)) = self.input.interaction_state.last_pointer_screen_global {
-                    self.monitor_for_screen(sx, sy).unwrap_or(default_monitor)
-                } else {
-                    default_monitor
-                }
+pub(crate) fn strict_spawn_arm_candidate(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+    dir: Vec2,
+    occurrence: usize,
+) -> Vec2 {
+    let candidate =
+        spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+    let gap = st.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+    let mut bases: Vec<(Vec2, CollisionExtents)> = st
+        .model
+        .field
+        .nodes()
+        .values()
+        .filter_map(|other| visible_spawn_obstacle(st, monitor, other.id))
+        .filter(|(pos, ext)| {
+            if dir.x > 0.0 {
+                pos.x >= center.x - 0.5
+                    && center.y >= pos.y - ext.top
+                    && center.y <= pos.y + ext.bottom
+            } else if dir.x < 0.0 {
+                pos.x <= center.x + 0.5
+                    && center.y >= pos.y - ext.top
+                    && center.y <= pos.y + ext.bottom
+            } else if dir.y < 0.0 {
+                pos.y <= center.y + 0.5
+                    && center.x >= pos.x - ext.left
+                    && center.x <= pos.x + ext.right
+            } else {
+                pos.y >= center.y - 0.5
+                    && center.x >= pos.x - ext.left
+                    && center.x <= pos.x + ext.right
             }
-            InitialWindowSpawnPlacement::ViewportCenter => default_monitor,
+        })
+        .collect();
+
+    bases.sort_by(|(a, _), (b, _)| {
+        let ordering = if dir.x > 0.0 {
+            a.x.partial_cmp(&b.x)
+        } else if dir.x < 0.0 {
+            b.x.partial_cmp(&a.x)
+        } else if dir.y < 0.0 {
+            b.y.partial_cmp(&a.y)
+        } else {
+            a.y.partial_cmp(&b.y)
+        };
+        ordering.unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if let Some((base_pos, base_ext)) = bases.get(occurrence.saturating_sub(1)).copied() {
+        if dir.x > 0.0 {
+            return Vec2 {
+                x: base_pos.x + base_ext.right + candidate.left + gap,
+                y: center.y,
+            };
         }
+        if dir.x < 0.0 {
+            return Vec2 {
+                x: base_pos.x - base_ext.left - candidate.right - gap,
+                y: center.y,
+            };
+        }
+        if dir.y < 0.0 {
+            return Vec2 {
+                x: center.x,
+                y: base_pos.y - base_ext.top - candidate.bottom - gap,
+            };
+        }
+        return Vec2 {
+            x: center.x,
+            y: base_pos.y + base_ext.bottom + candidate.top + gap,
+        };
     }
 
-    fn pick_cluster_growth_dir(&self, monitor: &str, center: Vec2) -> Vec2 {
-        let dirs = spawn_cardinal_dirs();
-        let local = self
-            .model
-            .monitor_state
-            .monitors
-            .get(monitor)
-            .map(|monitor| Vec2 {
-                x: center.x - monitor.offset_x as f32,
-                y: center.y - monitor.offset_y as f32,
-            })
-            .unwrap_or(center);
-        let idx = ((self.spawn_monitor_state(monitor).spawn_cursor as usize)
-            .wrapping_add(local.x.abs() as usize)
-            .wrapping_add((local.y.abs() * 3.0) as usize))
-            % dirs.len();
-        dirs[idx]
+    let offset = Vec2 {
+        x: dir.x * spawn_star_step_x(st, size) * occurrence as f32,
+        y: dir.y * spawn_star_step_y(st, size) * occurrence as f32,
+    };
+    Vec2 {
+        x: center.x + offset.x,
+        y: center.y + offset.y,
     }
 }
 
-impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
-    fn set_pending_initial_spawn_placement(
-        &mut self,
-        monitor: &str,
-        anchor_pos: Vec2,
-        anchor_ext: Option<CollisionExtents>,
-        chosen_pos: Vec2,
-        dir: Option<Vec2>,
-        preserve_chosen_pos: bool,
-        view_center_reset: bool,
-        _overlap_policy: InitialWindowOverlapPolicy,
-    ) {
-        self.model.spawn_state.pending_initial_spawn_placement = Some(InitialSpawnPlacement {
-            monitor: monitor.to_string(),
-            anchor_pos,
-            anchor_ext: anchor_ext.map(spawn_record_extents),
-            chosen_pos,
-            dir,
-            preserve_chosen_pos,
-            view_center_reset,
-        });
-    }
+pub(crate) fn try_strict_spawn_star(
+    st: &Halley,
+    monitor: &str,
+    center: Vec2,
+    size: Vec2,
+) -> Option<Vec2> {
+    try_strict_spawn_star_with_policy_skip(
+        st,
+        monitor,
+        center,
+        size,
+        InitialWindowOverlapPolicy::None,
+        None,
+        None,
+    )
+}
 
-    pub(crate) fn finalize_initial_spawn_position(&mut self, id: NodeId, size: Vec2) -> bool {
-        let Some(record) = self.model.spawn_state.initial_spawn_placements.remove(&id) else {
+pub(crate) fn resolve_parent_monitor(st: &Halley, parent_node: Option<NodeId>) -> Option<String> {
+    parent_node.and_then(|id| st.model.monitor_state.node_monitor.get(&id).cloned())
+}
+
+pub(crate) fn fullscreen_anchor_for_monitor(st: &Halley, monitor: &str) -> Option<(NodeId, Vec2)> {
+    let fullscreen_id = st
+        .model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(monitor)
+        .copied()?;
+    let pos = st.model.field.node(fullscreen_id).map(|node| node.pos)?;
+    Some((fullscreen_id, pos))
+}
+
+pub(crate) fn spawn_target_monitor_for_intent(st: &Halley, intent: &InitialWindowIntent) -> String {
+    let default_monitor = read::spawn_read_context(st).resolve_spawn_target_monitor();
+    match intent.effective_spawn_placement() {
+        InitialWindowSpawnPlacement::Default
+        | InitialWindowSpawnPlacement::Center
+        | InitialWindowSpawnPlacement::Adjacent
+        | InitialWindowSpawnPlacement::App => {
+            resolve_parent_monitor(st, intent.parent_node).unwrap_or(default_monitor)
+        }
+        InitialWindowSpawnPlacement::Cursor => {
+            if let Some((sx, sy)) = st.input.interaction_state.last_pointer_screen_global {
+                st.monitor_for_screen(sx, sy).unwrap_or(default_monitor)
+            } else {
+                default_monitor
+            }
+        }
+        InitialWindowSpawnPlacement::ViewportCenter => default_monitor,
+    }
+}
+
+pub(crate) fn pick_cluster_growth_dir(st: &Halley, monitor: &str, center: Vec2) -> Vec2 {
+    let dirs = spawn_cardinal_dirs();
+    let local = st
+        .model
+        .monitor_state
+        .monitors
+        .get(monitor)
+        .map(|monitor| Vec2 {
+            x: center.x - monitor.offset_x as f32,
+            y: center.y - monitor.offset_y as f32,
+        })
+        .unwrap_or(center);
+    let idx = ((st.spawn_monitor_state(monitor).spawn_cursor as usize)
+        .wrapping_add(local.x.abs() as usize)
+        .wrapping_add((local.y.abs() * 3.0) as usize))
+        % dirs.len();
+    dirs[idx]
+}
+
+pub(crate) fn set_pending_initial_spawn_placement(
+    st: &mut Halley,
+    monitor: &str,
+    anchor_pos: Vec2,
+    anchor_ext: Option<CollisionExtents>,
+    chosen_pos: Vec2,
+    dir: Option<Vec2>,
+    preserve_chosen_pos: bool,
+    view_center_reset: bool,
+    _overlap_policy: InitialWindowOverlapPolicy,
+) {
+    st.model.spawn_state.pending_initial_spawn_placement = Some(InitialSpawnPlacement {
+        monitor: monitor.to_string(),
+        anchor_pos,
+        anchor_ext: anchor_ext.map(spawn_record_extents),
+        chosen_pos,
+        dir,
+        preserve_chosen_pos,
+        view_center_reset,
+    });
+}
+
+pub(crate) fn finalize_initial_spawn_position(st: &mut Halley, id: NodeId, size: Vec2) -> bool {
+    let Some(record) = st.model.spawn_state.initial_spawn_placements.remove(&id) else {
+        return false;
+    };
+    let mut pos = record.chosen_pos;
+
+    if record.view_center_reset {
+        pos = try_view_center_spawn_star(
+            st,
+            record.monitor.as_str(),
+            record.anchor_pos,
+            size,
+            Some(id),
+        )
+        .unwrap_or(record.anchor_pos);
+    } else if !record.preserve_chosen_pos {
+        let Some(dir) = record.dir else {
             return false;
         };
-        let mut pos = record.chosen_pos;
+        let candidate =
+            spawn_candidate_extents(size, active_window_frame_pad_px(&st.runtime.tuning) as f32);
+        let pair_gap = st.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+        let row_gap = pair_gap * 2.0;
 
-        if record.view_center_reset {
-            pos = self
-                .try_view_center_spawn_star(
-                    record.monitor.as_str(),
-                    record.anchor_pos,
-                    size,
-                    Some(id),
-                )
-                .unwrap_or(record.anchor_pos);
-        } else if !record.preserve_chosen_pos {
-            let Some(dir) = record.dir else {
-                return false;
-            };
-            let candidate = spawn_candidate_extents(
-                size,
-                active_window_frame_pad_px(&self.runtime.tuning) as f32,
-            );
-            let pair_gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-            let row_gap = pair_gap * 2.0;
-
-            if dir.x > 0.0 {
-                if let Some(anchor) = record.anchor_ext {
-                    pos.x = record.anchor_pos.x + anchor.right + candidate.left + pair_gap;
-                    pos.y = record.anchor_pos.y;
-                }
-            } else if dir.x < 0.0 {
-                if let Some(anchor) = record.anchor_ext {
-                    pos.x = record.anchor_pos.x - anchor.left - candidate.right - pair_gap;
-                    pos.y = record.anchor_pos.y;
-                }
-            } else if dir.y != 0.0 {
-                pos.x = record.anchor_pos.x;
-                if let Some(y) = self.vertical_row_center_for_candidate(
-                    record.monitor.as_str(),
-                    record.anchor_pos,
-                    dir.y,
-                    size,
-                    Some(id),
-                ) {
-                    pos.y = y;
-                } else if let Some(anchor) = record.anchor_ext {
-                    pos.y = if dir.y < 0.0 {
-                        record.anchor_pos.y - anchor.top - row_gap - candidate.bottom
-                    } else {
-                        record.anchor_pos.y + anchor.bottom + row_gap + candidate.top
-                    };
-                }
+        if dir.x > 0.0 {
+            if let Some(anchor) = record.anchor_ext {
+                pos.x = record.anchor_pos.x + anchor.right + candidate.left + pair_gap;
+                pos.y = record.anchor_pos.y;
             }
-        }
-
-        if !record.view_center_reset
-            && !self.spawn_candidate_fits_with_policy(
-                record.monitor.as_str(),
-                pos,
-                size,
-                Some(id),
-                InitialWindowOverlapPolicy::None,
-                None,
-            )
-            && let Some(fallback) = self.try_strict_spawn_star_with_policy_skip(
+        } else if dir.x < 0.0 {
+            if let Some(anchor) = record.anchor_ext {
+                pos.x = record.anchor_pos.x - anchor.left - candidate.right - pair_gap;
+                pos.y = record.anchor_pos.y;
+            }
+        } else if dir.y != 0.0 {
+            pos.x = record.anchor_pos.x;
+            if let Some(y) = vertical_row_center_for_candidate(
+                st,
                 record.monitor.as_str(),
                 record.anchor_pos,
+                dir.y,
                 size,
-                InitialWindowOverlapPolicy::None,
-                None,
                 Some(id),
-            )
-        {
-            pos = fallback;
+            ) {
+                pos.y = y;
+            } else if let Some(anchor) = record.anchor_ext {
+                pos.y = if dir.y < 0.0 {
+                    record.anchor_pos.y - anchor.top - row_gap - candidate.bottom
+                } else {
+                    record.anchor_pos.y + anchor.bottom + row_gap + candidate.top
+                };
+            }
         }
-
-        let _ = self.model.field.carry(id, pos);
-        true
     }
 
-    pub(crate) fn update_spawn_patch(
-        &mut self,
-        monitor: &str,
-        anchor: Vec2,
-        focus_node: Option<NodeId>,
-        focus_pos: Vec2,
-        growth_dir: Vec2,
-    ) {
-        self.spawn_monitor_state_mut(monitor).spawn_patch =
-            Some(crate::compositor::spawn::state::SpawnPatch {
-                anchor,
-                focus_node,
-                focus_pos,
-                growth_dir,
-                placements_in_patch: 0,
-                frontier: Vec::new(),
-            });
+    if !record.view_center_reset
+        && !spawn_candidate_fits_with_policy(
+            st,
+            record.monitor.as_str(),
+            pos,
+            size,
+            Some(id),
+            InitialWindowOverlapPolicy::None,
+            None,
+        )
+        && let Some(fallback) = try_strict_spawn_star_with_policy_skip(
+            st,
+            record.monitor.as_str(),
+            record.anchor_pos,
+            size,
+            InitialWindowOverlapPolicy::None,
+            None,
+            Some(id),
+        )
+    {
+        pos = fallback;
     }
 
-    fn commit_spawn_plan(
-        &mut self,
-        monitor: &str,
-        anchor: SpawnAnchor,
-        candidate: SpawnCandidate,
-        overlap_policy: InitialWindowOverlapPolicy,
-    ) {
-        self.set_pending_initial_spawn_placement(
-            monitor,
-            anchor.pos,
-            anchor.ext,
-            candidate.pos,
-            candidate.dir,
-            false,
-            false,
-            overlap_policy,
-        );
-        let growth_dir = candidate
-            .dir
-            .unwrap_or_else(|| self.pick_cluster_growth_dir(monitor, anchor.pos));
-        self.update_spawn_patch(monitor, anchor.pos, anchor.node, anchor.pos, growth_dir);
-        self.spawn_monitor_state_mut(monitor).spawn_view_anchor = anchor.pos;
+    let _ = st.model.field.carry(id, pos);
+    true
+}
+
+pub(crate) fn update_spawn_patch(
+    st: &mut Halley,
+    monitor: &str,
+    anchor: Vec2,
+    focus_node: Option<NodeId>,
+    focus_pos: Vec2,
+    growth_dir: Vec2,
+) {
+    st.spawn_monitor_state_mut(monitor).spawn_patch =
+        Some(crate::compositor::spawn::state::SpawnPatch {
+            anchor,
+            focus_node,
+            focus_pos,
+            growth_dir,
+            placements_in_patch: 0,
+            frontier: Vec::new(),
+        });
+}
+
+fn commit_spawn_plan(
+    st: &mut Halley,
+    monitor: &str,
+    anchor: SpawnAnchor,
+    candidate: SpawnCandidate,
+    overlap_policy: InitialWindowOverlapPolicy,
+) {
+    set_pending_initial_spawn_placement(
+        st,
+        monitor,
+        anchor.pos,
+        anchor.ext,
+        candidate.pos,
+        candidate.dir,
+        false,
+        false,
+        overlap_policy,
+    );
+    let growth_dir = candidate
+        .dir
+        .unwrap_or_else(|| pick_cluster_growth_dir(st, monitor, anchor.pos));
+    update_spawn_patch(st, monitor, anchor.pos, anchor.node, anchor.pos, growth_dir);
+    st.spawn_monitor_state_mut(monitor).spawn_view_anchor = anchor.pos;
+}
+
+pub(crate) fn default_pick_spawn_position(st: &mut Halley, size: Vec2) -> (String, Vec2, bool) {
+    pick_spawn_position_impl(st, size)
+}
+
+#[allow(dead_code)]
+pub(crate) fn pick_spawn_position(st: &mut Halley, size: Vec2) -> (String, Vec2, bool) {
+    default_pick_spawn_position(st, size)
+}
+
+pub(crate) fn pick_spawn_position_with_intent(
+    st: &mut Halley,
+    size: Vec2,
+    intent: &InitialWindowIntent,
+) -> (String, Vec2, bool) {
+    if has_default_window_rule(intent) {
+        return default_pick_spawn_position(st, size);
     }
 
-    fn default_pick_spawn_position(&mut self, size: Vec2) -> (String, Vec2, bool) {
-        self.pick_spawn_position_impl(size)
-    }
+    let target_monitor = spawn_target_monitor_for_intent(st, intent);
+    let overlap_policy = intent.effective_overlap_policy();
+    let placement = intent.effective_spawn_placement();
+    st.spawn_monitor_state_mut(target_monitor.as_str())
+        .spawn_cursor += 1;
+    let viewport_center =
+        read::spawn_read_context(st).viewport_center_for_monitor(target_monitor.as_str());
+    let fullscreen_anchor = if overlap_policy != InitialWindowOverlapPolicy::None {
+        fullscreen_anchor_for_monitor(st, target_monitor.as_str())
+    } else {
+        None
+    };
+    let cursor_anchor = st
+        .input
+        .interaction_state
+        .last_pointer_screen_global
+        .and_then(|(sx, sy)| world_from_monitor_screen(st, target_monitor.as_str(), sx, sy));
 
-    #[allow(dead_code)]
-    pub(crate) fn pick_spawn_position(&mut self, size: Vec2) -> (String, Vec2, bool) {
-        self.default_pick_spawn_position(size)
-    }
-
-    pub(crate) fn pick_spawn_position_with_intent(
-        &mut self,
-        size: Vec2,
-        intent: &InitialWindowIntent,
-    ) -> (String, Vec2, bool) {
-        if Self::has_default_window_rule(intent) {
-            return self.default_pick_spawn_position(size);
-        }
-
-        let target_monitor = self.spawn_target_monitor_for_intent(intent);
-        let overlap_policy = intent.effective_overlap_policy();
-        let placement = intent.effective_spawn_placement();
-        self.spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_cursor += 1;
-        let viewport_center =
-            read::spawn_read_context(self).viewport_center_for_monitor(target_monitor.as_str());
-        let fullscreen_anchor = if overlap_policy != InitialWindowOverlapPolicy::None {
-            self.fullscreen_anchor_for_monitor(target_monitor.as_str())
-        } else {
-            None
-        };
-        let cursor_anchor = self
-            .input
-            .interaction_state
-            .last_pointer_screen_global
-            .and_then(|(sx, sy)| self.world_from_monitor_screen(target_monitor.as_str(), sx, sy));
-
-        match placement {
-            InitialWindowSpawnPlacement::Adjacent => {
-                if let Some(parent_id) = intent.parent_node
-                    && let Some(anchor) = self.spawn_anchor_for_node(parent_id)
+    match placement {
+        InitialWindowSpawnPlacement::Adjacent => {
+            if let Some(parent_id) = intent.parent_node
+                && let Some(anchor) = spawn_anchor_for_node(st, parent_id)
+            {
+                if overlap_policy != InitialWindowOverlapPolicy::None
+                    && fullscreen_anchor
+                        .is_some_and(|(fullscreen_id, _)| fullscreen_id == parent_id)
                 {
-                    if overlap_policy != InitialWindowOverlapPolicy::None
-                        && fullscreen_anchor
-                            .is_some_and(|(fullscreen_id, _)| fullscreen_id == parent_id)
-                    {
-                        let candidate = SpawnCandidate {
-                            pos: anchor.pos,
-                            dir: None,
-                        };
-                        self.commit_spawn_plan(
-                            target_monitor.as_str(),
-                            anchor,
-                            candidate,
-                            overlap_policy,
-                        );
-                        return (target_monitor, candidate.pos, false);
-                    }
+                    let candidate = SpawnCandidate {
+                        pos: anchor.pos,
+                        dir: None,
+                    };
+                    commit_spawn_plan(
+                        st,
+                        target_monitor.as_str(),
+                        anchor,
+                        candidate,
+                        overlap_policy,
+                    );
+                    return (target_monitor, candidate.pos, false);
+                }
 
-                    for dir in spawn_cardinal_dirs() {
-                        if let Some(pos) = self
-                            .spawn_candidate_for_focus_dir(parent_id, size, dir)
-                            .map(|pos| {
-                                self.adjust_vertical_candidate_to_row(
-                                    target_monitor.as_str(),
-                                    anchor.pos,
-                                    pos,
-                                    size,
-                                )
-                            })
-                            && self.spawn_candidate_fits_with_policy(
+                for dir in spawn_cardinal_dirs() {
+                    if let Some(pos) =
+                        spawn_candidate_for_focus_dir(st, parent_id, size, dir).map(|pos| {
+                            adjust_vertical_candidate_to_row(
+                                st,
                                 target_monitor.as_str(),
+                                anchor.pos,
                                 pos,
                                 size,
-                                None,
-                                overlap_policy,
-                                intent.parent_node,
                             )
-                        {
-                            let candidate = SpawnCandidate {
-                                pos,
-                                dir: Some(dir),
-                            };
-                            self.commit_spawn_plan(
-                                target_monitor.as_str(),
-                                anchor,
-                                candidate,
-                                overlap_policy,
-                            );
-                            return (target_monitor, candidate.pos, false);
-                        }
-                    }
-
-                    if let Some(pos) = self.try_spawn_star_with_policy(
-                        target_monitor.as_str(),
-                        anchor.pos,
-                        size,
-                        overlap_policy,
-                        intent.parent_node,
-                    ) {
+                        })
+                        && spawn_candidate_fits_with_policy(
+                            st,
+                            target_monitor.as_str(),
+                            pos,
+                            size,
+                            None,
+                            overlap_policy,
+                            intent.parent_node,
+                        )
+                    {
                         let candidate = SpawnCandidate {
                             pos,
-                            dir: spawn_dir_from_delta(Vec2 {
-                                x: pos.x - anchor.pos.x,
-                                y: pos.y - anchor.pos.y,
-                            }),
+                            dir: Some(dir),
                         };
-                        self.commit_spawn_plan(
+                        commit_spawn_plan(
+                            st,
                             target_monitor.as_str(),
                             anchor,
                             candidate,
@@ -1197,184 +1165,179 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                         );
                         return (target_monitor, candidate.pos, false);
                     }
-
-                    return self.default_pick_spawn_position(size);
                 }
-                return self.default_pick_spawn_position(size);
+
+                if let Some(pos) = try_spawn_star_with_policy(
+                    st,
+                    target_monitor.as_str(),
+                    anchor.pos,
+                    size,
+                    overlap_policy,
+                    intent.parent_node,
+                ) {
+                    let candidate = SpawnCandidate {
+                        pos,
+                        dir: spawn_dir_from_delta(Vec2 {
+                            x: pos.x - anchor.pos.x,
+                            y: pos.y - anchor.pos.y,
+                        }),
+                    };
+                    commit_spawn_plan(
+                        st,
+                        target_monitor.as_str(),
+                        anchor,
+                        candidate,
+                        overlap_policy,
+                    );
+                    return (target_monitor, candidate.pos, false);
+                }
+
+                return default_pick_spawn_position(st, size);
             }
-            InitialWindowSpawnPlacement::Default
-            | InitialWindowSpawnPlacement::Center
-            | InitialWindowSpawnPlacement::ViewportCenter
-            | InitialWindowSpawnPlacement::Cursor
-            | InitialWindowSpawnPlacement::App => {}
+            return default_pick_spawn_position(st, size);
         }
-
-        let anchor = match placement {
-            InitialWindowSpawnPlacement::Default
-            | InitialWindowSpawnPlacement::Center
-            | InitialWindowSpawnPlacement::App => intent
-                .parent_node
-                .and_then(|id| self.spawn_anchor_for_node(id))
-                .or_else(|| {
-                    fullscreen_anchor.and_then(|(id, pos)| {
-                        self.spawn_anchor_for_node(id)
-                            .or_else(|| Some(self.spawn_anchor_at(pos)))
-                    })
-                })
-                .unwrap_or_else(|| self.spawn_anchor_at(viewport_center)),
-            InitialWindowSpawnPlacement::ViewportCenter => self.spawn_anchor_at(viewport_center),
-            InitialWindowSpawnPlacement::Cursor => {
-                self.spawn_anchor_at(cursor_anchor.unwrap_or(viewport_center))
-            }
-            InitialWindowSpawnPlacement::Adjacent => unreachable!("adjacent handled above"),
-        };
-
-        let candidate = self
-            .try_spawn_star_with_policy(
-                target_monitor.as_str(),
-                anchor.pos,
-                size,
-                overlap_policy,
-                intent.parent_node,
-            )
-            .map(|pos| SpawnCandidate {
-                pos,
-                dir: spawn_dir_from_delta(Vec2 {
-                    x: pos.x - anchor.pos.x,
-                    y: pos.y - anchor.pos.y,
-                }),
-            })
-            .unwrap_or(SpawnCandidate {
-                pos: anchor.pos,
-                dir: None,
-            });
-        self.commit_spawn_plan(target_monitor.as_str(), anchor, candidate, overlap_policy);
-        (target_monitor, candidate.pos, false)
+        InitialWindowSpawnPlacement::Default
+        | InitialWindowSpawnPlacement::Center
+        | InitialWindowSpawnPlacement::ViewportCenter
+        | InitialWindowSpawnPlacement::Cursor
+        | InitialWindowSpawnPlacement::App => {}
     }
 
-    fn pick_spawn_position_impl(&mut self, size: Vec2) -> (String, Vec2, bool) {
-        let target_monitor = self
-            .model
-            .spawn_state
-            .pending_spawn_monitor
-            .take()
-            .filter(|monitor| self.model.monitor_state.monitors.contains_key(monitor))
-            .unwrap_or_else(|| read::spawn_read_context(self).resolve_spawn_target_monitor());
-        let focus_override = self
-            .spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_focus_override
-            .take();
-        self.spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_cursor += 1;
-        let viewport_center =
-            read::spawn_read_context(self).viewport_center_for_monitor(target_monitor.as_str());
-        let (focus_id, focus_pos) =
-            read::spawn_read_context(self).current_spawn_focus(target_monitor.as_str());
-        if !self.monitor_has_visible_spawn_surface(target_monitor.as_str()) {
-            self.spawn_monitor_state_mut(target_monitor.as_str())
-                .spawn_patch = None;
+    let anchor = match placement {
+        InitialWindowSpawnPlacement::Default
+        | InitialWindowSpawnPlacement::Center
+        | InitialWindowSpawnPlacement::App => intent
+            .parent_node
+            .and_then(|id| spawn_anchor_for_node(st, id))
+            .or_else(|| {
+                fullscreen_anchor.and_then(|(id, pos)| {
+                    spawn_anchor_for_node(st, id).or_else(|| Some(spawn_anchor_at(pos)))
+                })
+            })
+            .unwrap_or_else(|| spawn_anchor_at(viewport_center)),
+        InitialWindowSpawnPlacement::ViewportCenter => spawn_anchor_at(viewport_center),
+        InitialWindowSpawnPlacement::Cursor => {
+            spawn_anchor_at(cursor_anchor.unwrap_or(viewport_center))
         }
-        let monitor_spawn = self.spawn_monitor_state(target_monitor.as_str());
-        debug!(
-            "spawn target resolved: target_monitor={} focused_monitor={} interaction_monitor={} anchor_mode={:?} focus_id={:?}",
-            target_monitor,
-            self.focused_monitor(),
-            self.interaction_monitor(),
-            monitor_spawn.spawn_anchor_mode,
-            focus_id.map(|id| id.as_u64())
-        );
-        if let Some(override_focus) = focus_override.filter(|override_focus| {
-            self.view_center_hits_spawn_snapshot(
-                target_monitor.as_str(),
+        InitialWindowSpawnPlacement::Adjacent => unreachable!("adjacent handled above"),
+    };
+
+    let candidate = try_spawn_star_with_policy(
+        st,
+        target_monitor.as_str(),
+        anchor.pos,
+        size,
+        overlap_policy,
+        intent.parent_node,
+    )
+    .map(|pos| SpawnCandidate {
+        pos,
+        dir: spawn_dir_from_delta(Vec2 {
+            x: pos.x - anchor.pos.x,
+            y: pos.y - anchor.pos.y,
+        }),
+    })
+    .unwrap_or(SpawnCandidate {
+        pos: anchor.pos,
+        dir: None,
+    });
+    commit_spawn_plan(
+        st,
+        target_monitor.as_str(),
+        anchor,
+        candidate,
+        overlap_policy,
+    );
+    (target_monitor, candidate.pos, false)
+}
+
+pub(crate) fn pick_spawn_position_impl(st: &mut Halley, size: Vec2) -> (String, Vec2, bool) {
+    let target_monitor = st
+        .model
+        .spawn_state
+        .pending_spawn_monitor
+        .take()
+        .filter(|monitor| st.model.monitor_state.monitors.contains_key(monitor))
+        .unwrap_or_else(|| read::spawn_read_context(st).resolve_spawn_target_monitor());
+    let focus_override = st
+        .spawn_monitor_state_mut(target_monitor.as_str())
+        .spawn_focus_override
+        .take();
+    st.spawn_monitor_state_mut(target_monitor.as_str())
+        .spawn_cursor += 1;
+    let viewport_center =
+        read::spawn_read_context(st).viewport_center_for_monitor(target_monitor.as_str());
+    let (focus_id, focus_pos) =
+        read::spawn_read_context(st).current_spawn_focus(target_monitor.as_str());
+    if !monitor_has_visible_spawn_surface(st, target_monitor.as_str()) {
+        st.spawn_monitor_state_mut(target_monitor.as_str())
+            .spawn_patch = None;
+    }
+    let monitor_spawn = st.spawn_monitor_state(target_monitor.as_str());
+    debug!(
+        "spawn target resolved: target_monitor={} focused_monitor={} interaction_monitor={} anchor_mode={:?} focus_id={:?}",
+        target_monitor,
+        st.focused_monitor(),
+        st.interaction_monitor(),
+        monitor_spawn.spawn_anchor_mode,
+        focus_id.map(|id| id.as_u64())
+    );
+    if let Some(override_focus) = focus_override.filter(|override_focus| {
+        view_center_hits_spawn_snapshot(
+            st,
+            target_monitor.as_str(),
+            override_focus.pos,
+            override_focus.size,
+        )
+    }) {
+        let gap = st.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
+        let frame_pad = active_window_frame_pad_px(&st.runtime.tuning) as f32;
+        let override_ext = spawn_safe_obstacle_extents(CollisionExtents {
+            left: override_focus.size.x * 0.5 + frame_pad,
+            right: override_focus.size.x * 0.5 + frame_pad,
+            top: override_focus.size.y * 0.5 + frame_pad,
+            bottom: override_focus.size.y * 0.5 + frame_pad,
+        });
+        for dir in spawn_cardinal_dirs() {
+            let pos = spawn_candidate_for_snapshot_dir(
                 override_focus.pos,
                 override_focus.size,
-            )
-        }) {
-            let gap = self.non_overlap_gap_world() + SPAWN_CONTACT_MARGIN;
-            let frame_pad = active_window_frame_pad_px(&self.runtime.tuning) as f32;
-            let override_ext = spawn_safe_obstacle_extents(CollisionExtents {
-                left: override_focus.size.x * 0.5 + frame_pad,
-                right: override_focus.size.x * 0.5 + frame_pad,
-                top: override_focus.size.y * 0.5 + frame_pad,
-                bottom: override_focus.size.y * 0.5 + frame_pad,
-            });
-            for dir in spawn_cardinal_dirs() {
-                let pos = spawn_candidate_for_snapshot_dir(
-                    override_focus.pos,
-                    override_focus.size,
-                    size,
-                    dir,
-                    gap,
-                    frame_pad,
-                );
-                let pos = self.adjust_vertical_candidate_to_row(
-                    target_monitor.as_str(),
-                    override_focus.pos,
-                    pos,
-                    size,
-                );
-                if self.spawn_candidate_fits(target_monitor.as_str(), pos, size, None) {
-                    self.set_pending_initial_spawn_placement(
-                        target_monitor.as_str(),
-                        override_focus.pos,
-                        Some(override_ext),
-                        pos,
-                        Some(dir),
-                        false,
-                        false,
-                        InitialWindowOverlapPolicy::None,
-                    );
-                    self.update_spawn_patch(
-                        target_monitor.as_str(),
-                        override_focus.pos,
-                        None,
-                        override_focus.pos,
-                        dir,
-                    );
-                    self.spawn_monitor_state_mut(target_monitor.as_str())
-                        .spawn_view_anchor = override_focus.pos;
-                    debug!(
-                        "spawn position picked from override: target_monitor={} anchor=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
-                        target_monitor,
-                        override_focus.pos.x,
-                        override_focus.pos.y,
-                        pos.x,
-                        pos.y,
-                        size.x,
-                        size.y
-                    );
-                    return (target_monitor, pos, false);
-                }
-            }
-            if let Some(pos) =
-                self.try_strict_spawn_star(target_monitor.as_str(), override_focus.pos, size)
-            {
-                self.set_pending_initial_spawn_placement(
+                size,
+                dir,
+                gap,
+                frame_pad,
+            );
+            let pos = adjust_vertical_candidate_to_row(
+                st,
+                target_monitor.as_str(),
+                override_focus.pos,
+                pos,
+                size,
+            );
+            if spawn_candidate_fits(st, target_monitor.as_str(), pos, size, None) {
+                set_pending_initial_spawn_placement(
+                    st,
                     target_monitor.as_str(),
                     override_focus.pos,
                     Some(override_ext),
                     pos,
-                    spawn_dir_from_delta(Vec2 {
-                        x: pos.x - override_focus.pos.x,
-                        y: pos.y - override_focus.pos.y,
-                    }),
-                    true,
+                    Some(dir),
+                    false,
                     false,
                     InitialWindowOverlapPolicy::None,
                 );
-                let growth_dir =
-                    self.pick_cluster_growth_dir(target_monitor.as_str(), override_focus.pos);
-                self.update_spawn_patch(
+                update_spawn_patch(
+                    st,
                     target_monitor.as_str(),
                     override_focus.pos,
                     None,
                     override_focus.pos,
-                    growth_dir,
+                    dir,
                 );
-                self.spawn_monitor_state_mut(target_monitor.as_str())
+                st.spawn_monitor_state_mut(target_monitor.as_str())
                     .spawn_view_anchor = override_focus.pos;
                 debug!(
-                    "spawn position picked from override fallback: target_monitor={} anchor=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
+                    "spawn position picked from override: target_monitor={} anchor=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
                     target_monitor,
                     override_focus.pos.x,
                     override_focus.pos.y,
@@ -1386,95 +1349,129 @@ impl<T: DerefMut<Target = Halley>> SpawnRevealController<T> {
                 return (target_monitor, pos, false);
             }
         }
-
-        let patch = monitor_spawn.spawn_patch.as_ref();
-        let patch_anchor_active = patch.is_some_and(|patch| {
-            patch
-                .focus_node
-                .is_some_and(|id| self.view_center_hits_spawn_node(target_monitor.as_str(), id))
-                || (patch.focus_node.is_none()
-                    && self.point_is_spawn_view_center(target_monitor.as_str(), patch.anchor))
-        });
-        let focus_anchor_id = focus_id.filter(|id| {
-            let focus_continues_active_patch = patch.is_some_and(|patch| {
-                patch_anchor_active && patch.focus_node.is_some() && patch.focus_node != Some(*id)
-            });
-            self.view_center_hits_spawn_node(target_monitor.as_str(), *id)
-                || focus_continues_active_patch
-        });
-        let focus_moved_from_patch = patch.is_some_and(|patch| {
-            focus_anchor_id.is_some()
-                && ((focus_pos.x - patch.anchor.x).abs() > 0.5
-                    || (focus_pos.y - patch.anchor.y).abs() > 0.5)
-        });
-        let use_patch_anchor = patch.is_some()
-            && self.monitor_has_visible_spawn_surface(target_monitor.as_str())
-            && patch_anchor_active
-            && !focus_moved_from_patch;
-        let anchor = if use_patch_anchor {
-            patch.map(|patch| patch.anchor).unwrap_or(viewport_center)
-        } else if focus_anchor_id.is_some() {
-            focus_pos
-        } else if focus_id.is_some() {
-            viewport_center
-        } else {
-            focus_pos
-        };
-        let reset_to_view_center =
-            !use_patch_anchor && focus_id.is_some() && focus_anchor_id.is_none();
-        let anchor_node = if use_patch_anchor {
-            patch.and_then(|patch| patch.focus_node).or(focus_anchor_id)
-        } else {
-            focus_anchor_id
-        };
-        let view_center_reset = reset_to_view_center || anchor_node.is_none();
-        let anchor_ext = anchor_node.and_then(|id| {
-            self.model.field.node(id).and_then(|node| {
-                ((node.pos.x - anchor.x).abs() <= 0.5 && (node.pos.y - anchor.y).abs() <= 0.5)
-                    .then(|| self.spawn_safe_obstacle_extents_for_node(node))
-            })
-        });
-        let pos = if reset_to_view_center {
-            self.try_view_center_spawn_star(target_monitor.as_str(), anchor, size, None)
-        } else {
-            self.try_strict_spawn_star(target_monitor.as_str(), anchor, size)
+        if let Some(pos) =
+            try_strict_spawn_star(st, target_monitor.as_str(), override_focus.pos, size)
+        {
+            set_pending_initial_spawn_placement(
+                st,
+                target_monitor.as_str(),
+                override_focus.pos,
+                Some(override_ext),
+                pos,
+                spawn_dir_from_delta(Vec2 {
+                    x: pos.x - override_focus.pos.x,
+                    y: pos.y - override_focus.pos.y,
+                }),
+                true,
+                false,
+                InitialWindowOverlapPolicy::None,
+            );
+            let growth_dir =
+                pick_cluster_growth_dir(st, target_monitor.as_str(), override_focus.pos);
+            update_spawn_patch(
+                st,
+                target_monitor.as_str(),
+                override_focus.pos,
+                None,
+                override_focus.pos,
+                growth_dir,
+            );
+            st.spawn_monitor_state_mut(target_monitor.as_str())
+                .spawn_view_anchor = override_focus.pos;
+            debug!(
+                "spawn position picked from override fallback: target_monitor={} anchor=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
+                target_monitor,
+                override_focus.pos.x,
+                override_focus.pos.y,
+                pos.x,
+                pos.y,
+                size.x,
+                size.y
+            );
+            return (target_monitor, pos, false);
         }
-        .unwrap_or(anchor);
-        self.set_pending_initial_spawn_placement(
-            target_monitor.as_str(),
-            anchor,
-            anchor_ext,
-            pos,
-            spawn_dir_from_delta(Vec2 {
-                x: pos.x - anchor.x,
-                y: pos.y - anchor.y,
-            }),
-            true,
-            view_center_reset,
-            InitialWindowOverlapPolicy::None,
-        );
-        let growth_dir = self.pick_cluster_growth_dir(target_monitor.as_str(), anchor);
-        self.update_spawn_patch(
-            target_monitor.as_str(),
-            anchor,
-            anchor_node,
-            anchor,
-            growth_dir,
-        );
-        self.spawn_monitor_state_mut(target_monitor.as_str())
-            .spawn_view_anchor = anchor;
-        debug!(
-            "spawn position picked: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
-            target_monitor,
-            anchor.x,
-            anchor.y,
-            focus_pos.x,
-            focus_pos.y,
-            pos.x,
-            pos.y,
-            size.x,
-            size.y
-        );
-        (target_monitor, pos, false)
     }
+
+    let patch = monitor_spawn.spawn_patch.as_ref();
+    let patch_anchor_active = patch.is_some_and(|patch| {
+        patch
+            .focus_node
+            .is_some_and(|id| view_center_hits_spawn_node(st, target_monitor.as_str(), id))
+            || (patch.focus_node.is_none()
+                && point_is_spawn_view_center(st, target_monitor.as_str(), patch.anchor))
+    });
+    let focus_anchor_id = focus_id.filter(|id| {
+        let focus_continues_active_patch = patch.is_some_and(|patch| {
+            patch_anchor_active && patch.focus_node.is_some() && patch.focus_node != Some(*id)
+        });
+        view_center_hits_spawn_node(st, target_monitor.as_str(), *id)
+            || focus_continues_active_patch
+    });
+    let focus_moved_from_patch = patch.is_some_and(|patch| {
+        focus_anchor_id.is_some()
+            && ((focus_pos.x - patch.anchor.x).abs() > 0.5
+                || (focus_pos.y - patch.anchor.y).abs() > 0.5)
+    });
+    let use_patch_anchor = patch.is_some()
+        && monitor_has_visible_spawn_surface(st, target_monitor.as_str())
+        && patch_anchor_active
+        && !focus_moved_from_patch;
+    let anchor = if use_patch_anchor {
+        patch.map(|patch| patch.anchor).unwrap_or(viewport_center)
+    } else if focus_anchor_id.is_some() {
+        focus_pos
+    } else if focus_id.is_some() {
+        viewport_center
+    } else {
+        focus_pos
+    };
+    let reset_to_view_center = !use_patch_anchor && focus_id.is_some() && focus_anchor_id.is_none();
+    let anchor_node = if use_patch_anchor {
+        patch.and_then(|patch| patch.focus_node).or(focus_anchor_id)
+    } else {
+        focus_anchor_id
+    };
+    let view_center_reset = reset_to_view_center || anchor_node.is_none();
+    let anchor_ext = anchor_node.and_then(|id| {
+        st.model.field.node(id).and_then(|node| {
+            ((node.pos.x - anchor.x).abs() <= 0.5 && (node.pos.y - anchor.y).abs() <= 0.5)
+                .then(|| spawn_safe_obstacle_extents_for_node(st, node))
+        })
+    });
+    let pos = if reset_to_view_center {
+        try_view_center_spawn_star(st, target_monitor.as_str(), anchor, size, None)
+    } else {
+        try_strict_spawn_star(st, target_monitor.as_str(), anchor, size)
+    }
+    .unwrap_or(anchor);
+    set_pending_initial_spawn_placement(
+        st,
+        target_monitor.as_str(),
+        anchor,
+        anchor_ext,
+        pos,
+        spawn_dir_from_delta(Vec2 {
+            x: pos.x - anchor.x,
+            y: pos.y - anchor.y,
+        }),
+        true,
+        view_center_reset,
+        InitialWindowOverlapPolicy::None,
+    );
+    let growth_dir = pick_cluster_growth_dir(st, target_monitor.as_str(), anchor);
+    update_spawn_patch(
+        st,
+        target_monitor.as_str(),
+        anchor,
+        anchor_node,
+        anchor,
+        growth_dir,
+    );
+    st.spawn_monitor_state_mut(target_monitor.as_str())
+        .spawn_view_anchor = anchor;
+    debug!(
+        "spawn position picked: target_monitor={} anchor=({:.1},{:.1}) focus_pos=({:.1},{:.1}) chosen=({:.1},{:.1}) size=({:.1},{:.1})",
+        target_monitor, anchor.x, anchor.y, focus_pos.x, focus_pos.y, pos.x, pos.y, size.x, size.y
+    );
+    (target_monitor, pos, false)
 }

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/cleanup.rs
@@ -372,7 +372,7 @@ pub(super) fn drop_surface_impl(st: &mut Halley, surface: &WlSurface) {
                         == st.model.field.cluster_id_for_member_public(id))
                 .then_some((monitor, preferred_index))
             });
-        st.drop_fullscreen_surface(id, Instant::now());
+        crate::compositor::fullscreen::system::drop_fullscreen_surface(st, id, Instant::now());
         if st.model.focus_state.pan_restore_active_focus == Some(id) {
             st.model.focus_state.pan_restore_active_focus = None;
         }

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/mod.rs
@@ -179,7 +179,8 @@ fn plan_toplevel_destroy_close_restore(
     };
     let now = Instant::now();
     let suppress_restore_pan =
-        st.node_has_overlap_policy(closing_id) || st.is_fullscreen_active(closing_id);
+        crate::compositor::spawn::state::node_has_overlap_policy(st, closing_id)
+            || st.is_fullscreen_active(closing_id);
 
     if facts.closing_fullscreen {
         return non_cluster_close_restore_target(st, focused_monitor, closing_id).map(|target| {

--- a/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
+++ b/crates/halley-wl/src/compositor/workspace/lifecycle/surface.rs
@@ -126,8 +126,7 @@ pub(super) fn refresh_node_identity_for_surface(
         Some(app_id) => {
             st.model.node_app_ids.insert(node_id, app_id.clone());
             if let Some(monitor) = st.model.monitor_state.node_monitor.get(&node_id).cloned() {
-                let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .maybe_add_node_to_lift_cluster_finalize_draft(
+                let _ = crate::compositor::clusters::system::maybe_add_node_to_lift_cluster_finalize_draft(&mut *st,
                         monitor.as_str(),
                         node_id,
                         app_id.as_str(),
@@ -410,8 +409,11 @@ fn pending_lift_cluster_build_should_hold_unidentified_node(st: &Halley, node_id
     let Some(monitor) = st.model.monitor_state.node_monitor.get(&node_id) else {
         return false;
     };
-    crate::compositor::clusters::system::cluster_system_controller(st)
-        .pending_lift_cluster_build_waits_for_candidate_identity(monitor.as_str(), node_id)
+    crate::compositor::clusters::system::pending_lift_cluster_build_waits_for_candidate_identity(
+        st,
+        monitor.as_str(),
+        node_id,
+    )
 }
 
 pub(super) fn note_commit(st: &mut Halley, surface: &WlSurface, now: Instant) {
@@ -735,8 +737,11 @@ pub(super) fn ensure_node_for_surface_impl(
     st.model.surface_to_node.insert(key, id);
     st.assign_node_to_monitor(id, monitor.as_str());
     let lift_cluster_candidate = !spawned_in_active_cluster
-        && crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-            .note_pending_lift_cluster_candidate_node(monitor.as_str(), id);
+        && crate::compositor::clusters::system::note_pending_lift_cluster_candidate_node(
+            &mut *st,
+            monitor.as_str(),
+            id,
+        );
     if lift_cluster_candidate {
         st.model.spawn_state.pending_initial_reveal.insert(id);
         let _ = st.model.field.set_detached(id, true);

--- a/crates/halley-wl/src/frame_loop/activity.rs
+++ b/crates/halley-wl/src/frame_loop/activity.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::compositor::root::Halley;
-use crate::compositor::screenshot::screenshot_controller;
+use crate::compositor::screenshot;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct TtyOutputAnimationRedrawState {
@@ -63,7 +63,7 @@ fn monitor_overlay_requires_full_repaint_at(st: &Halley, monitor: &str, now_ms: 
             .cluster_state
             .cluster_name_prompt
             .contains_key(monitor)
-        || screenshot_controller(st).screenshot_session_active()
+        || screenshot::screenshot_session_active(st)
         || crate::compositor::portal_chooser::portal_chooser_active(st)
         || st
             .ui
@@ -116,7 +116,7 @@ fn monitor_overlay_animation_active_at(st: &Halley, monitor: &str, now_ms: u64) 
         || st.input.interaction_state.focus_cycle_session.is_some()
         || crate::compositor::overview::apogee_render_pending(st)
         || cluster_name_prompt_hover_animating(st, monitor)
-        || screenshot_controller(st).screenshot_session_active()
+        || screenshot::screenshot_session_active(st)
         || st
             .ui
             .render_state

--- a/crates/halley-wl/src/frame_loop/mod.rs
+++ b/crates/halley-wl/src/frame_loop/mod.rs
@@ -20,7 +20,6 @@ use smithay::wayland::compositor::{
 use smithay::wayland::presentation::Refresh;
 
 use crate::animation::AnimStyle;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 
 mod activity;
@@ -153,7 +152,7 @@ pub(crate) fn tick_frame_effects(st: &mut Halley, now: Instant) {
     crate::compositor::interaction::state::tick_bloom_pull_preview(st, now_ms);
     tick_pending_core_hover_bloom(st, now_ms);
     st.tick_apogee(now);
-    camera_controller(&mut *st).tick_smoothing(now);
+    crate::compositor::monitor::camera::tick_camera_smoothing(&mut *st, now);
 
     // Also ease the cameras of the other (non-active) monitors so a monitor that
     // is mid-zoom keeps settling into place instead of freezing the moment the
@@ -172,7 +171,8 @@ pub(crate) fn tick_frame_effects(st: &mut Halley, now: Instant) {
     for name in others {
         let previous = st.begin_temporary_render_monitor(&name);
         if previous.is_some() {
-            let moved = camera_controller(&mut *st).tick_smoothing_passive(now);
+            let moved =
+                crate::compositor::monitor::camera::tick_camera_smoothing_passive(&mut *st, now);
             if moved {
                 st.request_tty_redraw_for_monitor(&name);
             }
@@ -370,7 +370,7 @@ fn tick_active_drag(st: &mut Halley, now: Instant) {
                     * dt,
             };
             st.note_pan_activity(now);
-            camera_controller(&mut *st).pan_target(pan_delta);
+            crate::compositor::monitor::camera::pan_camera_target(&mut *st, pan_delta);
             st.note_pan_viewport_change(now);
         }
         active_drag.last_edge_pan_at = now;

--- a/crates/halley-wl/src/frame_loop/mod.rs
+++ b/crates/halley-wl/src/frame_loop/mod.rs
@@ -144,7 +144,7 @@ pub(crate) fn tick_frame_effects(st: &mut Halley, now: Instant) {
     st.tick_viewport_pan_animation(now_ms);
     crate::compositor::actions::window::tick_pending_maximize(st, now);
     let _ = st.process_pending_cluster_slot_transition_for_current_monitor(now);
-    st.tick_pending_spawn_pan(now, now_ms);
+    crate::compositor::spawn::reveal::tick_pending_spawn_pan(st, now, now_ms);
     crate::compositor::workspace::state::tick_maximize_animation(st, now);
     tick_active_drag(st, now);
     crate::compositor::focus::cycle::tick_focus_cycle_session(st, now);
@@ -223,7 +223,11 @@ fn tick_pending_core_hover_bloom(st: &mut Halley, now_ms: u64) {
         && st.cluster_bloom_for_monitor(pending_hover.monitor.as_str()) != Some(cid)
     {
         st.input.interaction_state.overlay_hover_target = None;
-        let _ = st.open_cluster_bloom_for_monitor(pending_hover.monitor.as_str(), cid);
+        let _ = crate::compositor::clusters::system::open_cluster_bloom_for_monitor(
+            st,
+            pending_hover.monitor.as_str(),
+            cid,
+        );
     }
 }
 

--- a/crates/halley-wl/src/input/events.rs
+++ b/crates/halley-wl/src/input/events.rs
@@ -100,7 +100,7 @@ pub(crate) fn handle_backend_input_event<B: BackendView>(
     ctx: &InputCtx<'_, B>,
     event: BackendInputEventData,
 ) {
-    st.note_input_activity();
+    crate::compositor::platform::note_input_activity(st);
 
     match event {
         BackendInputEventData::Keyboard { code, pressed } => {

--- a/crates/halley-wl/src/input/keyboard/bindings.rs
+++ b/crates/halley-wl/src/input/keyboard/bindings.rs
@@ -6,7 +6,7 @@ use crate::compositor::actions::window::{
     toggle_focused_fullscreen_node_state, toggle_focused_maximize_node_state,
     toggle_focused_pin_state,
 };
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::interaction::ModState;
 use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
@@ -175,7 +175,7 @@ pub(crate) fn apply_compositor_action_press(
 
     match action {
         CompositorBindingAction::Quit { .. } => {
-            exit_confirm_controller(st).show();
+            exit_confirm::show(st);
             info!("quit requested via keybind");
             true
         }

--- a/crates/halley-wl/src/input/keyboard/bindings.rs
+++ b/crates/halley-wl/src/input/keyboard/bindings.rs
@@ -8,7 +8,6 @@ use crate::compositor::actions::window::{
 };
 use crate::compositor::exit_confirm;
 use crate::compositor::interaction::ModState;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::compositor::surface::request_close_focused_toplevel;
 use halley_api::{
@@ -301,24 +300,24 @@ pub(crate) fn apply_compositor_action_press(
             true
         }
         CompositorBindingAction::ZoomIn => {
-            if camera_controller(&*st).zoom_blocked_by_interaction() {
+            if crate::compositor::monitor::camera::zoom_blocked_by_interaction(&*st) {
                 return false;
             }
-            camera_controller(st).zoom_by_steps(1.0);
+            crate::compositor::monitor::camera::zoom_by_steps(st, 1.0);
             true
         }
         CompositorBindingAction::ZoomOut => {
-            if camera_controller(&*st).zoom_blocked_by_interaction() {
+            if crate::compositor::monitor::camera::zoom_blocked_by_interaction(&*st) {
                 return false;
             }
-            camera_controller(st).zoom_by_steps(-1.0);
+            crate::compositor::monitor::camera::zoom_by_steps(st, -1.0);
             true
         }
         CompositorBindingAction::ZoomReset => {
-            if camera_controller(&*st).zoom_blocked_by_interaction() {
+            if crate::compositor::monitor::camera::zoom_blocked_by_interaction(&*st) {
                 return false;
             }
-            camera_controller(st).reset_zoom();
+            crate::compositor::monitor::camera::reset_zoom(st);
             true
         }
     }

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod bindings;
 pub(crate) mod modkeys;
 pub(crate) mod spawn;
 
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::root::Halley;
 use crate::compositor::screenshot::screenshot_controller;
 use crate::input::ctx::InputCtx;
@@ -236,7 +236,7 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
     code: u32,
     pressed: bool,
 ) {
-    let exit_confirm_active = exit_confirm_controller(&*st).active();
+    let exit_confirm_active = exit_confirm::active(&*st);
     update_mod_state(&mut ctx.mod_state.borrow_mut(), code, pressed);
     if !pressed
         && st
@@ -269,11 +269,11 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
         if pressed {
             if Some(code) == exit_escape {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                exit_confirm_controller(&mut *st).clear();
+                exit_confirm::clear(&mut *st);
                 ctx.backend.request_redraw();
             } else if Some(code) == exit_return {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                exit_confirm_controller(&mut *st).clear();
+                exit_confirm::clear(&mut *st);
                 st.request_exit();
                 ctx.backend.request_redraw();
             }

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -402,8 +402,10 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
         return;
     }
 
-    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
+    let prompt_monitor = crate::compositor::clusters::system::active_cluster_name_prompt_monitor(
+        &*st,
+        st.model.monitor_state.current_monitor.as_str(),
+    );
     if let Some(prompt_monitor) = prompt_monitor {
         let mut repeated_char = None;
         if let Some(keyboard) = st.platform.seat.get_keyboard() {
@@ -446,52 +448,66 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
             };
             let handled = if Some(code) == escape {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .cancel_cluster_name_prompt_for_monitor(prompt_monitor.as_str())
+                crate::compositor::clusters::system::cancel_cluster_name_prompt_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                )
             } else if Some(code) == enter {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .confirm_cluster_name_prompt_for_monitor(
-                        prompt_monitor.as_str(),
-                        Instant::now(),
-                    )
+                crate::compositor::clusters::system::confirm_cluster_name_prompt_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                    Instant::now(),
+                )
             } else if !first_press && repeat_action.is_none() {
                 false
             } else if Some(code) == left {
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .cluster_name_prompt_move_left_for_monitor(prompt_monitor.as_str())
+                crate::compositor::clusters::system::cluster_name_prompt_move_left_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                )
             } else if Some(code) == right {
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .cluster_name_prompt_move_right_for_monitor(prompt_monitor.as_str())
+                crate::compositor::clusters::system::cluster_name_prompt_move_right_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                )
             } else if Some(code) == backspace {
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .cluster_name_prompt_backspace_for_monitor(prompt_monitor.as_str())
+                crate::compositor::clusters::system::cluster_name_prompt_backspace_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                )
             } else if Some(code) == delete {
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .cluster_name_prompt_delete_for_monitor(prompt_monitor.as_str())
+                crate::compositor::clusters::system::cluster_name_prompt_delete_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                )
             } else if let Some(ch) = repeated_char {
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .insert_cluster_name_prompt_char_for_monitor(prompt_monitor.as_str(), ch)
+                crate::compositor::clusters::system::insert_cluster_name_prompt_char_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                    ch,
+                )
             } else {
                 false
             };
             if handled && let Some(action) = repeat_action {
                 let now_ms = st.now_ms(Instant::now());
-                crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .start_cluster_name_prompt_repeat_for_monitor(
-                        prompt_monitor.as_str(),
-                        code,
-                        action,
-                        now_ms,
-                    );
+                crate::compositor::clusters::system::start_cluster_name_prompt_repeat_for_monitor(
+                    &mut *st,
+                    prompt_monitor.as_str(),
+                    code,
+                    action,
+                    now_ms,
+                );
             }
             if handled {
                 ctx.backend.request_redraw();
             }
         } else {
             ctx.mod_state.borrow_mut().intercepted_keys.remove(&code);
-            crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                .stop_cluster_name_prompt_repeat_for_code(code);
+            crate::compositor::clusters::system::stop_cluster_name_prompt_repeat_for_code(
+                &mut *st, code,
+            );
         }
         return;
     }

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod spawn;
 
 use crate::compositor::exit_confirm;
 use crate::compositor::root::Halley;
-use crate::compositor::screenshot::screenshot_controller;
+use crate::compositor::screenshot;
 use crate::input::ctx::InputCtx;
 
 use std::time::Instant;
@@ -288,7 +288,7 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
         }
     }
 
-    if screenshot_controller(&mut *st).screenshot_session_active() {
+    if screenshot::screenshot_session_active(&mut *st) {
         if let Some(keyboard) = st.platform.seat.get_keyboard() {
             let serial = SERIAL_COUNTER.next_serial();
             keyboard.input::<(), _>(
@@ -318,26 +318,26 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
             if Some(code) == escape {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
                 if menu_mode {
-                    let _ = screenshot_controller(&mut *st).cancel_screenshot_session();
+                    let _ = screenshot::cancel_screenshot_session(&mut *st);
                 } else {
-                    let _ = screenshot_controller(&mut *st).return_screenshot_session_to_menu();
+                    let _ = screenshot::return_screenshot_session_to_menu(&mut *st);
                 }
                 ctx.backend.request_redraw();
             } else if Some(code) == enter {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                let _ = screenshot_controller(&mut *st).confirm_screenshot_session(Instant::now());
+                let _ = screenshot::confirm_screenshot_session(&mut *st, Instant::now());
                 ctx.backend.request_redraw();
             } else if Some(code) == left {
                 if menu_mode {
                     crate::compositor::interaction::state::trap_modal_key_release(st, code);
                 }
-                let _ = screenshot_controller(&mut *st).move_screenshot_menu_selection(-1);
+                let _ = screenshot::move_screenshot_menu_selection(&mut *st, -1);
                 ctx.backend.request_redraw();
             } else if Some(code) == right {
                 if menu_mode {
                     crate::compositor::interaction::state::trap_modal_key_release(st, code);
                 }
-                let _ = screenshot_controller(&mut *st).move_screenshot_menu_selection(1);
+                let _ = screenshot::move_screenshot_menu_selection(&mut *st, 1);
                 ctx.backend.request_redraw();
             }
         }

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -274,7 +274,7 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
             } else if Some(code) == exit_return {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
                 exit_confirm::clear(&mut *st);
-                st.request_exit();
+                crate::compositor::runtime::request_exit(st);
                 ctx.backend.request_redraw();
             }
         }
@@ -541,7 +541,7 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
                 st.exit_cluster_mode()
             } else {
                 crate::compositor::interaction::state::trap_modal_key_release(st, code);
-                st.confirm_cluster_mode(Instant::now())
+                crate::compositor::clusters::system::confirm_cluster_mode(st, Instant::now())
             };
             if handled || Some(code) == cluster_return || Some(code) == cluster_escape {
                 ctx.backend.request_redraw();

--- a/crates/halley-wl/src/input/pointer/axis.rs
+++ b/crates/halley-wl/src/input/pointer/axis.rs
@@ -7,7 +7,7 @@ use crate::backend::interface::BackendView;
 use crate::compositor::exit_confirm;
 use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
-use crate::compositor::screenshot::screenshot_controller;
+use crate::compositor::screenshot;
 use crate::input::ctx::InputCtx;
 
 use super::context::pointer_screen_context_for_monitor;
@@ -164,7 +164,7 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
     if exit_confirm::active(&*st) {
         return;
     }
-    if screenshot_controller(&mut *st).screenshot_session_active() {
+    if screenshot::screenshot_session_active(&mut *st) {
         return;
     }
     if crate::compositor::portal_chooser::portal_chooser_active(&*st) {

--- a/crates/halley-wl/src/input/pointer/axis.rs
+++ b/crates/halley-wl/src/input/pointer/axis.rs
@@ -5,7 +5,6 @@ use smithay::utils::SERIAL_COUNTER;
 
 use crate::backend::interface::BackendView;
 use crate::compositor::exit_confirm;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::compositor::screenshot;
 use crate::input::ctx::InputCtx;
@@ -124,7 +123,7 @@ fn handle_touchpad_scroll_pan<B: BackendView>(
     amount_horizontal: Option<f64>,
     amount_vertical: Option<f64>,
 ) -> bool {
-    let camera = camera_controller(&*st).view_size();
+    let camera = crate::compositor::monitor::camera::camera_view_size(&*st);
     let pan = touchpad_pan_delta(
         amount_v120_horizontal,
         amount_v120_vertical,
@@ -137,13 +136,13 @@ fn handle_touchpad_scroll_pan<B: BackendView>(
     if pan.x.abs() < f32::EPSILON && pan.y.abs() < f32::EPSILON {
         return true;
     }
-    if camera_controller(&*st).pan_blocked_on_monitor(context.monitor.as_str()) {
+    if crate::compositor::monitor::camera::pan_blocked_on_monitor(&*st, context.monitor.as_str()) {
         return true;
     }
 
     ctx.pointer_state.borrow_mut().panning = false;
     st.note_pan_activity(now);
-    camera_controller(&mut *st).pan_target(pan);
+    crate::compositor::monitor::camera::pan_camera_target(&mut *st, pan);
     st.note_pan_viewport_change(now);
     ctx.backend.request_output_redraw(context.monitor.as_str());
     true
@@ -535,7 +534,7 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
     }
 
     if touchpad_scroll {
-        let camera = camera_controller(&*st).view_size();
+        let camera = crate::compositor::monitor::camera::camera_view_size(&*st);
         let pan = touchpad_pan_delta(
             amount_v120_horizontal,
             amount_v120_vertical,
@@ -548,7 +547,10 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
         if pan.x.abs() < f32::EPSILON && pan.y.abs() < f32::EPSILON {
             return;
         }
-        if camera_controller(&*st).pan_blocked_on_monitor(context.monitor.as_str()) {
+        if crate::compositor::monitor::camera::pan_blocked_on_monitor(
+            &*st,
+            context.monitor.as_str(),
+        ) {
             return;
         }
         {
@@ -556,7 +558,7 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
             ps.panning = false;
         }
         st.note_pan_activity(now);
-        camera_controller(&mut *st).pan_target(pan);
+        crate::compositor::monitor::camera::pan_camera_target(&mut *st, pan);
         st.note_pan_viewport_change(now);
         ctx.backend.request_output_redraw(context.monitor.as_str());
         return;
@@ -566,21 +568,25 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
         return;
     }
 
-    if camera_controller(&*st)
-        .pan_blocked_on_monitor(st.model.monitor_state.current_monitor.as_str())
-    {
+    if crate::compositor::monitor::camera::pan_blocked_on_monitor(
+        &*st,
+        st.model.monitor_state.current_monitor.as_str(),
+    ) {
         return;
     }
 
     let steps = steps.clamp(-4.0, 4.0);
-    let camera = camera_controller(&*st).view_size();
+    let camera = crate::compositor::monitor::camera::camera_view_size(&*st);
     let pan_y = -camera.y * (steps / 18.0);
     {
         let mut ps = ctx.pointer_state.borrow_mut();
         ps.panning = false;
     }
     st.note_pan_activity(now);
-    camera_controller(&mut *st).pan_target(halley_core::field::Vec2 { x: 0.0, y: pan_y });
+    crate::compositor::monitor::camera::pan_camera_target(
+        &mut *st,
+        halley_core::field::Vec2 { x: 0.0, y: pan_y },
+    );
     st.note_pan_viewport_change(now);
     ctx.backend.request_redraw();
 }

--- a/crates/halley-wl/src/input/pointer/axis.rs
+++ b/crates/halley-wl/src/input/pointer/axis.rs
@@ -4,7 +4,7 @@ use smithay::input::pointer::{AxisFrame, MotionEvent};
 use smithay::utils::SERIAL_COUNTER;
 
 use crate::backend::interface::BackendView;
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::compositor::screenshot::screenshot_controller;
@@ -161,7 +161,7 @@ pub(crate) fn handle_pointer_axis_input<B: BackendView>(
     relative_direction_horizontal: AxisRelativeDirection,
     relative_direction_vertical: AxisRelativeDirection,
 ) {
-    if exit_confirm_controller(&*st).active() {
+    if exit_confirm::active(&*st) {
         return;
     }
     if screenshot_controller(&mut *st).screenshot_session_active() {

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
     button_code: u32,
     button_state: ButtonState,
 ) {
-    if exit_confirm_controller(&*st).active() {
+    if exit_confirm::active(&*st) {
         return;
     }
     if crate::compositor::interaction::state::note_cursor_activity(st, st.now_ms(Instant::now())) {
@@ -816,4 +816,4 @@ pub(super) fn dispatch_pointer_button(
     pointer.frame(st);
 }
 
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use frame::{
 };
 #[cfg(test)]
 pub(crate) use press::{handle_core_left_press, handle_workspace_left_press};
-pub(crate) use release::handle_button_release;
+pub(crate) use release::{collapse_bloom_for_core_if_open, handle_button_release};
 
 use press::{
     begin_bloom_pull_preview, handle_left_press, handle_move_binding_press,

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -289,9 +289,10 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
                 let now = Instant::now();
                 let monitor = st.monitor_for_screen_or_current(frame.global_sx, frame.global_sy);
                 st.focus_monitor_view(monitor.as_str(), now);
-                if !crate::compositor::monitor::camera::camera_controller(&*st)
-                    .pan_blocked_on_monitor(monitor.as_str())
-                {
+                if !crate::compositor::monitor::camera::pan_blocked_on_monitor(
+                    &*st,
+                    monitor.as_str(),
+                ) {
                     ps.panning = true;
                     ps.pan_monitor = Some(monitor);
                     ps.pan_last_screen = (frame.global_sx, frame.global_sy);

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -179,8 +179,10 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
         )
     ) || ps.drag.is_some()
         || ps.resize.is_some();
-    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
+    let prompt_monitor = crate::compositor::clusters::system::active_cluster_name_prompt_monitor(
+        &*st,
+        st.model.monitor_state.current_monitor.as_str(),
+    );
     if handle_screenshot_pointer_button(
         st,
         ctx,
@@ -229,16 +231,14 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
                     match hit {
                         crate::overlay::ClusterNamingDialogHit::ConfirmButton => {
                             let _ =
-                                crate::compositor::clusters::system::cluster_system_controller(st)
-                                    .confirm_cluster_name_prompt_for_monitor(
+                                crate::compositor::clusters::system::confirm_cluster_name_prompt_for_monitor(st,
                                         prompt_monitor.as_str(),
                                         Instant::now(),
                                     );
                         }
                         crate::overlay::ClusterNamingDialogHit::InputCaret(caret_char) => {
                             let _ =
-                                crate::compositor::clusters::system::cluster_system_controller(st)
-                                    .begin_cluster_name_prompt_drag_for_monitor(
+                                crate::compositor::clusters::system::begin_cluster_name_prompt_drag_for_monitor(st,
                                         prompt_monitor.as_str(),
                                         caret_char,
                                     );
@@ -249,8 +249,11 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
                 return;
             }
             ButtonState::Released if left || right => {
-                let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                    .end_cluster_name_prompt_drag_for_monitor(prompt_monitor.as_str());
+                let _ =
+                    crate::compositor::clusters::system::end_cluster_name_prompt_drag_for_monitor(
+                        &mut *st,
+                        prompt_monitor.as_str(),
+                    );
                 handle_button_release(st, &mut ps, ctx.backend, button_code, None, world_now);
                 return;
             }

--- a/crates/halley-wl/src/input/pointer/button/press.rs
+++ b/crates/halley-wl/src/input/pointer/button/press.rs
@@ -24,9 +24,7 @@ fn begin_pan_if_allowed(
     global_sx: f32,
     global_sy: f32,
 ) {
-    if crate::compositor::monitor::camera::camera_controller(&*st)
-        .pan_blocked_on_monitor(monitor.as_str())
-    {
+    if crate::compositor::monitor::camera::pan_blocked_on_monitor(&*st, monitor.as_str()) {
         backend.request_redraw();
         return;
     }

--- a/crates/halley-wl/src/input/pointer/button/press.rs
+++ b/crates/halley-wl/src/input/pointer/button/press.rs
@@ -392,7 +392,10 @@ pub(crate) fn handle_workspace_left_press(
         if inside {
             st.reveal_cluster_overflow_for_monitor(monitor.as_str(), st.now_ms(now));
         } else {
-            st.hide_cluster_overflow_for_monitor(monitor.as_str());
+            crate::compositor::clusters::system::hide_cluster_overflow_for_monitor(
+                st,
+                monitor.as_str(),
+            );
         }
     }
     if hit.move_surface && !hit.is_core {

--- a/crates/halley-wl/src/input/pointer/button/tests.rs
+++ b/crates/halley-wl/src/input/pointer/button/tests.rs
@@ -256,7 +256,7 @@ fn core_single_click_only_focuses_without_opening_bloom() {
         deadline_ms: st.now_ms(Instant::now()),
     });
 
-    st.run_maintenance(Instant::now());
+    crate::compositor::runtime::run_maintenance(&mut st, Instant::now());
 
     assert_eq!(st.cluster_bloom_for_monitor("monitor_a"), None);
     assert_eq!(st.active_cluster_workspace_for_monitor("monitor_a"), None);

--- a/crates/halley-wl/src/input/pointer/gesture.rs
+++ b/crates/halley-wl/src/input/pointer/gesture.rs
@@ -15,7 +15,6 @@ use crate::compositor::interaction::state::{
     ActiveCompositorHold, ActiveCompositorPinch, ActiveCompositorPinchMode, ActiveCompositorSwipe,
     ActiveGestureRoute, SwipeMode,
 };
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::input::ctx::InputCtx;
 use crate::input::keyboard::bindings::apply_compositor_action_press;
@@ -211,7 +210,7 @@ fn begin_pinch_route<B: BackendView>(st: &mut Halley, ctx: &InputCtx<'_, B>) -> 
     }
     if !gestures.pinch_to_zoom
         || !st.runtime.tuning.zoom_enabled
-        || camera_controller(&*st).zoom_blocked_by_interaction()
+        || crate::compositor::monitor::camera::zoom_blocked_by_interaction(&*st)
     {
         if target.focus.is_some() {
             return if begin_client_route(st, &target) {
@@ -272,7 +271,7 @@ fn begin_swipe_route<B: BackendView>(
     // client should own the gesture.
     let want_pan = !apogee_context && pan_fingers > 0 && fingers == pan_fingers;
     if want_pan {
-        if camera_controller(&*st).pan_blocked_on_monitor(target.monitor.as_str())
+        if crate::compositor::monitor::camera::pan_blocked_on_monitor(&*st, target.monitor.as_str())
             || (target.focus.is_some()
                 && (gestures.compositor_scope != CompositorGestureScope::Global
                     && !global_override
@@ -392,7 +391,7 @@ fn classify_pending_pinch(delta: Vec2, scale: f32) -> Option<PendingPinchIntent>
 }
 
 fn pinch_pan_delta(st: &Halley, monitor: &str, delta_x: f64, delta_y: f64) -> Vec2 {
-    let camera = camera_controller(st).view_size();
+    let camera = crate::compositor::monitor::camera::camera_view_size(st);
     let (ws_w, ws_h) = st
         .model
         .monitor_state
@@ -420,11 +419,11 @@ fn apply_pinch_pan<B: BackendView>(
     if pan.x.abs() < f32::EPSILON && pan.y.abs() < f32::EPSILON {
         return;
     }
-    if camera_controller(&*st).pan_blocked_on_monitor(monitor) {
+    if crate::compositor::monitor::camera::pan_blocked_on_monitor(&*st, monitor) {
         return;
     }
     st.note_pan_activity(Instant::now());
-    camera_controller(&mut *st).pan_target(pan);
+    crate::compositor::monitor::camera::pan_camera_target(&mut *st, pan);
     st.note_pan_viewport_change(Instant::now());
     ctx.backend.request_output_redraw(monitor);
 }
@@ -439,8 +438,10 @@ fn apply_pinch_zoom<B: BackendView>(
     if !st.activate_monitor(monitor) {
         return;
     }
-    camera_controller(&mut *st)
-        .set_target_view_size(pinch_target_view_size(start_view_size, scale as f32));
+    crate::compositor::monitor::camera::set_camera_target_view_size(
+        &mut *st,
+        pinch_target_view_size(start_view_size, scale as f32),
+    );
     ctx.backend.request_output_redraw(monitor);
 }
 

--- a/crates/halley-wl/src/input/pointer/motion/drag.rs
+++ b/crates/halley-wl/src/input/pointer/motion/drag.rs
@@ -172,6 +172,12 @@ pub(crate) fn begin_drag(
     st.input.interaction_state.pending_core_click = None;
     st.input.interaction_state.pending_collapsed_node_press = None;
     st.input.interaction_state.pending_collapsed_node_click = None;
+    // Grabbing a core whose bloom is open (from hover) collapses the bloom first so
+    // the drag moves the core itself rather than leaving the fan-out behind. Single
+    // choke point for every core-drag entry (plain press, drag/move bindings).
+    if hit.is_core {
+        let _ = crate::input::pointer::button::collapse_bloom_for_core_if_open(st, hit.node_id);
+    }
     if let Some(monitor) =
         crate::compositor::workspace::state::maximize_session_monitor_for_node(st, hit.node_id)
     {

--- a/crates/halley-wl/src/input/pointer/motion/drag.rs
+++ b/crates/halley-wl/src/input/pointer/motion/drag.rs
@@ -904,15 +904,16 @@ pub(crate) fn finish_pointer_drag(
         .unwrap_or_else(|| st.model.monitor_state.current_monitor.clone());
     crate::compositor::interaction::state::clear_grabbed_edge_pan_state(st);
     st.input.interaction_state.active_drag = None;
-    let joined = st.commit_ready_cluster_join_for_node(node_id, now)
-        || join_active_stacking_layout_at(
-            st,
-            drag_monitor.as_str(),
-            node_id,
-            world_now,
-            now,
-            now_ms,
-        );
+    let joined =
+        crate::compositor::clusters::system::commit_ready_cluster_join_for_node(st, node_id, now)
+            || join_active_stacking_layout_at(
+                st,
+                drag_monitor.as_str(),
+                node_id,
+                world_now,
+                now,
+                now_ms,
+            );
     if !joined {
         if started_active {
             let _ = st.move_active_cluster_member_to_drop_tile(
@@ -988,7 +989,12 @@ pub(super) fn handle_drag_motion(
 
     let drag_allowed = !drag.requires_drag_modifier || drag_mod_ok;
     if ps.resize.is_some() || !drag_allowed {
-        let joined = !drag_allowed && st.commit_ready_cluster_join_for_node(drag.node_id, now);
+        let joined = !drag_allowed
+            && crate::compositor::clusters::system::commit_ready_cluster_join_for_node(
+                st,
+                drag.node_id,
+                now,
+            );
         crate::compositor::carry::system::set_drag_authority_node(st, None);
         crate::compositor::carry::system::end_carry_state_tracking(st, drag.node_id);
         ps.drag = None;

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -106,6 +106,12 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
             st.input.interaction_state.apogee_live_preview_node = live_preview;
             st.input.interaction_state.apogee_live_preview_last_at = None;
         }
+        // Track the hovered tile (window or core) so the overview can ring core
+        // tiles too, not just window previews.
+        let hover_changed = st.input.interaction_state.apogee_hover_node != hit;
+        if hover_changed {
+            st.input.interaction_state.apogee_hover_node = hit;
+        }
         let icon = if hit.is_some() {
             Some(smithay::input::pointer::CursorIcon::Pointer)
         } else {
@@ -115,7 +121,7 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
             crate::compositor::interaction::pointer::set_cursor_override_icon(st, icon);
         }
         request_apogee_cursor_redraw(ctx, previous_monitor.as_deref(), target_monitor.as_str());
-        if live_preview_changed {
+        if live_preview_changed || hover_changed {
             ctx.backend.request_output_redraw(target_monitor.as_str());
         }
         return;

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -4,7 +4,7 @@ use smithay::input::pointer::{MotionEvent, RelativeMotionEvent};
 use smithay::utils::SERIAL_COUNTER;
 
 use crate::backend::interface::BackendView;
-use crate::compositor::exit_confirm::exit_confirm_controller;
+use crate::compositor::exit_confirm;
 use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::input::ctx::InputCtx;
@@ -59,7 +59,7 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
     delta_unaccel: (f64, f64),
     time_usec: u64,
 ) {
-    if exit_confirm_controller(&*st).active() {
+    if exit_confirm::active(&*st) {
         return;
     }
 

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -285,8 +285,10 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
         return;
     }
 
-    let prompt_monitor = crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .active_cluster_name_prompt_monitor(st.model.monitor_state.current_monitor.as_str());
+    let prompt_monitor = crate::compositor::clusters::system::active_cluster_name_prompt_monitor(
+        &*st,
+        st.model.monitor_state.current_monitor.as_str(),
+    );
     if let Some(prompt_monitor) = prompt_monitor {
         let prompt_hit = if routing.monitor == prompt_monitor {
             crate::overlay::cluster_naming_dialog_hit_test(
@@ -304,8 +306,9 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
         ps.hover_node = None;
         ps.hover_started_at = None;
         if let Some(crate::overlay::ClusterNamingDialogHit::InputCaret(caret_char)) = prompt_hit {
-            let _ = crate::compositor::clusters::system::cluster_system_controller(&mut *st)
-                .drag_cluster_name_prompt_selection_for_monitor(
+            let _ =
+                crate::compositor::clusters::system::drag_cluster_name_prompt_selection_for_monitor(
+                    &mut *st,
                     prompt_monitor.as_str(),
                     caret_char,
                 );

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -5,7 +5,6 @@ use smithay::utils::SERIAL_COUNTER;
 
 use crate::backend::interface::BackendView;
 use crate::compositor::exit_confirm;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::input::ctx::InputCtx;
 use crate::input::pointer::focus;
@@ -484,15 +483,18 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
         let (lsx, lsy) = ps.pan_last_screen;
         let dx_px = routing.global_sx - lsx;
         let dy_px = routing.global_sy - lsy;
-        let camera = camera_controller(&*st).view_size();
+        let camera = crate::compositor::monitor::camera::camera_view_size(&*st);
         let dx_world = dx_px * camera.x.max(1.0) / (routing.ws_w as f32).max(1.0);
         let dy_world = dy_px * camera.y.max(1.0) / (routing.ws_h as f32).max(1.0);
         let now = Instant::now();
         st.note_pan_activity(now);
-        camera_controller(&mut *st).pan_target(halley_core::field::Vec2 {
-            x: -dx_world,
-            y: -dy_world,
-        });
+        crate::compositor::monitor::camera::pan_camera_target(
+            &mut *st,
+            halley_core::field::Vec2 {
+                x: -dx_world,
+                y: -dy_world,
+            },
+        );
         st.note_pan_viewport_change(now);
         ps.pan_last_screen = (routing.global_sx, routing.global_sy);
         ctx.backend.request_output_redraw(routing.monitor.as_str());

--- a/crates/halley-wl/src/input/pointer/motion/mod.rs
+++ b/crates/halley-wl/src/input/pointer/motion/mod.rs
@@ -200,7 +200,7 @@ pub(crate) fn handle_pointer_motion_absolute<B: BackendView>(
     // Keep the Xwayland RandR primary on the monitor under the cursor so XWayland
     // games (which read the X primary at startup) get the resolution of the monitor
     // they are launched on. Debounced internally; only acts on monitor changes.
-    st.sync_xwayland_primary(routing.monitor.as_str());
+    crate::compositor::monitor::state::sync_xwayland_primary(st, routing.monitor.as_str());
 
     let (_, hover_focus_blocked) = {
         let ps = ctx.pointer_state.borrow();

--- a/crates/halley-wl/src/input/pointer/resize/anim.rs
+++ b/crates/halley-wl/src/input/pointer/resize/anim.rs
@@ -227,7 +227,7 @@ fn finish_resize_interaction(
             );
         }
         keep_resized_window_forward(st, resize.node_id, now);
-        st.end_resize_interaction(now);
+        crate::compositor::focus::system::end_resize_interaction(st, now);
         st.resolve_overlap_now();
         return;
     }
@@ -257,7 +257,7 @@ fn finish_resize_interaction(
         },
     );
     keep_resized_window_forward(st, resize.node_id, now);
-    st.end_resize_interaction(now);
+    crate::compositor::focus::system::end_resize_interaction(st, now);
     st.resolve_landmarks_overlapped_by_active_window(resize.node_id);
     st.resolve_overlap_now();
 }

--- a/crates/halley-wl/src/input/pointer/resize/geometry.rs
+++ b/crates/halley-wl/src/input/pointer/resize/geometry.rs
@@ -215,8 +215,11 @@ pub(crate) fn active_node_surface_transform_screen_details(
         n.intrinsic_size.x,
         n.intrinsic_size.y,
         transition_alpha,
-    ) * st.fullscreen_entry_scale(node_id, st.now_ms(now))
-        * fit_scale
+    ) * crate::compositor::fullscreen::system::fullscreen_entry_scale(
+        st,
+        node_id,
+        st.now_ms(now),
+    ) * fit_scale
         * cam_scale;
 
     let (origin_x, origin_y, scale) = if let Some(active_resize) =

--- a/crates/halley-wl/src/input/pointer/resize/interaction.rs
+++ b/crates/halley-wl/src/input/pointer/resize/interaction.rs
@@ -87,7 +87,7 @@ pub(crate) fn begin_resize(
         .interaction_state
         .physics_velocity
         .insert(hit.node_id, halley_core::field::Vec2 { x: 0.0, y: 0.0 });
-    st.begin_resize_interaction(hit.node_id, Instant::now());
+    crate::compositor::focus::system::begin_resize_interaction(st, hit.node_id, Instant::now());
 
     let (min_lw, min_lh) = toplevel_min_size_for_node(st, hit.node_id);
     let cam_scale = st.camera_render_scale();

--- a/crates/halley-wl/src/input/pointer/screenshot.rs
+++ b/crates/halley-wl/src/input/pointer/screenshot.rs
@@ -7,7 +7,7 @@ use smithay::input::pointer::CursorIcon;
 use crate::backend::interface::BackendView;
 use crate::compositor::interaction::PointerState;
 use crate::compositor::root::Halley;
-use crate::compositor::screenshot::screenshot_controller;
+use crate::compositor::screenshot;
 use crate::input::ctx::InputCtx;
 
 use super::button::{ButtonFrame, handle_button_release};
@@ -27,7 +27,7 @@ pub(super) fn handle_screenshot_pointer_button<B: BackendView>(
     local_sy: f32,
     world_now: halley_core::field::Vec2,
 ) -> bool {
-    if !screenshot_controller(&mut *st).screenshot_session_active() {
+    if !screenshot::screenshot_session_active(&mut *st) {
         return false;
     }
 
@@ -44,22 +44,24 @@ pub(super) fn handle_screenshot_pointer_button<B: BackendView>(
                 if let Some(crate::overlay::ScreenshotMenuHit::Item(idx)) =
                     crate::overlay::screenshot_menu_hit_test(local_w, local_h, local_sx, local_sy)
                 {
-                    screenshot_controller(&mut *st).hover_screenshot_menu_item(Some(idx));
-                    let _ = screenshot_controller(&mut *st).activate_screenshot_menu_item(idx);
+                    screenshot::hover_screenshot_menu_item(&mut *st, Some(idx));
+                    let _ = screenshot::activate_screenshot_menu_item(&mut *st, idx);
                 }
             }
             Some(CaptureMode::Region) => {
-                let _ = screenshot_controller(&mut *st).begin_screenshot_region_drag(
+                let _ = screenshot::begin_screenshot_region_drag(
+                    &mut *st,
                     frame.global_sx.round() as i32,
                     frame.global_sy.round() as i32,
                 );
             }
             Some(CaptureMode::Screen) => {
-                let _ = screenshot_controller(&mut *st).confirm_screenshot_session(Instant::now());
+                let _ = screenshot::confirm_screenshot_session(&mut *st, Instant::now());
             }
             Some(CaptureMode::Window) => {
                 let now = Instant::now();
-                screenshot_controller(&mut *st).update_screenshot_window_selection_from_pointer(
+                screenshot::update_screenshot_window_selection_from_pointer(
+                    &mut *st,
                     target_monitor,
                     local_w,
                     local_h,
@@ -67,7 +69,7 @@ pub(super) fn handle_screenshot_pointer_button<B: BackendView>(
                     local_sy,
                     now,
                 );
-                let _ = screenshot_controller(&mut *st).confirm_screenshot_session(now);
+                let _ = screenshot::confirm_screenshot_session(&mut *st, now);
             }
             _ => {}
         }
@@ -76,7 +78,7 @@ pub(super) fn handle_screenshot_pointer_button<B: BackendView>(
         && matches!(button_state, ButtonState::Released)
         && matches!(session_mode, Some(CaptureMode::Region))
     {
-        screenshot_controller(&mut *st).end_screenshot_region_drag();
+        screenshot::end_screenshot_region_drag(&mut *st);
     }
     if matches!(button_state, ButtonState::Released) {
         handle_button_release(st, ps, ctx.backend, button_code, None, world_now);
@@ -112,7 +114,7 @@ pub(super) fn handle_screenshot_pointer_motion<B: BackendView>(
         return false;
     };
 
-    screenshot_controller(&mut *st).update_screenshot_session_monitor(target_monitor.to_string());
+    screenshot::update_screenshot_session_monitor(&mut *st, target_monitor.to_string());
     let menu_mode = st
         .input
         .interaction_state
@@ -125,7 +127,7 @@ pub(super) fn handle_screenshot_pointer_motion<B: BackendView>(
             Some(crate::overlay::ScreenshotMenuHit::Item(idx)) => Some(idx),
             None => None,
         };
-        screenshot_controller(&mut *st).hover_screenshot_menu_item(idx);
+        screenshot::hover_screenshot_menu_item(&mut *st, idx);
         crate::compositor::interaction::pointer::set_cursor_override_icon(
             st,
             Some(CursorIcon::Pointer),
@@ -140,12 +142,14 @@ pub(super) fn handle_screenshot_pointer_motion<B: BackendView>(
         .as_ref()
         .is_some_and(|session| session.mode == CaptureMode::Window);
     if dragging_region {
-        screenshot_controller(&mut *st).update_screenshot_region_drag(
+        screenshot::update_screenshot_region_drag(
+            &mut *st,
             effective_sx.round() as i32,
             effective_sy.round() as i32,
         );
     } else if window_mode {
-        screenshot_controller(&mut *st).update_screenshot_window_selection_from_pointer(
+        screenshot::update_screenshot_window_selection_from_pointer(
+            &mut *st,
             target_monitor,
             local_w,
             local_h,

--- a/crates/halley-wl/src/ipc/cluster.rs
+++ b/crates/halley-wl/src/ipc/cluster.rs
@@ -90,9 +90,12 @@ fn open_cluster(
             cid.as_u64()
         )));
     };
-    if crate::compositor::clusters::system::cluster_system_controller(st)
-        .enter_cluster_workspace_by_core(core, monitor.as_str(), now)
-    {
+    if crate::compositor::clusters::system::enter_cluster_workspace_by_core(
+        st,
+        core,
+        monitor.as_str(),
+        now,
+    ) {
         Ok(())
     } else {
         Err(ApiError::Unsupported(format!(
@@ -116,16 +119,15 @@ fn open_finalize_draft(
         .collect::<Vec<_>>();
     let now = Instant::now();
     focus_output_if_needed(st, monitor.as_str(), now);
-    if crate::compositor::clusters::system::cluster_system_controller(st)
-        .open_lift_cluster_finalize_draft(
-            monitor.as_str(),
-            draft.name_hint,
-            draft.app_ids,
-            draft_app_launches(draft.app_launches),
-            running_node_ids,
-            now,
-        )
-    {
+    if crate::compositor::clusters::system::open_lift_cluster_finalize_draft(
+        st,
+        monitor.as_str(),
+        draft.name_hint,
+        draft.app_ids,
+        draft_app_launches(draft.app_launches),
+        running_node_ids,
+        now,
+    ) {
         Ok(())
     } else {
         Err(ApiError::Unsupported(format!(
@@ -156,9 +158,12 @@ fn activate_cluster_slot(st: &mut Halley, slot: u8, output: Option<&str>) -> Res
     }
 
     let monitor = resolve_output_context(st, output)?;
-    let exists = crate::compositor::clusters::system::cluster_system_controller(&*st)
-        .cluster_slot_cluster_for_monitor(monitor.as_str(), slot)
-        .is_some();
+    let exists = crate::compositor::clusters::system::cluster_slot_cluster_for_monitor(
+        &*st,
+        monitor.as_str(),
+        slot,
+    )
+    .is_some();
     if !exists {
         return Err(ApiError::NotFound(format!(
             "no cluster in slot {slot} on output {monitor}"
@@ -284,8 +289,7 @@ fn cluster_info(st: &Halley, cid: ClusterId) -> Result<ClusterInfo, ApiError> {
 
 fn cluster_slot(st: &Halley, cid: ClusterId) -> Option<u8> {
     let output = cluster_output(st, cid)?;
-    crate::compositor::clusters::system::cluster_system_controller(st)
-        .cluster_slot_order_for_monitor(output.as_str())
+    crate::compositor::clusters::system::cluster_slot_order_for_monitor(st, output.as_str())
         .iter()
         .position(|existing| *existing == cid)
         .and_then(|index| u8::try_from(index + 1).ok())

--- a/crates/halley-wl/src/ipc/mod.rs
+++ b/crates/halley-wl/src/ipc/mod.rs
@@ -15,7 +15,7 @@ use halley_api::{
 };
 
 use crate::compositor::root::Halley;
-use crate::compositor::screenshot::screenshot_controller;
+use crate::compositor::screenshot;
 
 use self::cluster::handle_cluster_request;
 use self::monitor::handle_monitor_request;
@@ -399,7 +399,8 @@ fn gamescope_target_response(st: &Halley, selector: &str) -> Response {
 fn handle_capture_request(st: &mut Halley, request: CaptureRequest) -> Response {
     match request {
         CaptureRequest::Start { mode, output } => {
-            if screenshot_controller(&mut *st).start_screenshot_session(
+            if screenshot::start_screenshot_session(
+                &mut *st,
                 mode,
                 output.as_deref(),
                 Instant::now(),
@@ -418,7 +419,7 @@ fn handle_capture_request(st: &mut Halley, request: CaptureRequest) -> Response 
 fn capture_status_response(st: &Halley) -> CaptureStatusResponse {
     let last = st.input.interaction_state.last_screenshot_result.as_ref();
     CaptureStatusResponse {
-        active: screenshot_controller(st).screenshot_session_active()
+        active: screenshot::screenshot_session_active(st)
             || st
                 .input
                 .interaction_state

--- a/crates/halley-wl/src/overlay/observatory.rs
+++ b/crates/halley-wl/src/overlay/observatory.rs
@@ -14,8 +14,8 @@ use crate::text::{draw_ui_text_in, ui_text_size_in};
 
 use super::{
     OverlayView, OverlayVisuals, draw_overflow_member_chip, draw_overlay_chip,
-    draw_overlay_chip_without_shadow, draw_overlay_ring, overlay_accent_fill,
-    overlay_text_color_for_fill,
+    draw_overlay_chip_with_border_color, draw_overlay_chip_without_shadow, draw_overlay_ring,
+    overlay_accent_fill, overlay_text_color_for_fill,
     preview_source::{preview_src_uv, window_preview_source_rect},
     resolve_overlay_visuals, truncate_overlay_text_to_width,
 };
@@ -361,16 +361,24 @@ fn draw_core_tile(
     tile: &ApogeeTile,
     rect: Rectangle<i32, Physical>,
     alpha: f32,
+    hovered: bool,
     damage: Rectangle<i32, Physical>,
 ) -> Result<(), Box<dyn Error>> {
-    let fill = visuals.palette.key_fill.alpha(0.84 * alpha);
-    draw_overlay_chip(
+    let fill = crate::presentation::themed_node_fill_color(&st.runtime.tuning, hovered);
+    let border_color =
+        crate::presentation::themed_node_ring_color(&st.runtime.tuning, hovered, 1.0);
+    let core_visuals = OverlayVisuals {
+        border_px: 5.0,
+        ..*visuals
+    };
+    draw_overlay_chip_with_border_color(
         frame,
         overlay.render_state,
-        visuals,
+        &core_visuals,
         rect,
         rect.size.w.min(rect.size.h) as f32 * 0.5,
         fill,
+        border_color,
         true,
         damage,
         alpha,
@@ -488,8 +496,9 @@ pub(crate) fn draw_observatory(
         if rect.loc.x > screen_w || rect.loc.x + rect.size.w < 0 {
             continue;
         }
+        let hovered = phase_open && hovered_node == Some(tile.node_id);
         draw_core_tile(
-            frame, &*st, &overlay, &visuals, tile, rect, tile_alpha, damage,
+            frame, &*st, &overlay, &visuals, tile, rect, tile_alpha, hovered, damage,
         )?;
     }
 

--- a/crates/halley-wl/src/overlay/observatory.rs
+++ b/crates/halley-wl/src/overlay/observatory.rs
@@ -471,6 +471,7 @@ pub(crate) fn draw_observatory(
     let core_offset = monitor_session.core_scroll_offset;
     let phase_open = matches!(session.phase, ApogeePhase::Open);
     let hovered_node = st.input.interaction_state.apogee_live_preview_node;
+    let hovered_overlay_node = st.input.interaction_state.apogee_hover_node;
 
     let visuals = resolve_overlay_visuals(&st.runtime.tuning);
     let overlay = OverlayView::from_halley(st);
@@ -496,7 +497,7 @@ pub(crate) fn draw_observatory(
         if rect.loc.x > screen_w || rect.loc.x + rect.size.w < 0 {
             continue;
         }
-        let hovered = phase_open && hovered_node == Some(tile.node_id);
+        let hovered = phase_open && hovered_overlay_node == Some(tile.node_id);
         draw_core_tile(
             frame, &*st, &overlay, &visuals, tile, rect, tile_alpha, hovered, damage,
         )?;

--- a/crates/halley-wl/src/overlay/view.rs
+++ b/crates/halley-wl/src/overlay/view.rs
@@ -5,7 +5,6 @@ use halley_core::viewport::Viewport;
 
 use crate::compositor::clusters::state::ClusterState;
 use crate::compositor::interaction::state::InteractionState;
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::monitor::state::MonitorState;
 use crate::compositor::root::Halley;
 use crate::render::state::{NodeAppIconCacheEntry, RenderState};
@@ -37,7 +36,7 @@ impl<'a> OverlayView<'a> {
             last_active_size: &st.model.workspace_state.last_active_size,
             fullscreen_active: &st.model.fullscreen_state.fullscreen_active_node,
             viewport: st.model.viewport,
-            camera_view_size: camera_controller(st).view_size(),
+            camera_view_size: crate::compositor::monitor::camera::camera_view_size(st),
         }
     }
 

--- a/crates/halley-wl/src/presentation.rs
+++ b/crates/halley-wl/src/presentation.rs
@@ -1,13 +1,11 @@
+use crate::compositor::root::Halley;
 use halley_config::{NodeBackgroundColorMode, NodeBorderColorMode, RuntimeTuning};
 #[cfg(test)]
 use halley_core::field::Vec2;
 use smithay::backend::renderer::Color32F;
 
-use crate::compositor::monitor::camera::camera_controller;
-use crate::compositor::root::Halley;
-
 pub(crate) fn world_to_screen(st: &Halley, w: i32, h: i32, x: f32, y: f32) -> (i32, i32) {
-    let view = camera_controller(st).view_size();
+    let view = crate::compositor::monitor::camera::camera_view_size(st);
     let vw = view.x.max(1.0);
     let vh = view.y.max(1.0);
 

--- a/crates/halley-wl/src/protocol/wayland/handlers.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers.rs
@@ -51,7 +51,7 @@ impl SeatHandler for Halley {
 
     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) {
         let now = Instant::now();
-        fullscreen::system::on_seat_focus_changed(&mut self.fullscreen_ctx(), focused, now);
+        fullscreen::system::on_seat_focus_changed(self, focused, now);
         focus::system::on_seat_focus_changed(&self.focus_ctx(), seat, focused);
     }
 

--- a/crates/halley-wl/src/protocol/wayland/handlers.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers.rs
@@ -27,7 +27,7 @@ pub(super) fn initial_toplevel_size(
     toplevel: &ToplevelSurface,
     intent: &spawn::rules::InitialWindowIntent,
 ) -> spawn::reveal::InitialToplevelSize {
-    let mut ctx = st.spawn_ctx();
+    let mut ctx = crate::compositor::ctx::spawn_ctx(st);
     spawn::reveal::initial_toplevel_size(&mut ctx, toplevel, intent)
 }
 
@@ -52,7 +52,11 @@ impl SeatHandler for Halley {
     fn focus_changed(&mut self, seat: &Seat<Self>, focused: Option<&WlSurface>) {
         let now = Instant::now();
         fullscreen::system::on_seat_focus_changed(self, focused, now);
-        focus::system::on_seat_focus_changed(&self.focus_ctx(), seat, focused);
+        focus::system::on_seat_focus_changed(
+            &crate::compositor::ctx::focus_ctx(self),
+            seat,
+            focused,
+        );
     }
 
     fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
@@ -114,7 +118,7 @@ impl CompositorHandler for Halley {
 
     fn commit(&mut self, surface: &WlSurface) {
         on_commit_buffer_handler::<Self>(surface);
-        self.install_drm_syncobj_blocker(surface);
+        crate::compositor::platform::install_drm_syncobj_blocker(self, surface);
         self.platform.popup_manager.commit(surface);
         if crate::render::handle_cursor_surface_commit(
             self.platform.cursor_manager.cursor_image(),
@@ -238,7 +242,7 @@ impl PointerConstraintsHandler for Halley {
         location: smithay::utils::Point<f64, smithay::utils::Logical>,
     ) {
         interaction::pointer::cursor_position_hint(
-            &mut self.pointer_ctx(),
+            &mut crate::compositor::ctx::pointer_ctx(self),
             surface,
             pointer,
             location,

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -256,7 +256,7 @@ impl XdgShellHandler for Halley {
         }
         if !handled_by_lift_staging && (!handled_by_cluster || handled_by_active_cluster) {
             spawn::reveal::reveal_new_toplevel_node_via_ctx(
-                &mut self.spawn_ctx(),
+                &mut crate::compositor::ctx::spawn_ctx(self),
                 id,
                 is_transient,
                 now,

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -256,7 +256,12 @@ impl XdgShellHandler for Halley {
             let _ = self.model.field.touch(id, self.now_ms(now));
         }
         if !handled_by_lift_staging && (!handled_by_cluster || handled_by_active_cluster) {
-            spawn::reveal::reveal_new_toplevel_node(&mut self.spawn_ctx(), id, is_transient, now);
+            spawn::reveal::reveal_new_toplevel_node_via_ctx(
+                &mut self.spawn_ctx(),
+                id,
+                is_transient,
+                now,
+            );
         }
         if !handled_by_cluster && !handled_by_lift_staging {
             if !self.model.spawn_state.pending_initial_reveal.contains(&id) {

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -246,8 +246,7 @@ impl XdgShellHandler for Halley {
                 });
         let handled_by_cluster = node_cluster.is_some();
         let handled_by_lift_staging =
-            crate::compositor::clusters::system::cluster_system_controller(&*self)
-                .pending_lift_cluster_node_staged(id);
+            crate::compositor::clusters::system::pending_lift_cluster_node_staged(&*self, id);
         if !is_transient && !handled_by_cluster && !handled_by_lift_staging {
             self.model.spawn_state.pending_initial_reveal.insert(id);
             let _ = self.model.field.set_detached(id, true);

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -359,12 +359,7 @@ impl XdgShellHandler for Halley {
             surface.send_configure();
             return;
         };
-        fullscreen::system::enter_xdg_fullscreen(
-            &mut self.fullscreen_ctx(),
-            node_id,
-            output,
-            Instant::now(),
-        );
+        fullscreen::system::enter_xdg_fullscreen(self, node_id, output, Instant::now());
     }
 
     fn unfullscreen_request(&mut self, surface: ToplevelSurface) {
@@ -373,11 +368,7 @@ impl XdgShellHandler for Halley {
             surface.send_configure();
             return;
         };
-        fullscreen::system::exit_xdg_fullscreen(
-            &mut self.fullscreen_ctx(),
-            node_id,
-            Instant::now(),
-        );
+        fullscreen::system::exit_xdg_fullscreen(self, node_id, Instant::now());
     }
 
     fn minimize_request(&mut self, surface: ToplevelSurface) {

--- a/crates/halley-wl/src/render/frame/draw.rs
+++ b/crates/halley-wl/src/render/frame/draw.rs
@@ -20,7 +20,6 @@ use super::super::node::{draw_closing_node_markers, draw_node_hover_labels, draw
 use super::super::pin_icon::draw_pin_badges;
 use super::super::state::{ClosingWindowAnimationKind, ClosingWindowAnimationSnapshot};
 use super::scene::{CursorScene, PreparedFrameState, SceneCollections};
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 use crate::overlay::{
     OverlayView, draw_cluster_bloom, draw_cluster_overflow_promotion, draw_cluster_overflow_strip,
@@ -510,8 +509,11 @@ pub(super) fn draw_scene_windows_and_hud(
         let ring_world_cx = st.model.viewport.center.x + focus_ring.offset_x;
         let ring_world_cy = st.model.viewport.center.y + focus_ring.offset_y;
         let (ring_sx, ring_sy) = world_to_screen(st, size.w, size.h, ring_world_cx, ring_world_cy);
-        let (screen_rx, screen_ry) =
-            focus_ring_screen_radii(camera_controller(&*st).view_size(), size, focus_ring);
+        let (screen_rx, screen_ry) = focus_ring_screen_radii(
+            crate::compositor::monitor::camera::camera_view_size(&*st),
+            size,
+            focus_ring,
+        );
         draw_ring(
             frame,
             ring_sx as f32,

--- a/crates/halley-wl/src/render/frame/scene.rs
+++ b/crates/halley-wl/src/render/frame/scene.rs
@@ -258,8 +258,7 @@ pub(super) fn collect_debug_frame_scene(
         .into_iter()
         .filter_map(|id| {
             let node = st.model.field.node(id)?;
-            if crate::compositor::clusters::system::cluster_system_controller(&*st)
-                .pending_lift_cluster_node_staged(id)
+            if crate::compositor::clusters::system::pending_lift_cluster_node_staged(&*st, id)
                 || !st.model.field.participates_in_field_view(id)
                 || !st.model.field.is_visible(id)
                 || !st.node_assigned_to_current_monitor(id)

--- a/crates/halley-wl/src/spatial/mod.rs
+++ b/crates/halley-wl/src/spatial/mod.rs
@@ -1,6 +1,4 @@
 mod hit_test;
-
-use crate::compositor::monitor::camera::camera_controller;
 use crate::compositor::root::Halley;
 
 pub(crate) fn screen_to_world(
@@ -12,7 +10,7 @@ pub(crate) fn screen_to_world(
 ) -> halley_core::field::Vec2 {
     let w = (w as f32).max(1.0);
     let h = (h as f32).max(1.0);
-    let view = camera_controller(st).view_size();
+    let view = crate::compositor::monitor::camera::camera_view_size(st);
     let nx = (sx / w) - 0.5;
     let ny = (sy / h) - 0.5;
 

--- a/crates/halley-wl/src/window/layout.rs
+++ b/crates/halley-wl/src/window/layout.rs
@@ -164,11 +164,13 @@ pub(super) fn resolve_window_render_layout(
     let transition_alpha =
         crate::compositor::workspace::state::active_transition_alpha(st, node_id, now);
     let anim = crate::frame_loop::anim_style_for(st, node_id, node_state, now);
-    let fullscreen_entry_scale = st.fullscreen_entry_scale(node_id, st.now_ms(now));
+    let fullscreen_entry_scale =
+        crate::compositor::fullscreen::system::fullscreen_entry_scale(st, node_id, st.now_ms(now));
     let active_resize = active_resize_geometry_screen(st, node_id, resize_preview);
     let resizing_this_node = active_resize.is_some();
     let persistent_rule_top = is_persistent_rule_top(st, node_id);
-    let overlap_policy_stack_this_node = st.node_has_overlap_policy(node_id);
+    let overlap_policy_stack_this_node =
+        crate::compositor::spawn::state::node_has_overlap_policy(st, node_id);
     let draw_top_this_node = resizing_this_node
         || dragging_this_node
         || (persistent_rule_top && !overlap_policy_stack_this_node);

--- a/crates/halley-wl/src/window/layout.rs
+++ b/crates/halley-wl/src/window/layout.rs
@@ -111,18 +111,23 @@ pub(super) fn resolve_window_render_layout(
     now: Instant,
 ) -> Option<WindowRenderLayout> {
     let node = st.model.field.node(node_id)?;
-    if node.state != halley_core::field::NodeState::Active
-        || !st.model.field.is_visible(node_id)
-        || !st.node_assigned_to_current_monitor(node_id)
-    {
-        return None;
-    }
-
     let stack_transition_pose = stack_layout
         .transition_plan
         .as_ref()
         .and_then(|plan| plan.poses.get(&node_id).copied());
     let stack_member_rendered = stack_layout.render_set.contains(&node_id);
+    // A node taking part in the stack-cycle transition keeps rendering even after
+    // the relayout has already moved it out of the visible set (hidden / no longer
+    // Active) — otherwise the outgoing top of a forward cycle vanishes instead of
+    // flying out to the left. The transition pose drives its geometry/alpha.
+    let in_stack_transition = stack_transition_pose.is_some();
+    if !st.node_assigned_to_current_monitor(node_id)
+        || (!in_stack_transition
+            && (node.state != halley_core::field::NodeState::Active
+                || !st.model.field.is_visible(node_id)))
+    {
+        return None;
+    }
     let node_pos = node.pos;
     let node_state = node.state.clone();
     let node_intrinsic = node.intrinsic_size;

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -463,8 +463,7 @@ pub(crate) fn collect_active_surfaces(
             let key = wl.id();
             let node_id = st.model.surface_to_node.get(&key).copied()?;
             let node = st.model.field.node(node_id)?;
-            if crate::compositor::clusters::system::cluster_system_controller(&*st)
-                .pending_lift_cluster_node_staged(node_id)
+            if crate::compositor::clusters::system::pending_lift_cluster_node_staged(&*st, node_id)
                 || !st.model.field.is_visible(node_id)
                 || !st.node_assigned_to_current_monitor(node_id)
             {

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -225,7 +225,7 @@ fn rect_covers_output(rect: (i32, i32, i32, i32), output: Rectangle<i32, Physica
         && rect.1 + rect.3 >= output.loc.y + output.size.h - tolerance
 }
 
-fn active_surface_draw_rank(st: &Halley, node_id: NodeId) -> (u64, u64) {
+pub(crate) fn active_surface_draw_rank(st: &Halley, node_id: NodeId) -> (u64, u64) {
     let (rank, tie) = st.overlap_policy_stack_rank(node_id);
     if node_floats_over_active_cluster(st, node_id) {
         (rank.saturating_add(1_u64 << 62), tie)

--- a/crates/halley-wl/src/window/stack.rs
+++ b/crates/halley-wl/src/window/stack.rs
@@ -58,11 +58,18 @@ pub(super) fn build_stack_transition_plan(
     transition: &crate::render::state::StackCycleTransitionSnapshot,
 ) -> Option<StackTransitionPlan> {
     let custom_source_rects = transition.source_rects.is_some();
-    let old_rects = transition
-        .source_rects
-        .clone()
-        .or_else(|| st.stack_layout_rects_for_members(monitor, &transition.old_visible))?;
-    let new_rects = st.stack_layout_rects_for_members(monitor, &transition.new_visible)?;
+    let old_rects = transition.source_rects.clone().or_else(|| {
+        crate::compositor::clusters::system::stack_layout_rects_for_members(
+            st,
+            monitor,
+            &transition.old_visible,
+        )
+    })?;
+    let new_rects = crate::compositor::clusters::system::stack_layout_rects_for_members(
+        st,
+        monitor,
+        &transition.new_visible,
+    )?;
     let t = ease_in_out_cubic(transition.progress);
     let draw_orders = stack_draw_order_map(&transition.new_visible);
     let topmost_order = transition.new_visible.len() as i32 + 1;


### PR DESCRIPTION
## Summary

Bundles the recent `dev` work ahead of the v0.5.0 cut: the controller-wrapper flattening + `root.rs` facade trim, a round of Apogee/cluster fixes, and the changelog update.

## Refactors (no behavior change; all 452 `halley-wl` tests pass)

- **Drop `*Controller` wrapper structs** (`742b05a`…`95d3588`): convert every method on the ClusterSystem, ClusterRead, ClusterMutation, FocusSystem, FocusState, FocusCycle, FocusDecay, FocusTrail, Fullscreen, ExitConfirm, Runtime, SpawnReveal, Screenshot, and Camera controllers into free functions taking `&Halley`/`&mut Halley`. Deletes the wrapper structs, constructors, and `Deref`/`DerefMut` impls; collapses a few same-module duplicates surfaced along the way.
- **Trim `root.rs` facade** (`6b0d518`): inline the thin one-line `Halley` facade methods that only delegated to a free fn with ≤2 callers, and remove the last dead code (`FullscreenCtx`, `debug_dump`). `root.rs` drops from 212 → 171 methods (1888 → 1680 lines). Build is warning-free workspace-wide.

## Apogee / cluster fixes

- **Themed core-tile look** (`39493f7`): Apogee core tiles now use the same themed fill (`node_background_color`) and 5px themed border ring (`node_border_color_*`) as normal core nodes, plus a hover ring driven by new `apogee_hover_node` state.
- **Overflow members in Apogee** (`debd42d`): tile-cluster overflow members now surface in Apogee (flying in from the overflow strip, app-icon fallback previews); selecting any cluster member promotes it to master for both tiling and stacking.
- **Maximize re-center + close z-order + core-select opens cluster** (`f3bdfa6`): selecting a maximized window no longer leaves it off-centre; closing Apogee without a selection no longer flashes wrong z-order; new `apogee.open-cluster-on-select` (default `true`) opens a core's workspace on select.
- **Lift core overlap + cluster stays put on select** (`a1c8c9d`): Lift-created cores now resolve overlap immediately; selecting a cluster member no longer shifts the whole cluster off-centre.
- **Collapse bloom on drag grab** (`12369de`): grabbing a core whose bloom was opened from hover now collapses the bloom.
- **Forward-cycle stack rendering** (`e032dd1`): the outgoing top now flies out to the left on a Next cycle instead of vanishing.
- **Config-reload cluster layout preservation**: reloading config no longer resets an active cluster workspace to its default layout (one-shot `skip_next_cluster_relayout` flag on the reload-driven maintenance tick).

## Other

- **Modal key-trap clear** (`e916b4b`): clear `modal_release_keys`/`forwarded_pressed_keys` in `finish_modal_capture` so a dismissed portal chooser can't leave a trapped Enter repeating forever.
- **Lift config entries** (`a189a4c`): move open-config entries out of Actions mode into Config mode.
- **Changelog** (`64a48e4`): update `CHANGELOG.md` for all of the above.

## Test plan
- [x] `cargo build -p halley-wl` warning-free
- [x] All 452 `halley-wl` tests pass (per commit messages)
- [x] Manual: verify Apogee core tiles show themed fill + border matching normal nodes
- [x] Manual: verify config reload preserves a manually-arranged cluster workspace
- [x] Manual: verify forward stack-cycle animates the outgoing member out to the left