### PR TITLE
feat/fix(wl): Apogee keyboard nav, fullscreen/maximize overhaul, and input fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,10 +119,12 @@ All notable changes to this project will be documented in this file.
   visible when zooming out, where each marker's keep-out gap grows in screen-constant space);
   windows now spread to keep its gap clear. Pinning a node is no longer required to make it a
   landmark — it now only affects drag-carry behaviour.
-- Selecting a window in Apogee that sits beside or behind a fullscreen window now leaves
-  fullscreen (soft-suspend) and switches focus in one action, instead of raising the window
-  above the fullscreen and keeping the presentation (which needed a second select to actually
-  exit fullscreen). Alt+Tab and focus-trail keep the original raise-above-keep behaviour.
+- Maximize and fullscreen are now mutually exclusive per monitor: entering fullscreen aborts any
+  active maximize session on that monitor, and maximizing a window exits any active fullscreen on
+  it. Previously the two could coexist — a maximize session was preserved underneath fullscreen so
+  a maximized window returned from fullscreen still maximized (and maximizing was blocked while
+  fullscreen). Cross-window maximization on the same monitor now exits the other window's
+  fullscreen too.
 - Animate the Alt+Tab focus-cycle switcher with a quick open fade/scale and smooth carousel-style
   card motion between selections, while keeping the existing bounded snapshot prewarm behavior.
 - Open Apogee on every active monitor at once, with each monitor showing only its own windows and
@@ -231,6 +233,27 @@ All notable changes to this project will be documented in this file.
   offscreen texture.
 
 ### Fixed
+- Smooth the maximize↔fullscreen transitions, which flashed: switching between the two modes
+  tore the outgoing mode down (snapping the window to its small windowed size) before the
+  incoming mode's grow animation started. Each direction now captures the outgoing window's
+  on-screen rect (the maximized rect when fullscreening, the full-screen rect when maximizing)
+  and eases from it, so the window grows/shrinks directly between maximized and full-screen
+  with no intermediate snap.
+- Fix a window staying stuck at maximized size after a `maximize → fullscreen → maximize →
+  unmaximize` sequence. Exiting fullscreen straight into a maximize re-snapshotted the size
+  from the still-stale fullscreen/maximized surface geometry, so unmaximize "restored" to that
+  size. `restore_fullscreen_snapshot` now pins the restored windowed size into the node's
+  `resize_footprint` *after* the footprint sync (the sync was clearing the value the prior fix
+  set), so the re-maximize snapshots the true windowed size before the client commits its
+  resize.
+- Stop runaway key repeat (e.g. Enter repeating forever in a terminal after first opening a
+  cluster) for good, with a general guard instead of another per-case patch: physical key
+  state is now tracked and, after every key event, any key still forwarded to a client as
+  pressed but no longer physically held is released (`reconcile_forwarded_keys`). This covers
+  modal/overlay interactions that begin and end on the same surface, async opens, and deferred
+  focus to freshly-revealed windows — paths the previous focus-change-only flush missed.
+  Genuine key-holds and held modifiers are unaffected, and popup-grab focus now routes through
+  the same focus choke point.
 - Fix corrupt first-fullscreen rendering of XWayland windows (e.g. Steam) where the live surface
   was blown up so only its top-left corner filled the screen until you toggled fullscreen again.
   A fullscreen surface's render geometry is now derived from its live buffer rather than the cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ All notable changes to this project will be documented in this file.
   fallback previews, and promote a selected overflow member into the master slot (re-laying out the
   cluster and shifting the old master into overflow). Selecting any cluster workspace member in Apogee
   now promotes it to master for both tiling and stacking layouts.
+- Add frosted-glass backdrop blur behind Apogee tile labels (Dual-Kawase, honouring the
+  global `effects.blur` switches) so labels stay legible over the blurred window thumbnail
+  behind them; the Apogee render fast path now sets up a `FrameBlurContext` for overlay chrome.
 
 ### Changed
 - Animate the Alt+Tab focus-cycle switcher with a quick open fade/scale and smooth carousel-style
@@ -191,6 +194,16 @@ All notable changes to this project will be documented in this file.
   thin one-line `root.rs` facade methods that only delegated to those functions, removing the last dead
   code (unused `FullscreenCtx`, empty `debug_dump`) and clearing workspace-wide warnings. Pure
   mechanical transform; no behavior changes.
+- Fullscreen windows now grow and shrink in place, centred on the window's own position, with
+  the monitor camera easing to centre on the window and zoom to 1.0 together. The old behaviour
+  snapped the zoom to 1.0 about the (often off-window) camera centre, shoving every windowed node
+  behind it sideways by the zoom delta; the steady-state fullscreen rect also anchors on the node
+  centre now, so there is no jump when the grow/shrink animation expires mid-camera-ease.
+- Narrow config-reload texture invalidation: offscreen window textures are rebuilt only when the
+  baked border-corner radius actually changes (including crossing 0, which toggles the geometry
+  clip), not whenever the whole `decorations` block differs. Border sizes/colours, shadows and
+  blur are drawn live per frame, so a colour-only theme reload no longer flushes every window's
+  offscreen texture.
 
 ### Fixed
 - Ensure client-side fullscreen requests still send the xdg fullscreen configure when the window
@@ -317,6 +330,14 @@ All notable changes to this project will be documented in this file.
   suppressing the tiling re-layout that normally fires on maintenance (preserving manual member
   positions) while leaving all other maintenance work and legitimate re-layouts (cluster entry, member
   add, overflow animations) unaffected.
+- Capture real previews for fullscreen and game windows in Apogee and the Alt+Tab focus-cycle
+  switcher instead of falling back to the app icon. The immersive fullscreen/game lock is released
+  while Apogee is open and during an Alt+Tab cycle (the window is composited, off direct scanout),
+  so its surface is sampleable; the per-node fullscreen skip has been dropped from the
+  apogee/focus-cycle prewarm and preview paths.
+- Deliver a press landing on an overflowing popup (e.g. a context menu spilling past its parent
+  window) to the popup without also raising or focusing the toplevel beneath it. The window-side
+  raise/drag/resize path is now skipped when a popup is under the pointer.
 
 ## [v0.4.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this project will be documented in this file.
 - Add a Halley Lift search-bar magnifier icon: a `search-icon:` block (`enabled`, `side`
   `left`/`right`, `size`) with a `colors.search-icon` tint (empty follows `hint`). The bundled
   square SVG is rendered to an alpha mask and tinted at draw time.
+- Add a dedicated Halley Lift settings glyph (bundled `settings.svg`) shown as the search-bar
+  icon while the `config` search mode is active and as the row icon for config-editing results
+  (Lift config / Halley config), so config entries are no longer iconless.
 - Add a dedicated Halley Lift Apps-mode search glyph, alongside refreshed bundled search and
   terminal glyph strokes for clearer small-size rendering.
 - Add drawn fallback glyphs for Halley Lift result rows without a raster icon: a squircle for
@@ -96,8 +99,30 @@ All notable changes to this project will be documented in this file.
 - Add frosted-glass backdrop blur behind Apogee tile labels (Dual-Kawase, honouring the
   global `effects.blur` switches) so labels stay legible over the blurred window thumbnail
   behind them; the Apogee render fast path now sets up a `FrameBlurContext` for overlay chrome.
+- Add arrow-key navigation in Apogee: the arrow keys move a highlighted selection across the
+  window mosaic and the core rail, Enter activates it (windows fly to focus; cluster cores open
+  their workspace), and Escape closes. Navigation is unified with the mouse — pressing an arrow
+  warps the cursor onto the target tile so keyboard and pointer drive the same single hover/focus
+  (a later mouse move continues from there) — and it crosses monitor boundaries in global screen
+  space (jump to the next monitor's tiles, no wrap).
+- Show a frosted name label below a hovered or keyboard-selected cluster **core** tile in Apogee
+  (cores previously showed only their icon); the label stays up for the whole hover.
+- Add a `center-last-focused` keybind action (default `mod+h`) that pans the camera back to centre
+  on the last focused node — a quick "go back" after wandering the field. Wired into the internal
+  template, bootstrap backfill, and example configs. The bare-defaults field node-move bindings
+  also move from vim `hjkl` to the arrow keys, matching the generated config and freeing `mod+h`.
 
 ### Changed
+- Treat field node/core markers as fixed landmarks in passive (idle/zoom) overlap resolution:
+  neighbouring windows now yield around a marker instead of the marker being pushed aside. A
+  marker boxed between two windows used to have nowhere to go and ended up overlapped (most
+  visible when zooming out, where each marker's keep-out gap grows in screen-constant space);
+  windows now spread to keep its gap clear. Pinning a node is no longer required to make it a
+  landmark — it now only affects drag-carry behaviour.
+- Selecting a window in Apogee that sits beside or behind a fullscreen window now leaves
+  fullscreen (soft-suspend) and switches focus in one action, instead of raising the window
+  above the fullscreen and keeping the presentation (which needed a second select to actually
+  exit fullscreen). Alt+Tab and focus-trail keep the original raise-above-keep behaviour.
 - Animate the Alt+Tab focus-cycle switcher with a quick open fade/scale and smooth carousel-style
   card motion between selections, while keeping the existing bounded snapshot prewarm behavior.
 - Open Apogee on every active monitor at once, with each monitor showing only its own windows and
@@ -206,6 +231,17 @@ All notable changes to this project will be documented in this file.
   offscreen texture.
 
 ### Fixed
+- Fix corrupt first-fullscreen rendering of XWayland windows (e.g. Steam) where the live surface
+  was blown up so only its top-left corner filled the screen until you toggled fullscreen again.
+  A fullscreen surface's render geometry is now derived from its live buffer rather than the cached
+  xdg window-geometry, which can lag the buffer right after the client goes fullscreen and made the
+  render scale come out far too large. Routed through one `render_window_geometry_for_node` helper
+  shared by the field, offscreen-compose, and close-capture paths (Apogee/Alt+Tab previews already
+  handled this).
+- Stop field node/core markers from being hidden underneath windows. Markers are screen-space
+  constant (readable at every zoom) and now draw above window bodies and borders — but below
+  popups, overlay HUD, and their own hover labels — so a window grown over a marker can no longer
+  occlude it.
 - Ensure client-side fullscreen requests still send the xdg fullscreen configure when the window
   was already fullscreened by a Halley keybind, so client fullscreen buttons map cleanly onto
   Halley's fullscreen state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "rune-cfg"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614efe3ece0e72948bb47b649b2141f90b9f2534c74bc2abb1c35dc9f4fb3cac"
+checksum = "63fd1e21478afb995a2fc9af5d40777f673f37e6c88fb3dc3e727fbc4f6151ca"
 dependencies = [
  "indexmap",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ halley-wl = { path = "crates/halley-wl", version = "0.5.0", default-features = f
 
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
 postcard = { version = "1.1.3", features = ["use-std"] }
-rune-cfg = "0.5.0"
+rune-cfg = "0.6.1"
 serde = { version = "1.0.228", features = ["derive"] }
 smithay-client-toolkit = "0.20.0"
 wayland-client = "0.31.14"

--- a/crates/halley-config/src/keybinds/types.rs
+++ b/crates/halley-config/src/keybinds/types.rs
@@ -114,6 +114,9 @@ pub enum CompositorBindingAction {
     CloseFocusedWindow,
     ClusterMode,
     Apogee,
+    /// Pan the camera back to centre on the last focused node — a quick "go back"
+    /// after wandering the field.
+    CenterLastFocused,
     FocusCycle(FocusCycleBindingAction),
     Quit { requires_shift: bool },
     ZoomIn,

--- a/crates/halley-config/src/layout/defaults.rs
+++ b/crates/halley-config/src/layout/defaults.rs
@@ -253,22 +253,25 @@ pub fn default_compositor_bindings(modifier: KeyModifiers) -> Vec<CompositorBind
                 requires_shift: true,
             },
         },
+        // Field node movement on the arrow keys, matching the generated template and
+        // example configs (which use arrows, not vim hjkl). This frees `mod+h` for the
+        // center-last-focused binding below.
         CompositorBinding {
             scope: CompositorBindingScope::Field,
             modifiers: modifier,
-            key: key("h"),
+            key: key("left"),
             action: CompositorBindingAction::Node(NodeBindingAction::Move(DirectionalAction::Left)),
         },
         CompositorBinding {
             scope: CompositorBindingScope::Field,
             modifiers: modifier,
-            key: key("k"),
+            key: key("up"),
             action: CompositorBindingAction::Node(NodeBindingAction::Move(DirectionalAction::Up)),
         },
         CompositorBinding {
             scope: CompositorBindingScope::Field,
             modifiers: modifier,
-            key: key("l"),
+            key: key("right"),
             action: CompositorBindingAction::Node(NodeBindingAction::Move(
                 DirectionalAction::Right,
             )),
@@ -276,8 +279,15 @@ pub fn default_compositor_bindings(modifier: KeyModifiers) -> Vec<CompositorBind
         CompositorBinding {
             scope: CompositorBindingScope::Field,
             modifiers: modifier,
-            key: key("j"),
+            key: key("down"),
             action: CompositorBindingAction::Node(NodeBindingAction::Move(DirectionalAction::Down)),
+        },
+        // Quick "go back": pan the camera to centre on the last focused node.
+        CompositorBinding {
+            scope: CompositorBindingScope::Global,
+            modifiers: modifier,
+            key: key("h"),
+            action: CompositorBindingAction::CenterLastFocused,
         },
         CompositorBinding {
             scope: CompositorBindingScope::Global,

--- a/crates/halley-config/src/layout/runtime.rs
+++ b/crates/halley-config/src/layout/runtime.rs
@@ -919,6 +919,9 @@ keybinds:
   "$var.mod+up" "node-move up"
   "$var.mod+down" "node-move down"
 
+  # Pan the camera back to centre on the last focused node (quick "go back").
+  "$var.mod+h" "center-last-focused"
+
   # Switch active monitor focus.
   "$var.mod+shift+left" "monitor-focus left"
   "$var.mod+shift+right" "monitor-focus right"

--- a/crates/halley-config/src/layout/update.rs
+++ b/crates/halley-config/src/layout/update.rs
@@ -458,6 +458,7 @@ fn keybind_candidates() -> &'static [(&'static str, &'static str)] {
         ("$var.mod+m", "maximize-focused"),
         ("$var.mod+f", "toggle-fullscreen"),
         ("$var.mod+p", "toggle-focused-pin"),
+        ("$var.mod+h", "center-last-focused"),
         ("$var.mod+1", "cluster slot 1"),
         ("$var.mod+2", "cluster slot 2"),
         ("$var.mod+3", "cluster slot 3"),

--- a/crates/halley-config/src/parse/keybinds.rs
+++ b/crates/halley-config/src/parse/keybinds.rs
@@ -425,6 +425,15 @@ fn apply_explicit_binding(
                 CompositorBindingAction::ZoomReset,
             );
         }
+        "center_last_focused" | "center-last-focused" => {
+            upsert_compositor_binding(
+                out,
+                CompositorBindingScope::Global,
+                mods,
+                key,
+                CompositorBindingAction::CenterLastFocused,
+            );
+        }
         "move_window" | "move-window" if is_pointer_button_code(key) => {
             upsert_pointer_binding(out, mods, key, PointerBindingAction::MoveWindow);
         }

--- a/crates/halley-lift/assets/apps.svg
+++ b/crates/halley-lift/assets/apps.svg
@@ -1,12 +1,62 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="128"
-   height="128"
-   viewBox="0 0 128 128"
+   width="98"
+   height="100"
+   viewBox="0 0 98 100"
    version="1.1"
-   xmlns="http://www.w3.org/2000/svg">
-  <rect x="15" y="14" width="42" height="58" rx="8" />
-  <rect x="15" y="82" width="42" height="32" rx="8" />
-  <rect x="71" y="14" width="42" height="42" rx="8" />
-  <rect x="71" y="66" width="42" height="48" rx="8" />
+   id="svg4"
+   sodipodi:docname="apps.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="5.1015625"
+     inkscape:cx="46.358346"
+     inkscape:cy="50.082695"
+     inkscape:window-width="1402"
+     inkscape:window-height="1404"
+     inkscape:window-x="103"
+     inkscape:window-y="103"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <rect
+     x="0"
+     y="0"
+     width="42"
+     height="58"
+     rx="8"
+     id="rect1" />
+  <rect
+     x="0"
+     y="68"
+     width="42"
+     height="32"
+     rx="8"
+     id="rect2" />
+  <rect
+     x="56"
+     y="0"
+     width="42"
+     height="42"
+     rx="8"
+     id="rect3" />
+  <rect
+     x="56"
+     y="52"
+     width="42"
+     height="48"
+     rx="8"
+     id="rect4" />
 </svg>

--- a/crates/halley-lift/assets/settings.svg
+++ b/crates/halley-lift/assets/settings.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="108.24124mm"
+   height="108.03705mm"
+   viewBox="0 0 108.24124 108.03705"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="settings.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.683254"
+     inkscape:cx="194.86067"
+     inkscape:cy="155.35386"
+     inkscape:window-width="1196"
+     inkscape:window-height="1198"
+     inkscape:window-x="103"
+     inkscape:window-y="103"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-44.55078,-71.387071)">
+    <g
+       id="g20"
+       transform="translate(0,12.922427)">
+      <path
+         id="rect1"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="M 93.030508,60.645079 H 104.3123 l 3.4871,10.307915 H 89.543409 Z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path5"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="M 93.030508,60.645079 H 104.3123 l 3.4871,10.307915 H 89.543409 Z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path10"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="M 93.030508,164.32126 H 104.3123 l 3.4871,-10.30791 H 89.543409 Z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path11"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 130.7259,71.355119 8.09591,7.857164 -4.67653,9.825629 -13.10066,-12.714321 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path12"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 130.7259,71.355119 8.09591,7.857164 -4.67653,9.825629 -13.10066,-12.714321 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path13"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 58.520994,145.75406 8.095912,7.85716 9.681281,-4.96847 -13.100659,-12.71432 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path14"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 150.38681,105.81058 0.22478,11.27955 -10.23639,3.69179 -0.36373,-18.25237 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path15"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 150.38681,105.81058 0.22478,11.27955 -10.23639,3.69179 -0.36373,-18.25237 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path16"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 46.731212,107.87621 0.224779,11.27955 10.375341,3.28103 -0.363729,-18.25236 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path17"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 140.91298,143.05532 -7.56439,8.37011 -9.98567,-4.32427 12.24056,-13.54437 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path18"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 140.91298,143.05532 -7.56439,8.37011 -9.98567,-4.32427 12.24056,-13.54437 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path19"
+         style="stroke:#000000;stroke-width:4.36087;stroke-linecap:round;stroke-linejoin:round"
+         d="m 63.994214,73.540905 -7.564388,8.370114 5.309496,9.498532 12.240557,-13.544362 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <path
+       id="path20"
+       style="stroke:#000000;stroke-width:7.23487;stroke-linecap:round;stroke-linejoin:round"
+       d="M 98.671497,85.176713 A 40.229115,40.229115 0 0 0 58.442428,125.40578 40.229115,40.229115 0 0 0 98.671497,165.63485 40.229115,40.229115 0 0 0 138.90057,125.40578 40.229115,40.229115 0 0 0 98.671497,85.176713 Z m 0,10.274825 A 29.954157,29.954157 0 0 1 128.62574,125.40578 29.954157,29.954157 0 0 1 98.671497,155.35951 29.954157,29.954157 0 0 1 68.717253,125.40578 29.954157,29.954157 0 0 1 98.671497,95.451538 Z" />
+  </g>
+</svg>

--- a/crates/halley-lift/src/ui.rs
+++ b/crates/halley-lift/src/ui.rs
@@ -405,6 +405,8 @@ pub struct IconCache {
     action_search_icon: Option<(u32, IconRaster)>,
     action_icon: Option<(u32, IconRaster)>,
     term_icon: Option<(u32, IconRaster)>,
+    config_search_icon: Option<(u32, IconRaster)>,
+    config_icon: Option<(u32, IconRaster)>,
 }
 
 /// Search-bar glyphs. Authored as square SVGs and rendered to alpha masks that are
@@ -413,6 +415,7 @@ const SEARCH_ICON_SVG: &[u8] = include_bytes!("../assets/loupe.svg");
 const APP_SEARCH_ICON_SVG: &[u8] = include_bytes!("../assets/apps.svg");
 const ACTION_ICON_SVG: &[u8] = include_bytes!("../assets/spark.svg");
 const TERM_ICON_SVG: &[u8] = include_bytes!("../assets/term.svg");
+const CONFIG_ICON_SVG: &[u8] = include_bytes!("../assets/settings.svg");
 const CLUSTER_SEARCH_ICON_SVG: &[u8] =
     include_bytes!("../../halley-wl/src/compositor/clusters/assets/clusters.svg");
 
@@ -485,6 +488,8 @@ impl IconCache {
             action_search_icon: None,
             action_icon: None,
             term_icon: None,
+            config_search_icon: None,
+            config_icon: None,
         }
     }
 
@@ -497,6 +502,7 @@ impl IconCache {
             LiftMode::Clusters => (&mut self.cluster_search_icon, CLUSTER_SEARCH_ICON_SVG),
             LiftMode::Actions => (&mut self.action_search_icon, ACTION_ICON_SVG),
             LiftMode::Term => (&mut self.term_icon, TERM_ICON_SVG),
+            LiftMode::Config => (&mut self.config_search_icon, CONFIG_ICON_SVG),
             _ => (&mut self.search_icon, SEARCH_ICON_SVG),
         };
         if slot.as_ref().map(|(s, _)| *s) != Some(size) {
@@ -522,6 +528,15 @@ impl IconCache {
             self.action_icon = Some((size, raster));
         }
         self.action_icon.as_ref().map(|(_, raster)| raster)
+    }
+
+    fn config_glyph(&mut self, size: u32) -> Option<&IconRaster> {
+        let size = size.max(1);
+        if self.config_icon.as_ref().map(|(s, _)| *s) != Some(size) {
+            let raster = render_svg_data(CONFIG_ICON_SVG, None, size)?;
+            self.config_icon = Some((size, raster));
+        }
+        self.config_icon.as_ref().map(|(_, raster)| raster)
     }
 
     pub fn needs_index(&self) -> bool {
@@ -1370,6 +1385,21 @@ fn draw_result_icon(
                 );
             }
         }
+        LiftResultKind::Config => {
+            if let Some(raster) = icon_cache.config_glyph(config.icon_size) {
+                draw_raster_tinted(
+                    canvas,
+                    width,
+                    height,
+                    raster,
+                    x,
+                    y,
+                    size,
+                    size,
+                    colors.accent,
+                );
+            }
+        }
         _ => {}
     }
 }
@@ -2120,6 +2150,33 @@ mod tests {
     }
 
     #[test]
+    fn config_mode_uses_settings_glyph() {
+        let mut config = LiftConfig::default();
+        config.icons = false;
+        let mut cache = IconCache::new(&config);
+
+        let loupe = cache
+            .search_glyph(24, LiftMode::General)
+            .expect("loupe glyph")
+            .rgba
+            .clone();
+        let settings = cache
+            .search_glyph(24, LiftMode::Config)
+            .expect("settings glyph")
+            .rgba
+            .clone();
+
+        assert_ne!(loupe, settings);
+        // The settings.svg must rasterize to real coverage (some non-zero alpha), not a
+        // blank mask — otherwise the tinted draw would paint nothing.
+        assert!(settings.chunks_exact(4).any(|px| px[3] != 0));
+
+        // The result-row glyph uses the same asset and must also render.
+        let row = cache.config_glyph(24).expect("config row glyph");
+        assert!(row.rgba.chunks_exact(4).any(|px| px[3] != 0));
+    }
+
+    #[test]
     fn apps_mode_uses_apps_search_glyph() {
         let mut config = LiftConfig::default();
         config.icons = false;
@@ -2202,6 +2259,8 @@ mod tests {
             action_search_icon: None,
             action_icon: None,
             term_icon: None,
+            config_search_icon: None,
+            config_icon: None,
         };
 
         assert!(cache.load("new-app-icon").is_none());

--- a/crates/halley-wl/src/bootstrap/mod.rs
+++ b/crates/halley-wl/src/bootstrap/mod.rs
@@ -136,7 +136,10 @@ fn apply_reloaded_tuning_state(st: &mut Halley, next: RuntimeTuning) {
     st.apply_tuning(next);
     restore_live_camera_state(st, live_camera);
     let opacity_changed = crate::compositor::spawn::state::recompute_all_node_rule_opacities(st);
-    st.ui.render_state.clear_window_offscreen_caches();
+    // Note: window offscreen caches hold only client surface content (rounded to the
+    // border radius). Borders, shadows, overlays and blur are drawn live per frame, so a
+    // color-only reload needs no texture rebuild. `apply_tuning` already invalidates these
+    // caches when the baked rounding radius changes, so no blanket clear is needed here.
     st.runtime.skip_next_cluster_relayout = true;
     st.request_maintenance();
     if opacity_changed {

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -183,6 +183,28 @@ pub(crate) fn focus_from_presentation_navigation(
     node_id: halley_core::field::NodeId,
     now: Instant,
 ) -> bool {
+    focus_from_presentation_navigation_inner(st, node_id, now, false)
+}
+
+/// `prefer_switch`: when true (apogee tile select), a target that isn't already
+/// floating above the presentation switches to it (soft-suspends the fullscreen /
+/// aborts the maximize) in one action instead of just raising it above and keeping
+/// the presentation. Alt+tab / focus-trail pass false to keep the raise-above-keep
+/// behaviour.
+pub(crate) fn focus_from_presentation_navigation_switching(
+    st: &mut Halley,
+    node_id: halley_core::field::NodeId,
+    now: Instant,
+) -> bool {
+    focus_from_presentation_navigation_inner(st, node_id, now, true)
+}
+
+fn focus_from_presentation_navigation_inner(
+    st: &mut Halley,
+    node_id: halley_core::field::NodeId,
+    now: Instant,
+    prefer_switch: bool,
+) -> bool {
     let Some(node) = st.model.field.node(node_id).cloned() else {
         return false;
     };
@@ -211,7 +233,19 @@ pub(crate) fn focus_from_presentation_navigation(
     }
 
     let target_visible = st.surface_is_fully_visible_on_monitor(target_monitor.as_str(), node_id);
-    if node.state == halley_core::field::NodeState::Active && target_visible {
+    // The focus-only "raise above and keep the presentation" shortcut. With
+    // `prefer_switch` (apogee), restrict it to a window already floating above the
+    // fullscreen — a window beside/behind it falls through to the soft-suspend +
+    // switch path below, so an apogee select leaves fullscreen and switches in one
+    // action instead of needing a second select. Without `prefer_switch` (alt+tab,
+    // focus trail) keep the original raise-above-keep behaviour for any visible
+    // active target.
+    let already_above_fullscreen =
+        st.node_draws_above_fullscreen_on_monitor(node_id, target_monitor.as_str());
+    if node.state == halley_core::field::NodeState::Active
+        && target_visible
+        && (already_above_fullscreen || !prefer_switch)
+    {
         let _ = st.raise_overlap_policy_node(node_id);
         st.set_interaction_focus(Some(node_id), 30_000, now);
         return true;

--- a/crates/halley-wl/src/compositor/actions/window.rs
+++ b/crates/halley-wl/src/compositor/actions/window.rs
@@ -183,28 +183,6 @@ pub(crate) fn focus_from_presentation_navigation(
     node_id: halley_core::field::NodeId,
     now: Instant,
 ) -> bool {
-    focus_from_presentation_navigation_inner(st, node_id, now, false)
-}
-
-/// `prefer_switch`: when true (apogee tile select), a target that isn't already
-/// floating above the presentation switches to it (soft-suspends the fullscreen /
-/// aborts the maximize) in one action instead of just raising it above and keeping
-/// the presentation. Alt+tab / focus-trail pass false to keep the raise-above-keep
-/// behaviour.
-pub(crate) fn focus_from_presentation_navigation_switching(
-    st: &mut Halley,
-    node_id: halley_core::field::NodeId,
-    now: Instant,
-) -> bool {
-    focus_from_presentation_navigation_inner(st, node_id, now, true)
-}
-
-fn focus_from_presentation_navigation_inner(
-    st: &mut Halley,
-    node_id: halley_core::field::NodeId,
-    now: Instant,
-    prefer_switch: bool,
-) -> bool {
     let Some(node) = st.model.field.node(node_id).cloned() else {
         return false;
     };
@@ -233,19 +211,7 @@ fn focus_from_presentation_navigation_inner(
     }
 
     let target_visible = st.surface_is_fully_visible_on_monitor(target_monitor.as_str(), node_id);
-    // The focus-only "raise above and keep the presentation" shortcut. With
-    // `prefer_switch` (apogee), restrict it to a window already floating above the
-    // fullscreen — a window beside/behind it falls through to the soft-suspend +
-    // switch path below, so an apogee select leaves fullscreen and switches in one
-    // action instead of needing a second select. Without `prefer_switch` (alt+tab,
-    // focus trail) keep the original raise-above-keep behaviour for any visible
-    // active target.
-    let already_above_fullscreen =
-        st.node_draws_above_fullscreen_on_monitor(node_id, target_monitor.as_str());
-    if node.state == halley_core::field::NodeState::Active
-        && target_visible
-        && (already_above_fullscreen || !prefer_switch)
-    {
+    if node.state == halley_core::field::NodeState::Active && target_visible {
         let _ = st.raise_overlap_policy_node(node_id);
         st.set_interaction_focus(Some(node_id), 30_000, now);
         return true;
@@ -480,6 +446,7 @@ fn start_active_maximize_session(
         NodeId,
         crate::compositor::workspace::state::MaximizeNodeSnapshot,
     >,
+    from_override: Option<(halley_core::field::Vec2, halley_core::field::Vec2)>,
     now: Instant,
 ) -> bool {
     crate::compositor::workspace::state::reset_monitor_zoom_for_maximize(st, monitor);
@@ -488,10 +455,16 @@ fn start_active_maximize_session(
 
     let _ = node_snapshots;
     let (target_pos, target_size) = maximize_target_for_monitor(st, monitor);
-    let from =
-        crate::compositor::workspace::state::maximize_animation_visual_for_node_on_monitor_at(
-            st, target_id, monitor, now,
-        )
+    // `from_override` carries the outgoing fullscreen window's on-screen rect when
+    // maximizing straight out of fullscreen, so the grow eases from the full-screen
+    // rect down to the maximized rect instead of snapping to the small windowed size
+    // first (which read as a jarring flash).
+    let from = from_override
+        .or_else(|| {
+            crate::compositor::workspace::state::maximize_animation_visual_for_node_on_monitor_at(
+                st, target_id, monitor, now,
+            )
+        })
         .or_else(|| {
             st.model.field.node(target_id).map(|node| {
                 (
@@ -550,12 +523,42 @@ fn start_maximize_session(st: &mut Halley, id: NodeId, monitor: &str, now: Insta
                         session.state =
                             crate::compositor::workspace::state::MaximizeSessionState::Active;
                     }
-                    start_active_maximize_session(st, id, monitor, &existing.node_snapshots, now)
+                    start_active_maximize_session(
+                        st,
+                        id,
+                        monitor,
+                        &existing.node_snapshots,
+                        None,
+                        now,
+                    )
                 }
             };
         }
         let _ =
             crate::compositor::workspace::state::abort_maximize_session_for_monitor(st, monitor);
+    }
+
+    // Maximize and fullscreen are mutually exclusive on a monitor: exit any active
+    // fullscreen before starting the maximize session. Skip the shrink animation so
+    // only the maximize grow is visible (no conflicting shrink-then-grow flash).
+    // Capture the fullscreen window's current on-screen rect first so the maximize
+    // grow eases from full-screen down to the maximized rect, rather than snapping to
+    // the small windowed size between exit and grow.
+    let mut from_override = None;
+    if let Some(fs_id) = st
+        .model
+        .fullscreen_state
+        .fullscreen_active_node
+        .get(monitor)
+        .copied()
+    {
+        if fs_id == id {
+            from_override =
+                crate::compositor::fullscreen::system::fullscreen_visual_for_node_on_monitor_at(
+                    st, fs_id, monitor, now,
+                );
+        }
+        st.exit_xdg_fullscreen_no_anim(fs_id, now);
     }
 
     let Some(target_snapshot) = maximize_snapshot_for_node(st, id) else {
@@ -575,7 +578,7 @@ fn start_maximize_session(st: &mut Halley, id: NodeId, monitor: &str, now: Insta
             state: crate::compositor::workspace::state::MaximizeSessionState::Active,
         },
     );
-    start_active_maximize_session(st, id, monitor, &node_snapshots, now)
+    start_active_maximize_session(st, id, monitor, &node_snapshots, from_override, now)
 }
 
 pub(crate) fn toggle_focused_maximize_node_state(st: &mut Halley) -> bool {
@@ -631,9 +634,7 @@ pub(crate) fn toggle_node_maximize_state(
     if st.node_user_pinned(id) {
         return false;
     }
-    if crate::compositor::surface::is_active_cluster_workspace_member(st, id)
-        || st.is_fullscreen_active(id)
-    {
+    if crate::compositor::surface::is_active_cluster_workspace_member(st, id) {
         return false;
     }
 

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -297,8 +297,13 @@ mod tests {
         assert_eq!(anim.monitor, "monitor_a");
         assert_eq!(anim.from_pos, Vec2 { x: 140.0, y: 150.0 });
         assert_eq!(anim.from_size, Vec2 { x: 320.0, y: 240.0 });
-        assert_eq!(anim.to_pos, Vec2 { x: 400.0, y: 300.0 });
+        // The window grows in place (centred on itself); the camera recentres onto
+        // it, so the fill target is the window's own position, not the monitor centre.
+        assert_eq!(anim.to_pos, Vec2 { x: 140.0, y: 150.0 });
         assert_eq!(anim.to_size, Vec2 { x: 800.0, y: 600.0 });
+        // The camera is retargeted to centre on the window at zoom 1.0.
+        assert_eq!(state.model.camera_target_center, Vec2 { x: 140.0, y: 150.0 });
+        assert_eq!(state.model.camera_target_view_size, Vec2 { x: 800.0, y: 600.0 });
     }
 
     #[test]
@@ -348,7 +353,8 @@ mod tests {
         let (mid_pos, mid_size) =
             fullscreen_visual_for_node_on_current_monitor_at(&state, fullscreen, mid)
                 .expect("mid visual");
-        assert!(mid_pos.x > 140.0 && mid_pos.x < 400.0);
+        // Grows in place: the centre stays put while only the size eases up.
+        assert_eq!(mid_pos, Vec2 { x: 140.0, y: 150.0 });
         assert!(mid_size.x > 320.0 && mid_size.x < 800.0);
 
         state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
@@ -358,7 +364,7 @@ mod tests {
             now + std::time::Duration::from_millis(260),
         )
         .expect("end visual");
-        assert_eq!(end_pos, Vec2 { x: 400.0, y: 300.0 });
+        assert_eq!(end_pos, Vec2 { x: 140.0, y: 150.0 });
         assert_eq!(end_size, Vec2 { x: 800.0, y: 600.0 });
         assert!(
             !state
@@ -405,7 +411,8 @@ mod tests {
             .get(&fullscreen)
             .expect("exit animation");
         assert_eq!(anim.monitor, "monitor_a");
-        assert_eq!(anim.from_pos, Vec2 { x: 400.0, y: 300.0 });
+        // Shrinks in place at the window's own centre (the grow did the same).
+        assert_eq!(anim.from_pos, Vec2 { x: 140.0, y: 150.0 });
         assert_eq!(anim.from_size, Vec2 { x: 800.0, y: 600.0 });
         assert_eq!(anim.to_pos, Vec2 { x: 140.0, y: 150.0 });
         assert_eq!(anim.to_size, Vec2 { x: 320.0, y: 240.0 });
@@ -415,7 +422,7 @@ mod tests {
         let (mid_pos, mid_size) =
             fullscreen_visual_for_node_on_current_monitor_at(&state, fullscreen, mid)
                 .expect("mid exit visual");
-        assert!(mid_pos.x > 140.0 && mid_pos.x < 400.0);
+        assert_eq!(mid_pos, Vec2 { x: 140.0, y: 150.0 });
         assert!(mid_size.x > 320.0 && mid_size.x < 800.0);
 
         // Once it expires the override is gone and the window rests at restored geometry.
@@ -923,12 +930,32 @@ pub(crate) fn fullscreen_visual_for_node_on_monitor_at(
         .copied()
         == Some(node_id))
     .then(|| {
-        st.model
+        // Centre the fullscreen window on its OWN position (the camera is recentred
+        // onto it on entry), at the monitor's native size. Anchoring to the node's
+        // centre rather than the live camera centre keeps the steady-state rect
+        // consistent with the grow/shrink animation's endpoint, so there's no jump
+        // when the animation expires while the camera is still easing in.
+        let size = st
+            .model
             .monitor_state
             .monitors
             .get(monitor)
-            .map(|space| (space.viewport.center, space.viewport.size))
-            .unwrap_or((st.model.viewport.center, st.model.viewport.size))
+            .map(|space| space.viewport.size)
+            .unwrap_or(st.model.viewport.size);
+        let center = st
+            .model
+            .field
+            .node(node_id)
+            .map(|node| node.pos)
+            .unwrap_or_else(|| {
+                st.model
+                    .monitor_state
+                    .monitors
+                    .get(monitor)
+                    .map(|space| space.viewport.center)
+                    .unwrap_or(st.model.viewport.center)
+            });
+        (center, size)
     })
 }
 
@@ -982,17 +1009,6 @@ fn fullscreen_monitor_view(st: &Halley, monitor_name: &str) -> (Vec2, Vec2) {
         .get(monitor_name)
         .map(|monitor| (monitor.viewport.center, monitor.viewport.size))
         .unwrap_or((st.model.viewport.center, st.model.viewport.size))
-}
-
-fn reset_monitor_zoom_once(st: &mut Halley, monitor_name: &str) {
-    if let Some(monitor) = st.model.monitor_state.monitors.get_mut(monitor_name) {
-        monitor.zoom_ref_size = monitor.viewport.size;
-        monitor.camera_target_view_size = monitor.viewport.size;
-    }
-    if st.model.monitor_state.current_monitor == monitor_name {
-        st.model.zoom_ref_size = st.model.viewport.size;
-        st.model.camera_target_view_size = st.model.viewport.size;
-    }
 }
 
 fn fullscreen_target_size_for(st: &Halley, monitor_name: &str) -> (i32, i32) {
@@ -1425,12 +1441,22 @@ fn enter_fullscreen(
         .entry(monitor_name.clone())
         .or_insert(pre_fullscreen_camera);
 
-    // One-time reset of the target monitor's zoom to 1.0. Do not hold or lock it.
-    reset_monitor_zoom_once(st, monitor_name.as_str());
-
     let Some(node) = st.model.field.node(node_id).cloned() else {
         return;
     };
+
+    // Animate the monitor camera to centre on the window AND ease the zoom to 1.0
+    // together, so the window grows in place to fill the screen. The old behaviour
+    // snapped the zoom to 1.0 about the (off-window) camera centre, which shoved
+    // every windowed node behind it sideways by the zoom delta.
+    crate::compositor::workspace::state::set_monitor_camera_target_snapshot(
+        st,
+        monitor_name.as_str(),
+        crate::compositor::workspace::state::MaximizeCameraSnapshot {
+            center: node.pos,
+            view_size: viewport_size,
+        },
+    );
 
     let soft_resume_entry = soft_resume
         .then(|| {
@@ -1499,7 +1525,9 @@ fn enter_fullscreen(
             crate::compositor::fullscreen::state::FullscreenScaleAnim {
                 monitor: monitor_name.clone(),
                 from_pos: from.0,
-                to_pos: viewport_center,
+                // Grow in place (centred on the window itself), matching the camera
+                // recentring above — not toward the old camera centre.
+                to_pos: node.pos,
                 from_size: from.1,
                 to_size: viewport_size,
                 start_ms,

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -1151,6 +1151,13 @@ fn exit_xdg_fullscreen_inner(
         None => return, // not active fullscreen on any monitor
     };
 
+    // Invalidate the offscreen texture so the next capture (Apogee/Alt+Tab or the
+    // main render path) rebuilds it at the post-fullscreen geometry instead of
+    // reusing the fullscreen-sized snapshot for a now-windowed surface.
+    st.ui
+        .render_state
+        .clear_window_offscreen_cache_for(node_id);
+
     st.model
         .fullscreen_state
         .clear_direct_scanout_for_monitor(&monitor_name);
@@ -1444,6 +1451,16 @@ fn enter_fullscreen(
     let Some(node) = st.model.field.node(node_id).cloned() else {
         return;
     };
+
+    // Invalidate any stale windowed offscreen texture so the next Apogee/Alt+Tab
+    // capture rebuilds it at the fullscreen surface geometry instead of reusing
+    // the smaller windowed snapshot. Defense-in-depth: the offscreen cache also
+    // self-heals on size change (`ensure_window_offscreen_cache` → `matches_size`).
+    // NOTE: this does NOT fix the live field render — that corruption is the scale
+    // math using stale CSD geometry, handled by `render_window_geometry_for_node`.
+    st.ui
+        .render_state
+        .clear_window_offscreen_cache_for(node_id);
 
     // Animate the monitor camera to centre on the window AND ease the zoom to 1.0
     // together, so the window grows in place to fill the screen. The old behaviour

--- a/crates/halley-wl/src/compositor/fullscreen/system.rs
+++ b/crates/halley-wl/src/compositor/fullscreen/system.rs
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn fullscreen_roundtrip_preserves_active_maximize_session() {
+    fn fullscreen_and_maximize_are_mutually_exclusive() {
         let dh = Display::<Halley>::new().expect("display").handle();
         let mut tuning = single_monitor_tuning();
         tuning.animations.maximize.enabled = false;
@@ -803,48 +803,147 @@ mod tests {
             .expect("target")
             .intrinsic_size;
 
-        assert!(
-            crate::compositor::actions::window::toggle_node_maximize_state(
-                &mut state,
-                target,
-                now,
-                "monitor_a"
-            )
-        );
-        let maximized = state.model.field.node(target).expect("target").clone();
-        assert_eq!(maximized.pos, original_pos);
-        assert_eq!(maximized.intrinsic_size, original_size);
-        assert!(
-            crate::compositor::workspace::state::maximize_session_active_on_monitor(
-                &state,
-                "monitor_a"
-            )
-        );
+        // Maximize the window.
+        assert!(crate::compositor::actions::window::toggle_node_maximize_state(
+            &mut state,
+            target,
+            now,
+            "monitor_a"
+        ));
+        assert!(crate::compositor::workspace::state::maximize_session_active_on_monitor(
+            &state,
+            "monitor_a"
+        ));
 
+        // Fullscreening the same window must abort the maximize session (mutual
+        // exclusivity per monitor), not preserve it underneath.
         state.enter_xdg_fullscreen(target, None, now + std::time::Duration::from_millis(20));
-        assert!(
-            crate::compositor::workspace::state::maximize_session_active_on_monitor(
-                &state,
-                "monitor_a"
-            )
-        );
+        assert!(!crate::compositor::workspace::state::maximize_session_active_on_monitor(
+            &state,
+            "monitor_a"
+        ));
+        assert!(state.is_fullscreen_active(target));
         state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
 
+        // Exiting fullscreen returns to the pre-maximize geometry — the maximize
+        // session was aborted on fullscreen entry, so it does not resume.
         state.exit_xdg_fullscreen(target, now + std::time::Duration::from_millis(300));
         state.tick_fullscreen_motion(now + std::time::Duration::from_millis(700));
 
         let restored = state.model.field.node(target).expect("target");
-        assert_eq!(restored.pos, maximized.pos);
-        assert_eq!(restored.intrinsic_size, maximized.intrinsic_size);
-        assert!(
-            crate::compositor::workspace::state::maximize_session_active_on_monitor(
-                &state,
-                "monitor_a"
-            )
-        );
         assert_eq!(restored.pos, original_pos);
         assert_eq!(restored.intrinsic_size, original_size);
+        assert!(!crate::compositor::workspace::state::maximize_session_active_on_monitor(
+            &state,
+            "monitor_a"
+        ));
         assert!(!restored.pinned);
+    }
+
+    #[test]
+    fn maximize_fullscreen_maximize_unmaximize_restores_windowed_size() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let tuning = single_monitor_tuning();
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let now = Instant::now();
+
+        let target = state.model.field.spawn_surface(
+            "browser",
+            Vec2 { x: 120.0, y: 140.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        state.assign_node_to_monitor(target, "monitor_a");
+        let original_pos = state.model.field.node(target).expect("target").pos;
+        let original_size = state
+            .model
+            .field
+            .node(target)
+            .expect("target")
+            .intrinsic_size;
+
+        // 1. maximize
+        assert!(crate::compositor::actions::window::toggle_node_maximize_state(
+            &mut state, target, now, "monitor_a"
+        ));
+        // Simulate the real client whose committed surface geometry lags behind: the
+        // `window_geometry` cache still reports a large (maximized/fullscreen) size that
+        // the client has not yet shrunk. This is captured as the fullscreen restore's
+        // `window_geometry` and re-applied on exit, so on the re-maximize below
+        // `current_surface_size_for_node` would report this stale large size. The
+        // re-maximize must instead trust the windowed size pinned into `resize_footprint`.
+        state
+            .ui
+            .render_state
+            .cache
+            .window_geometry
+            .insert(target, (0.0, 0.0, 1920.0, 1080.0));
+        // 2. fullscreen
+        state.enter_xdg_fullscreen(target, None, now + std::time::Duration::from_millis(20));
+        state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
+        assert!(state.is_fullscreen_active(target));
+        // 3. maximize again (must exit fullscreen, re-snapshot the *windowed* size)
+        assert!(crate::compositor::actions::window::toggle_node_maximize_state(
+            &mut state,
+            target,
+            now + std::time::Duration::from_millis(300),
+            "monitor_a"
+        ));
+        assert!(!state.is_fullscreen_active(target));
+        state.tick_fullscreen_motion(now + std::time::Duration::from_millis(560));
+        // 4. unmaximize
+        assert!(crate::compositor::actions::window::toggle_node_maximize_state(
+            &mut state,
+            target,
+            now + std::time::Duration::from_millis(600),
+            "monitor_a"
+        ));
+
+        let restored = state.model.field.node(target).expect("target");
+        assert_eq!(restored.pos, original_pos, "pos must return to windowed");
+        assert_eq!(
+            restored.intrinsic_size, original_size,
+            "size must return to windowed, not stay maximized"
+        );
+    }
+
+    #[test]
+    fn maximize_exits_active_fullscreen_on_same_monitor() {
+        let dh = Display::<Halley>::new().expect("display").handle();
+        let mut tuning = single_monitor_tuning();
+        tuning.animations.maximize.enabled = false;
+        let mut state = Halley::new_for_test(&dh, tuning);
+        let now = Instant::now();
+
+        let a = state.model.field.spawn_surface(
+            "game",
+            Vec2 { x: 100.0, y: 100.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        let b = state.model.field.spawn_surface(
+            "terminal",
+            Vec2 { x: 500.0, y: 100.0 },
+            Vec2 { x: 320.0, y: 240.0 },
+        );
+        state.assign_node_to_monitor(a, "monitor_a");
+        state.assign_node_to_monitor(b, "monitor_a");
+
+        // Fullscreen window A.
+        state.enter_xdg_fullscreen(a, None, now);
+        state.tick_fullscreen_motion(now + std::time::Duration::from_millis(260));
+        assert!(state.is_fullscreen_active(a));
+
+        // Maximizing window B must exit A's fullscreen (mutual exclusivity).
+        assert!(crate::compositor::actions::window::toggle_node_maximize_state(
+            &mut state,
+            b,
+            now + std::time::Duration::from_millis(300),
+            "monitor_a"
+        ));
+        assert!(!state.is_fullscreen_active(a));
+        assert!(crate::compositor::workspace::state::maximize_session_active_on_monitor(
+            &state,
+            "monitor_a"
+        ));
     }
 }
 
@@ -1144,6 +1243,7 @@ fn exit_xdg_fullscreen_inner(
     now: Instant,
     suspend: bool,
     preserve_client_fullscreen: bool,
+    skip_animation: bool,
 ) {
     // Find which monitor this node is fullscreened on.
     let monitor_name = match fullscreen_monitor_for_node(st, node_id) {
@@ -1218,6 +1318,7 @@ fn exit_xdg_fullscreen_inner(
     // ease from it (the node leaves active state below).
     let should_animate = !suspend
         && !preserve_client_fullscreen
+        && !skip_animation
         && st.runtime.tuning.fullscreen_animation_enabled()
         && st.model.monitor_state.current_monitor == monitor_name;
     let exit_anim_from = should_animate.then(|| {
@@ -1306,7 +1407,7 @@ fn exit_xdg_fullscreen_inner(
 }
 
 pub(crate) fn soft_suspend_xdg_fullscreen(st: &mut Halley, node_id: NodeId, now: Instant) {
-    exit_xdg_fullscreen_inner(st, node_id, now, true, true);
+    exit_xdg_fullscreen_inner(st, node_id, now, true, true, false);
 }
 
 fn restore_fullscreen_snapshot(
@@ -1318,7 +1419,20 @@ fn restore_fullscreen_snapshot(
         node.pos = entry.pos;
         node.intrinsic_size = entry.intrinsic_size;
     }
+    // Reset the footprint to the restored intrinsic size first (this also clears any
+    // stale `resize_footprint`), THEN pin `resize_footprint` to the restored windowed
+    // size so it survives. `sync_active_footprint_to_intrinsic` sets `resize_footprint
+    // = None`, so doing it the other way around wipes the value we need: until the
+    // client commits the windowed resize, `current_surface_size_for_node` still reports
+    // the fullscreen geometry, and `current_window_size_for_node` prefers
+    // `resize_footprint` over that stale surface size. Without this, exiting fullscreen
+    // straight into a maximize snapshots the fullscreen size and "restores" to it on
+    // unmaximize.
     let _ = st.model.field.sync_active_footprint_to_intrinsic(id);
+    let _ = st
+        .model
+        .field
+        .set_resize_footprint(id, Some(entry.intrinsic_size));
     if let Some(loc) = entry.bbox_loc {
         st.ui.render_state.cache.bbox_loc.insert(id, loc);
     } else {
@@ -1433,6 +1547,39 @@ fn enter_fullscreen(
         exit_xdg_fullscreen(st, existing, now);
     }
 
+    // Maximize and fullscreen are mutually exclusive on a monitor: abort any active
+    // maximize session before taking over. This must precede the pre-fullscreen camera
+    // capture below so exit-fullscreen returns to the pre-maximize view.
+    // Capture the node's pre-maximize geometry first: after the abort the surface
+    // buffer is still at the (larger) maximize size until the client commits the
+    // resize, so `current_surface_size_for_node` would return a stale size for
+    // `fullscreen_restore`. The snapshot has the true original windowed size.
+    let maximize_pre_size = st
+        .model
+        .workspace_state
+        .maximize_sessions
+        .get(monitor_name.as_str())
+        .and_then(|session| session.node_snapshots.get(&node_id))
+        .map(|snapshot| snapshot.size);
+    // Also capture the maximized window's current on-screen rect before the abort, so
+    // the fullscreen grow eases from the maximized rect up to full-screen instead of
+    // snapping to the small windowed size first (the abort restores windowed geometry).
+    let maximize_pre_visual = crate::compositor::workspace::state::maximized_visual_for_node_on_monitor_at(
+        st,
+        node_id,
+        monitor_name.as_str(),
+        now,
+    );
+    if crate::compositor::workspace::state::maximize_session_active_on_monitor(
+        st,
+        monitor_name.as_str(),
+    ) {
+        let _ = crate::compositor::workspace::state::abort_maximize_session_for_monitor(
+            st,
+            monitor_name.as_str(),
+        );
+    }
+
     let target_size = fullscreen_target_size_for(st, monitor_name.as_str());
     let (viewport_center, viewport_size) = fullscreen_monitor_view(st, monitor_name.as_str());
     clear_non_target_fullscreen_restore_entries(st, &monitor_name, node_id);
@@ -1486,6 +1633,7 @@ fn enter_fullscreen(
         .flatten();
     let saved_size = soft_resume_entry
         .map(|entry| entry.size)
+        .or(maximize_pre_size)
         .unwrap_or_else(|| {
             crate::compositor::surface::current_surface_size_for_node(st, node_id)
                 .unwrap_or(node.intrinsic_size)
@@ -1525,15 +1673,20 @@ fn enter_fullscreen(
     );
     if st.runtime.tuning.fullscreen_animation_enabled() && !soft_resume {
         st.request_window_animation_prewarm(node_id, now);
-        let from = (st.model.monitor_state.current_monitor == monitor_name)
-            .then(|| {
-                crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
-                    st,
-                    node_id,
-                    now,
-                )
+        // Prefer the maximized window's pre-abort rect (captured above) so a
+        // maximize→fullscreen grows smoothly from maximized to full-screen. The abort
+        // has already torn down the maximize session, so re-querying it here returns
+        // nothing — hence capturing before the abort.
+        let from = maximize_pre_visual
+            .or_else(|| {
+                (st.model.monitor_state.current_monitor == monitor_name)
+                    .then(|| {
+                        crate::compositor::workspace::state::maximized_visual_for_node_on_current_monitor_at(
+                            st, node_id, now,
+                        )
+                    })
+                    .flatten()
             })
-            .flatten()
             .unwrap_or((saved_pos, saved_size));
         let start_ms = st.now_ms(now);
         let duration_ms = st.runtime.tuning.fullscreen_animation_duration_ms();
@@ -1575,6 +1728,21 @@ fn enter_fullscreen(
 }
 
 pub(crate) fn exit_xdg_fullscreen(st: &mut Halley, node_id: NodeId, now: Instant) {
+    resume_and_clear_fullscreen_suspended_state(st, node_id);
+    exit_xdg_fullscreen_inner(st, node_id, now, false, false, false);
+}
+
+/// Exit fullscreen without the shrink animation — used when transitioning directly
+/// to maximize so the maximize grow animation is the only visible motion (no
+/// conflicting shrink-then-grow flash).
+pub(crate) fn exit_xdg_fullscreen_no_anim(st: &mut Halley, node_id: NodeId, now: Instant) {
+    resume_and_clear_fullscreen_suspended_state(st, node_id);
+    exit_xdg_fullscreen_inner(st, node_id, now, false, false, true);
+}
+
+/// Promote a soft-suspended fullscreen node back to active and clear the suspended
+/// entry, so the inner exit processes it as a genuine active-fullscreen exit.
+fn resume_and_clear_fullscreen_suspended_state(st: &mut Halley, node_id: NodeId) {
     if !is_fullscreen_active(st, node_id)
         && let Some(monitor) =
             fullscreen_suspended_monitor_for_node(st, node_id).map(str::to_string)
@@ -1595,7 +1763,6 @@ pub(crate) fn exit_xdg_fullscreen(st: &mut Halley, node_id: NodeId, now: Instant
             .fullscreen_suspended_node
             .remove(&monitor);
     }
-    exit_xdg_fullscreen_inner(st, node_id, now, false, false);
 }
 
 pub(crate) fn drop_fullscreen_surface(st: &mut Halley, id: NodeId, _now: Instant) {

--- a/crates/halley-wl/src/compositor/interaction/state.rs
+++ b/crates/halley-wl/src/compositor/interaction/state.rs
@@ -367,6 +367,12 @@ pub(crate) struct InteractionState {
     /// Used by `flush_stuck_forwarded_keys` to clear stale non-modifier keys on a
     /// focus change so the next focused surface never inherits a stuck repeat.
     pub(crate) forwarded_pressed_keys: HashSet<u32>,
+    /// Ground truth of which keycodes are *physically* down right now, updated from the
+    /// raw libinput key events at the very top of `handle_keyboard_input` before any
+    /// modal routing. `reconcile_forwarded_keys` releases any `forwarded_pressed_keys`
+    /// entry missing here, so a key whose release was swallowed (by a modal, a dead
+    /// surface, a deferred focus) can never leave a client stuck repeating.
+    pub(crate) keys_physically_down: HashSet<u32>,
     pub(crate) pending_modal_focus_restore: Option<PendingModalFocusRestore>,
     pub(crate) focus_cycle_session: Option<FocusCycleSession>,
     pub(crate) active_gesture_route: Option<ActiveGestureRoute>,

--- a/crates/halley-wl/src/compositor/overlap/system/mod.rs
+++ b/crates/halley-wl/src/compositor/overlap/system/mod.rs
@@ -126,7 +126,12 @@ fn mixed_expanded_landmark_locks(
                 (a_locked, true)
             }
         } else {
-            (true, b_locked)
+            // Passive (idle / zoom): treat the landmark as the fixed reference and make
+            // the window yield. A marker boxed between two windows can't move to satisfy
+            // both, so locking the window and moving the marker leaves it overlapping;
+            // locking the marker pushes the windows apart to open its keep-out gap. The
+            // gap is screen-constant, so this keeps the marker clear at every zoom.
+            (a_locked, true)
         }
     } else if b_expanded && a_landmark {
         let a_pinned = st.model.field.node(a).is_some_and(|node| node.pinned);
@@ -142,7 +147,8 @@ fn mixed_expanded_landmark_locks(
                 (true, b_locked)
             }
         } else {
-            (a_locked, true)
+            // Passive: mirror of the branch above — lock the landmark, move the window.
+            (true, b_locked)
         }
     } else {
         (a_locked, b_locked)

--- a/crates/halley-wl/src/compositor/overlap/system/tests.rs
+++ b/crates/halley-wl/src/compositor/overlap/system/tests.rs
@@ -101,7 +101,7 @@ fn new_expanded_window_does_not_displace_existing_expanded_window() {
 }
 
 #[test]
-fn active_window_pushes_unpinned_collapsed_node() {
+fn active_window_yields_to_unpinned_collapsed_node() {
     let mut tuning = halley_config::RuntimeTuning::default();
     tuning.physics_enabled = false;
     let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
@@ -130,11 +130,15 @@ fn active_window_pushes_unpinned_collapsed_node() {
 
     state.resolve_surface_overlap();
 
-    assert_eq!(
+    // Landmarks (nodes/cores) are fixed reference points: in passive overlap the node
+    // stays and the window yields, so a marker boxed between windows is never pushed
+    // under them (it would have no room to escape). Pinning is no longer required for
+    // this — it now only matters for drag carry behaviour.
+    assert_eq!(state.model.field.node(node).expect("node").pos, node_pos);
+    assert_ne!(
         state.model.field.node(window).expect("window").pos,
         window_pos
     );
-    assert_ne!(state.model.field.node(node).expect("node").pos, node_pos);
     assert!(!nodes_overlap(&state, window, node));
 }
 
@@ -1257,11 +1261,13 @@ fn idle_overlap_settles_active_surface_and_node() {
 
     tick_overlap_frames(&mut state, 96);
 
-    assert_eq!(
+    // The landmark node is the fixed reference: it stays put and the window yields,
+    // so a marker is never shoved around by (or boxed under) neighbouring windows.
+    assert_eq!(state.model.field.node(node).expect("node").pos, node_pos);
+    assert_ne!(
         state.model.field.node(active).expect("active").pos,
         active_pos
     );
-    assert_ne!(state.model.field.node(node).expect("node").pos, node_pos);
     assert!(!nodes_overlap(&state, active, node));
 }
 

--- a/crates/halley-wl/src/compositor/overview.rs
+++ b/crates/halley-wl/src/compositor/overview.rs
@@ -583,6 +583,221 @@ pub(crate) fn apogee_region_for_point(screen_h: i32, sy: f32) -> ApogeeInteracti
     }
 }
 
+/// Global (cross-monitor) origin of a monitor in screen space.
+fn apogee_monitor_global_offset(st: &Halley, monitor: &str) -> (f32, f32) {
+    st.model
+        .monitor_state
+        .monitors
+        .get(monitor)
+        .map(|space| (space.offset_x as f32, space.offset_y as f32))
+        .unwrap_or((0.0, 0.0))
+}
+
+/// On-screen *local* center of an apogee tile within its monitor, using the same
+/// projection as `apogee_tile_at` (Open phase) so a cursor warped here lands on the
+/// tile. Returns `None` if the node isn't a tile in this session.
+fn apogee_tile_local_center(
+    monitor_session: &ApogeeMonitorSession,
+    screen_w: i32,
+    node_id: NodeId,
+) -> Option<(f32, f32)> {
+    if let Some(tile) = monitor_session
+        .core_tiles
+        .iter()
+        .find(|tile| tile.node_id == node_id)
+    {
+        let p = apogee_project_core_rect(
+            tile.to,
+            monitor_session.core_scroll_offset,
+            monitor_session.core_atlas_width,
+            screen_w,
+            0,
+        );
+        return Some((p.rect.cx, p.rect.cy));
+    }
+    monitor_session
+        .tiles
+        .iter()
+        .find(|tile| tile.node_id == node_id && matches!(tile.kind, ApogeeTileKind::Window))
+        .map(|tile| (tile.to.cx, tile.to.cy))
+}
+
+/// Global screen center of an apogee tile (any monitor). Mirrors the on-screen
+/// projection so the keyboard warp drops the cursor exactly onto the tile.
+pub(crate) fn apogee_tile_global_center(st: &Halley, node_id: NodeId) -> Option<(f32, f32)> {
+    let session = st.input.interaction_state.apogee_session.as_ref()?;
+    for monitor_session in &session.monitors {
+        let screen_w = st
+            .model
+            .monitor_state
+            .monitors
+            .get(&monitor_session.monitor)
+            .map(|space| space.width)
+            .unwrap_or(1);
+        if let Some((lx, ly)) = apogee_tile_local_center(monitor_session, screen_w, node_id) {
+            let (ox, oy) = apogee_monitor_global_offset(st, &monitor_session.monitor);
+            return Some((lx + ox, ly + oy));
+        }
+    }
+    None
+}
+
+/// Pick the next apogee tile to move the cursor to when navigating with the arrow keys.
+/// Every monitor's window mosaic and (scrolled) core rail are flattened into one
+/// **global** screen field, so navigation crosses monitor boundaries naturally (no wrap)
+/// and `Up`/`Down` step between the mosaic and the core rail. Navigation starts from the
+/// live cursor position (the single source of truth — same as mouse hover) and excludes
+/// the tile already under the cursor so each press advances.
+pub(crate) fn apogee_navigate(
+    st: &Halley,
+    dir: halley_config::DirectionalAction,
+) -> Option<NodeId> {
+    use halley_config::DirectionalAction as D;
+    let session = st.input.interaction_state.apogee_session.as_ref()?;
+    let (cx, cy) = st
+        .input
+        .interaction_state
+        .last_pointer_screen_global
+        .unwrap_or_else(|| {
+            let monitor = st.model.monitor_state.current_monitor.clone();
+            let (ox, oy) = apogee_monitor_global_offset(st, &monitor);
+            let (w, h) = st
+                .model
+                .monitor_state
+                .monitors
+                .get(&monitor)
+                .map(|space| (space.width as f32, space.height as f32))
+                .unwrap_or((1.0, 1.0));
+            (ox + w * 0.5, oy + h * 0.5)
+        });
+    let exclude = st.input.interaction_state.apogee_hover_node;
+
+    // (node, global_cx, global_cy) for every selectable tile across all monitors.
+    let mut cands: Vec<(NodeId, f32, f32)> = Vec::new();
+    for monitor_session in &session.monitors {
+        let screen_w = st
+            .model
+            .monitor_state
+            .monitors
+            .get(&monitor_session.monitor)
+            .map(|space| space.width)
+            .unwrap_or(1);
+        let (ox, oy) = apogee_monitor_global_offset(st, &monitor_session.monitor);
+        for tile in &monitor_session.core_tiles {
+            if Some(tile.node_id) == exclude {
+                continue;
+            }
+            let p = apogee_project_core_rect(
+                tile.to,
+                monitor_session.core_scroll_offset,
+                monitor_session.core_atlas_width,
+                screen_w,
+                0,
+            );
+            cands.push((tile.node_id, p.rect.cx + ox, p.rect.cy + oy));
+        }
+        for tile in monitor_session
+            .tiles
+            .iter()
+            .filter(|tile| matches!(tile.kind, ApogeeTileKind::Window))
+        {
+            if Some(tile.node_id) == exclude {
+                continue;
+            }
+            cands.push((tile.node_id, tile.to.cx + ox, tile.to.cy + oy));
+        }
+    }
+
+    // Keep tiles strictly in the travel direction; score primary-axis distance plus a
+    // perpendicular penalty so the nearest aligned tile wins. Track the nearest tile
+    // overall too, to seed the very first press when the cursor isn't over any tile.
+    let mut best: Option<(f32, NodeId)> = None;
+    let mut nearest: Option<(f32, NodeId)> = None;
+    for (id, gx, gy) in cands {
+        let dx = gx - cx;
+        let dy = gy - cy;
+        let dist2 = dx * dx + dy * dy;
+        if nearest.is_none_or(|(b, _)| dist2 < b) {
+            nearest = Some((dist2, id));
+        }
+        let (primary, perp) = match dir {
+            D::Left => (-dx, dy.abs()),
+            D::Right => (dx, dy.abs()),
+            D::Up => (-dy, dx.abs()),
+            D::Down => (dy, dx.abs()),
+        };
+        if primary <= 1.0 {
+            continue;
+        }
+        let cost = primary + perp * 2.0;
+        if best.is_none_or(|(b, _)| cost < b) {
+            best = Some((cost, id));
+        }
+    }
+    best.map(|(_, id)| id).or_else(|| {
+        // Nothing in the travel direction: only seed from the nearest tile when the
+        // cursor isn't already on a tile (so a dead-end press at an edge is a no-op).
+        exclude.is_none().then(|| nearest.map(|(_, id)| id)).flatten()
+    })
+}
+
+/// Scroll the core rail of whichever monitor owns `node_id` so the core is on screen.
+/// No-op for window tiles. Run after navigation lands on a (possibly scrolled-off) core,
+/// before warping the cursor to it.
+pub(crate) fn apogee_reveal_tile(st: &mut Halley, node_id: NodeId) {
+    let monitor = st.input.interaction_state.apogee_session.as_ref().and_then(|session| {
+        session
+            .monitors
+            .iter()
+            .find(|ms| ms.core_tiles.iter().any(|tile| tile.node_id == node_id))
+            .map(|ms| ms.monitor.clone())
+    });
+    if let Some(monitor) = monitor {
+        apogee_reveal_core(st, monitor.as_str(), node_id);
+    }
+}
+
+/// Scroll the core rail so the given core tile is fully visible. No-op for window tiles
+/// or when the rail can't scroll. Used after keyboard navigation lands on an off-screen
+/// core so the selection is always on screen.
+fn apogee_reveal_core(st: &mut Halley, monitor: &str, node_id: NodeId) {
+    let screen_w = st
+        .model
+        .monitor_state
+        .monitors
+        .get(monitor)
+        .map(|space| space.width.max(1) as f32)
+        .unwrap_or(1.0);
+    let Some(session) = st.input.interaction_state.apogee_session.as_mut() else {
+        return;
+    };
+    let Some(monitor_session) = session.monitor_session_mut(monitor) else {
+        return;
+    };
+    let max_offset = (monitor_session.core_atlas_width - screen_w).max(0.0);
+    if max_offset <= 0.5 {
+        return;
+    }
+    let Some(tile) = monitor_session
+        .core_tiles
+        .iter()
+        .find(|tile| tile.node_id == node_id)
+    else {
+        return;
+    };
+    let half_w = tile.to.w * 0.5;
+    let left = tile.to.cx - half_w;
+    let right = tile.to.cx + half_w;
+    let margin = 24.0;
+    let mut offset = monitor_session.core_scroll_offset;
+    if left - offset < margin {
+        offset = left - margin;
+    } else if right - offset > screen_w - margin {
+        offset = right - screen_w + margin;
+    }
+    monitor_session.core_scroll_offset = offset.clamp(0.0, max_offset);
+}
+
 /// Begin closing Apogee with a pending selection. The selected tile is raised to
 /// the top of the draw order for the close animation, and the actual focus /
 /// activation is deferred until the close animation finishes (via `tick_apogee`)
@@ -644,8 +859,9 @@ pub(crate) fn activate_apogee_target(st: &mut Halley, node_id: NodeId, now: Inst
         }
     }
 
-    if crate::compositor::actions::window::focus_from_presentation_navigation(st, node_id, now)
-        || crate::compositor::actions::window::focus_or_reveal_surface_node(st, node_id, now)
+    if crate::compositor::actions::window::focus_from_presentation_navigation_switching(
+        st, node_id, now,
+    ) || crate::compositor::actions::window::focus_or_reveal_surface_node(st, node_id, now)
     {
         return;
     }
@@ -1754,7 +1970,7 @@ mod tests {
     }
 
     #[test]
-    fn apogee_activation_can_raise_visible_target_above_fullscreen() {
+    fn apogee_activation_switches_from_fullscreen_to_adjacent_window() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -1777,12 +1993,14 @@ mod tests {
 
         activate_apogee_target(&mut state, target, now);
 
-        assert!(state.is_fullscreen_active(fullscreen));
+        // Selecting a window that is not already floating above the fullscreen
+        // leaves fullscreen (soft-suspended) and switches focus to it — one action,
+        // no second select needed.
+        assert!(!state.is_fullscreen_active(fullscreen));
         assert_eq!(
             state.model.focus_state.primary_interaction_focus,
             Some(target)
         );
-        assert!(state.node_draws_above_fullscreen_on_monitor(target, monitor.as_str()));
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/overview.rs
+++ b/crates/halley-wl/src/compositor/overview.rs
@@ -859,7 +859,7 @@ pub(crate) fn activate_apogee_target(st: &mut Halley, node_id: NodeId, now: Inst
         }
     }
 
-    if crate::compositor::actions::window::focus_from_presentation_navigation_switching(
+    if crate::compositor::actions::window::focus_from_presentation_navigation(
         st, node_id, now,
     ) || crate::compositor::actions::window::focus_or_reveal_surface_node(st, node_id, now)
     {
@@ -1970,7 +1970,7 @@ mod tests {
     }
 
     #[test]
-    fn apogee_activation_switches_from_fullscreen_to_adjacent_window() {
+    fn apogee_activation_raises_visible_target_above_fullscreen() {
         let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
             .expect("display")
             .handle();
@@ -1993,14 +1993,15 @@ mod tests {
 
         activate_apogee_target(&mut state, target, now);
 
-        // Selecting a window that is not already floating above the fullscreen
-        // leaves fullscreen (soft-suspended) and switches focus to it — one action,
-        // no second select needed.
-        assert!(!state.is_fullscreen_active(fullscreen));
+        // Selecting a window in Apogee raises it above the fullscreen but does NOT
+        // exit the fullscreen — only an explicit fullscreen/maximize action on the
+        // target triggers mutual exclusivity.
+        assert!(state.is_fullscreen_active(fullscreen));
         assert_eq!(
             state.model.focus_state.primary_interaction_focus,
             Some(target)
         );
+        assert!(state.node_draws_above_fullscreen_on_monitor(target, monitor.as_str()));
     }
 
     #[test]

--- a/crates/halley-wl/src/compositor/root.rs
+++ b/crates/halley-wl/src/compositor/root.rs
@@ -433,6 +433,7 @@ impl Halley {
                     portal_chooser: None,
                     modal_release_keys: HashSet::new(),
                     forwarded_pressed_keys: HashSet::new(),
+                    keys_physically_down: HashSet::new(),
                     pending_modal_focus_restore: None,
                     focus_cycle_session: None,
                     active_gesture_route: None,
@@ -1270,6 +1271,10 @@ impl Halley {
 
     pub(crate) fn exit_xdg_fullscreen(&mut self, node_id: NodeId, now: Instant) {
         super::fullscreen::system::exit_xdg_fullscreen(self, node_id, now)
+    }
+
+    pub(crate) fn exit_xdg_fullscreen_no_anim(&mut self, node_id: NodeId, now: Instant) {
+        super::fullscreen::system::exit_xdg_fullscreen_no_anim(self, node_id, now)
     }
 
     pub(crate) fn tick_fullscreen_motion(&mut self, now: Instant) {

--- a/crates/halley-wl/src/compositor/runtime.rs
+++ b/crates/halley-wl/src/compositor/runtime.rs
@@ -237,7 +237,7 @@ fn animation_deadline_ms(st: &Halley, now_ms: u64) -> Option<u64> {
 pub fn apply_tuning(st: &mut Halley, mut tuning: RuntimeTuning) {
     let prev_runtime_viewport = st.model.viewport;
     let prev_config_viewport = st.runtime.tuning.viewport();
-    let prev_decorations = st.runtime.tuning.decorations;
+    let prev_border_radius_px = st.runtime.tuning.window_border_radius_px();
     let prev_font = st.runtime.tuning.font.clone();
     let prev_input = st.runtime.tuning.input.clone();
     let prev_physics_enabled = st.runtime.tuning.physics_enabled;
@@ -353,7 +353,11 @@ pub fn apply_tuning(st: &mut Halley, mut tuning: RuntimeTuning) {
     if st.runtime.tuning.font != prev_font {
         st.ui.render_state.invalidate_ui_text_cache();
     }
-    if st.runtime.tuning.decorations != prev_decorations {
+    // Only the baked rounded-corner radius affects the offscreen window texture; border
+    // sizes/colors, shadows and blur are all drawn live per frame. So rebuild textures only
+    // when the radius actually changes (including crossing 0, which toggles the geometry
+    // clip), not on color-only theme reloads.
+    if st.runtime.tuning.window_border_radius_px() != prev_border_radius_px {
         st.ui.render_state.clear_window_offscreen_caches();
     }
     if !st.runtime.tuning.cursor.hide_while_typing {

--- a/crates/halley-wl/src/compositor/surface/mod.rs
+++ b/crates/halley-wl/src/compositor/surface/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use query::{
     node_blocks_interactive_transform, stack_focus_target_for_node,
 };
 pub(crate) use xdg::{
-    current_surface_size_for_node, request_close_focused_toplevel, request_close_node_toplevel,
-    request_toplevel_resize_mode, toplevel_min_size_for_node, window_geometry_for_node,
+    current_surface_size_for_node, render_window_geometry_for_node,
+    request_close_focused_toplevel, request_close_node_toplevel, request_toplevel_resize_mode,
+    toplevel_min_size_for_node, window_geometry_for_node,
 };

--- a/crates/halley-wl/src/compositor/surface/xdg.rs
+++ b/crates/halley-wl/src/compositor/surface/xdg.rs
@@ -452,6 +452,26 @@ pub(crate) fn current_surface_size_for_node(
         })
 }
 
+/// Geometry to use when *rendering* a node's surface to the output.
+///
+/// The single rule: a fullscreen surface fills the output with no CSD inset — its whole
+/// buffer is content — and its cached xdg window-geometry can lag the live buffer right
+/// after the client goes fullscreen (notably XWayland/Steam, which update geometry a
+/// commit or two late). Scaling the surface through that stale windowed geometry blows
+/// the texture up so only its top-left shows. So this returns `None` for a fullscreen
+/// node, signalling the caller to substitute the live surface bbox; otherwise it returns
+/// the committed window geometry. Keep all render paths (field layout, offscreen
+/// compose, close-capture, previews) on this one helper so they can't drift apart.
+pub(crate) fn render_window_geometry_for_node(
+    st: &Halley,
+    node_id: halley_core::field::NodeId,
+) -> Option<(f32, f32, f32, f32)> {
+    if st.is_fullscreen_active(node_id) {
+        return None;
+    }
+    window_geometry_for_node(st, node_id)
+}
+
 pub(crate) fn window_geometry_for_node(
     st: &Halley,
     node_id: halley_core::field::NodeId,

--- a/crates/halley-wl/src/input/keyboard/bindings.rs
+++ b/crates/halley-wl/src/input/keyboard/bindings.rs
@@ -320,7 +320,35 @@ pub(crate) fn apply_compositor_action_press(
             crate::compositor::monitor::camera::reset_zoom(st);
             true
         }
+        CompositorBindingAction::CenterLastFocused => center_on_last_focused(st),
     }
+}
+
+/// Pan the camera back to centre on the last focused node — a quick "go back" after
+/// wandering the field. Uses the live interaction focus, falling back to the monitor's
+/// last focused surface node. Mirrors the focus-and-pan path used by Apogee selection
+/// (`set_interaction_focus` + `set_pan_restore_focus_target` + `animate_viewport_center_to`).
+fn center_on_last_focused(st: &mut Halley) -> bool {
+    let now = Instant::now();
+    let monitor = st.focused_monitor().to_string();
+    let Some(node_id) = st
+        .model
+        .focus_state
+        .primary_interaction_focus
+        .or_else(|| st.last_focused_surface_node_for_monitor(monitor.as_str()))
+    else {
+        return false;
+    };
+    let Some(pos) = st.model.field.node(node_id).map(|node| node.pos) else {
+        return false;
+    };
+    let node_monitor = st.monitor_for_node_or_current(node_id);
+    if st.focused_monitor() != node_monitor {
+        st.focus_monitor_view(node_monitor.as_str(), now);
+    }
+    st.set_interaction_focus(Some(node_id), 30_000, now);
+    st.set_pan_restore_focus_target(node_id);
+    st.animate_viewport_center_to(pos, now)
 }
 
 fn apogee_allows_compositor_action(action: &CompositorBindingAction) -> bool {
@@ -364,6 +392,7 @@ pub(crate) fn apply_bound_key(
             | CompositorBindingAction::CloseFocusedWindow
             | CompositorBindingAction::ClusterMode
             | CompositorBindingAction::Apogee
+            | CompositorBindingAction::CenterLastFocused
             | CompositorBindingAction::FocusCycle(_)
             | CompositorBindingAction::Stack(_)
             | CompositorBindingAction::Tile(_)

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -110,6 +110,59 @@ pub(crate) fn flush_stuck_forwarded_keys(st: &mut Halley) {
     }
 }
 
+/// Release any key we forwarded to a client as *pressed* that is no longer physically
+/// held. This is the general, choke-point guarantee against stuck client-side key repeat:
+/// it runs after **every** key event (see `handle_keyboard_input`), so a release swallowed
+/// by a modal, lost to a dead surface, or skipped by a deferred focus is still delivered to
+/// whoever now holds focus — no per-case `trap_modal_key_release` required. Genuinely held
+/// keys (still in `keys_physically_down`, modifiers included) are left untouched, so normal
+/// key-holds and held Ctrl/Alt/Super are unaffected.
+pub(crate) fn reconcile_forwarded_keys(st: &mut Halley) {
+    let codes: Vec<u32> = st
+        .input
+        .interaction_state
+        .forwarded_pressed_keys
+        .iter()
+        .copied()
+        .filter(|code| {
+            !st.input
+                .interaction_state
+                .keys_physically_down
+                .contains(code)
+        })
+        .collect();
+    if codes.is_empty() {
+        return;
+    }
+    let Some(keyboard) = st.platform.seat.get_keyboard() else {
+        for code in &codes {
+            st.input
+                .interaction_state
+                .forwarded_pressed_keys
+                .remove(code);
+            st.input.interaction_state.modal_release_keys.remove(code);
+        }
+        return;
+    };
+    for code in codes {
+        let (_, mods_changed) =
+            keyboard.input_intercept::<(), _>(st, code.into(), KeyState::Released, |_, _, _| ());
+        keyboard.input_forward(
+            st,
+            code.into(),
+            KeyState::Released,
+            SERIAL_COUNTER.next_serial(),
+            now_millis_u32(),
+            mods_changed,
+        );
+        st.input
+            .interaction_state
+            .forwarded_pressed_keys
+            .remove(&code);
+        st.input.interaction_state.modal_release_keys.remove(&code);
+    }
+}
+
 #[inline]
 fn cluster_mode_allows_keyboard_action(action: &CompositorBindingAction) -> bool {
     let _ = action;
@@ -231,6 +284,24 @@ fn keyboard_has_client_focus(st: &Halley) -> bool {
 }
 
 pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
+    st: &mut Halley,
+    ctx: &InputCtx<'_, B>,
+    code: u32,
+    pressed: bool,
+) {
+    // Record raw physical key state before any modal routing, then reconcile afterwards so
+    // no client is ever left holding a key whose release got swallowed — the general fix
+    // for stuck key repeat, independent of which path consumed this event.
+    if pressed {
+        st.input.interaction_state.keys_physically_down.insert(code);
+    } else {
+        st.input.interaction_state.keys_physically_down.remove(&code);
+    }
+    handle_keyboard_input_inner(st, ctx, code, pressed);
+    reconcile_forwarded_keys(st);
+}
+
+fn handle_keyboard_input_inner<B: crate::backend::interface::BackendView>(
     st: &mut Halley,
     ctx: &InputCtx<'_, B>,
     code: u32,
@@ -864,6 +935,30 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reconcile_forwarded_keys_drains_only_keys_not_physically_down() {
+        let dh = smithay::reexports::wayland_server::Display::<Halley>::new()
+            .expect("display")
+            .handle();
+        let mut state = Halley::new_for_test(&dh, halley_config::RuntimeTuning::default());
+
+        // `stuck` was forwarded as pressed but its release was swallowed (no longer
+        // physically down) — it must be drained so the client stops repeating. `held` is
+        // still physically down (a genuine key-hold) — it must be left forwarded.
+        let stuck = 36; // return
+        let held = 45; // arbitrary letter key
+        let st = &mut state.input.interaction_state;
+        st.forwarded_pressed_keys.insert(stuck);
+        st.forwarded_pressed_keys.insert(held);
+        st.keys_physically_down.insert(held);
+
+        reconcile_forwarded_keys(&mut state);
+
+        let st = &state.input.interaction_state;
+        assert!(!st.forwarded_pressed_keys.contains(&stuck));
+        assert!(st.forwarded_pressed_keys.contains(&held));
+    }
 
     #[test]
     fn hover_keyboard_launch_latches_pointer_monitor_over_stale_pending_monitor() {

--- a/crates/halley-wl/src/input/keyboard/mod.rs
+++ b/crates/halley-wl/src/input/keyboard/mod.rs
@@ -512,6 +512,90 @@ pub(crate) fn handle_keyboard_input<B: crate::backend::interface::BackendView>(
         return;
     }
 
+    // Apogee keyboard navigation: arrows move a highlighted selection across the window
+    // mosaic and the core rail, Enter activates it, Escape closes. These keys are raw
+    // (not compositor binds), so they're intercepted here before normal dispatch and
+    // kept from leaking to focused clients while the overview is open.
+    if st.input.interaction_state.apogee_session.is_some()
+        && !crate::protocol::wayland::session_lock::session_lock_active(st)
+    {
+        let escape = key_name_to_evdev("escape").map(|code| code + 8);
+        let enter = key_name_to_evdev("return").map(|code| code + 8);
+        let left = key_name_to_evdev("left").map(|code| code + 8);
+        let right = key_name_to_evdev("right").map(|code| code + 8);
+        let up = key_name_to_evdev("up").map(|code| code + 8);
+        let down = key_name_to_evdev("down").map(|code| code + 8);
+        let dir = if Some(code) == left {
+            Some(halley_config::DirectionalAction::Left)
+        } else if Some(code) == right {
+            Some(halley_config::DirectionalAction::Right)
+        } else if Some(code) == up {
+            Some(halley_config::DirectionalAction::Up)
+        } else if Some(code) == down {
+            Some(halley_config::DirectionalAction::Down)
+        } else {
+            None
+        };
+        if dir.is_some() || Some(code) == enter || Some(code) == escape {
+            if let Some(keyboard) = st.platform.seat.get_keyboard() {
+                let serial = SERIAL_COUNTER.next_serial();
+                keyboard.input::<(), _>(
+                    st,
+                    code.into(),
+                    if pressed {
+                        KeyState::Pressed
+                    } else {
+                        KeyState::Released
+                    },
+                    serial,
+                    now_millis_u32(),
+                    |_, _, _| FilterResult::Intercept(()),
+                );
+            }
+            if pressed {
+                crate::compositor::interaction::state::trap_modal_key_release(st, code);
+                let now = Instant::now();
+                if let Some(dir) = dir {
+                    // Navigate in global screen space (crosses monitors) and warp the
+                    // cursor onto the target tile. The cursor is the single source of
+                    // truth: warping it drives the same hover path the mouse uses, and
+                    // updates the pointer accumulator so a later physical move continues
+                    // from here — one focus, not two.
+                    if let Some(target) =
+                        crate::compositor::overview::apogee_navigate(st, dir)
+                    {
+                        crate::compositor::overview::apogee_reveal_tile(st, target);
+                        if let Some((gsx, gsy)) =
+                            crate::compositor::overview::apogee_tile_global_center(st, target)
+                        {
+                            crate::input::pointer::motion::handle_pointer_motion_absolute(
+                                st,
+                                ctx,
+                                0,
+                                0,
+                                gsx,
+                                gsy,
+                                (0.0, 0.0),
+                                (0.0, 0.0),
+                                0,
+                            );
+                        }
+                    }
+                } else if Some(code) == enter {
+                    if let Some(node) = st.input.interaction_state.apogee_hover_node {
+                        crate::compositor::overview::select_apogee_target(st, node, now);
+                    } else {
+                        st.close_apogee(now);
+                    }
+                } else {
+                    st.close_apogee(now);
+                }
+                ctx.backend.request_redraw();
+            }
+            return;
+        }
+    }
+
     if st.focus_cycle_session_active() {
         handle_focus_cycle_session_input(st, ctx, code, pressed);
         return;

--- a/crates/halley-wl/src/input/pointer/button/mod.rs
+++ b/crates/halley-wl/src/input/pointer/button/mod.rs
@@ -19,6 +19,7 @@ use smithay::utils::SERIAL_COUNTER;
 
 use super::focus::{
     grabbed_layer_surface_focus, layer_surface_focus_for_screen, pointer_focus_for_screen,
+    popup_focus_for_screen,
 };
 use super::portal_chooser::handle_portal_chooser_pointer_button;
 use super::screenshot::handle_screenshot_pointer_button;
@@ -135,6 +136,25 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
         Instant::now(),
         ps.resize,
     );
+    let popup_focus = popup_focus_for_screen(
+        st,
+        local_w,
+        local_h,
+        local_sx,
+        local_sy,
+        Instant::now(),
+        ps.resize,
+    );
+    // A seat grab (an open xdg_popup menu, or a drag) owns pointer routing: the
+    // button is delivered through the grab by `dispatch_pointer_button`. Skip the
+    // window-side node-focus/raise so we don't steal focus to a window beneath the
+    // menu — and unlike `popup_focus` this holds even in the menu's overflow region
+    // where the per-position popup hit-test misses.
+    let pointer_grabbed = st
+        .platform
+        .seat
+        .get_pointer()
+        .is_some_and(|pointer| pointer.is_grabbed());
     if matches!(button_state, ButtonState::Pressed)
         && let Some((surface, _)) = layer_focus.as_ref()
     {
@@ -464,6 +484,8 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
         && left
         && !intercepted
         && layer_focus.is_none()
+        && popup_focus.is_none()
+        && !pointer_grabbed
         && let Some(hit) = press_hit
         && !hit.move_surface
         && !hit.is_core
@@ -483,6 +505,16 @@ pub(crate) fn handle_pointer_button_input<B: BackendView>(
         && let Some((surface, _)) = layer_focus
     {
         let _ = crate::compositor::monitor::layer_shell::focus_layer_surface(st, &surface);
+        return;
+    }
+    // A press landing on a popup (e.g. a context menu overflowing its parent
+    // window) was already delivered to the popup by dispatch_pointer_button.
+    // Skip the window-side raise/drag/resize handling so the toplevel beneath
+    // the menu is not focused or raised.
+    if matches!(button_state, ButtonState::Pressed)
+        && !intercepted
+        && (popup_focus.is_some() || pointer_grabbed)
+    {
         return;
     }
     match button_state {

--- a/crates/halley-wl/src/input/pointer/focus/mod.rs
+++ b/crates/halley-wl/src/input/pointer/focus/mod.rs
@@ -4,6 +4,7 @@ mod surface;
 pub(crate) use policy::apply_hover_focus_mode;
 pub(crate) use surface::{
     grabbed_layer_surface_focus, layer_surface_focus_for_screen, pointer_focus_for_screen,
+    popup_focus_for_screen,
 };
 
 #[cfg(test)]

--- a/crates/halley-wl/src/input/pointer/focus/policy.rs
+++ b/crates/halley-wl/src/input/pointer/focus/policy.rs
@@ -10,6 +10,17 @@ pub(crate) fn apply_hover_focus_mode(
     blocked: bool,
     now: Instant,
 ) {
+    // While a seat grab is active (e.g. an open xdg_popup menu, or a drag), the
+    // grab owns focus. Changing the interaction focus here would reassert keyboard
+    // focus onto a window and break the popup keyboard grab, dismissing the menu.
+    if st
+        .platform
+        .seat
+        .get_pointer()
+        .is_some_and(|pointer| pointer.is_grabbed())
+    {
+        return;
+    }
     if !hover_focus_enabled(
         st.runtime.tuning.input.focus_mode,
         blocked,

--- a/crates/halley-wl/src/input/pointer/focus/surface.rs
+++ b/crates/halley-wl/src/input/pointer/focus/surface.rs
@@ -80,7 +80,7 @@ fn popups_top_to_bottom(st: &Halley, surface: &WlSurface) -> Vec<(PopupKind, Poi
         .collect()
 }
 
-fn popup_focus_for_screen(
+pub(crate) fn popup_focus_for_screen(
     st: &mut Halley,
     ws_w: i32,
     ws_h: i32,

--- a/crates/halley-wl/src/overlay/focus_cycle.rs
+++ b/crates/halley-wl/src/overlay/focus_cycle.rs
@@ -228,24 +228,24 @@ fn draw_focus_cycle_preview(
         alpha,
     )?;
 
-    // Fullscreen windows capture to a black texture, so force the app-icon
-    // fallback below instead of previewing them. The selected card previews live
-    // from the shared `window_offscreen_cache`; neighbours read their frozen
+    // Preview from the captured offscreen texture when ready. Fullscreen and game
+    // windows are now captured during the cycle (the immersive lock is released, so
+    // they're composited), so they preview for real too. The selected card previews
+    // live from the shared `window_offscreen_cache`; neighbours read their frozen
     // `focus_cycle_still` so they don't animate (see `prewarm_focus_cycle_previews`).
-    let preview = (!overlay.node_is_fullscreen(node_id))
-        .then(|| {
-            let cache = &overlay.render_state.cache;
-            let source = if selected {
-                &cache.window_offscreen_cache
-            } else {
-                &cache.focus_cycle_still
-            };
-            source
-                .get(&node_id)
-                .filter(|cache| cache.has_content)
-                .and_then(|cache| Some((cache.texture.as_ref()?, cache.bbox?)))
-        })
-        .flatten();
+    // No usable texture → app-icon fallback below.
+    let preview = {
+        let cache = &overlay.render_state.cache;
+        let source = if selected {
+            &cache.window_offscreen_cache
+        } else {
+            &cache.focus_cycle_still
+        };
+        source
+            .get(&node_id)
+            .filter(|cache| cache.has_content)
+            .and_then(|cache| Some((cache.texture.as_ref()?, cache.bbox?)))
+    };
 
     if let Some((texture, bbox)) = preview {
         let source = window_preview_source_rect(overlay, node_id, bbox);

--- a/crates/halley-wl/src/overlay/observatory.rs
+++ b/crates/halley-wl/src/overlay/observatory.rs
@@ -13,9 +13,9 @@ use crate::render::draw_primitives::draw_rect;
 use crate::text::{draw_ui_text_in, ui_text_size_in};
 
 use super::{
-    OverlayView, OverlayVisuals, draw_overflow_member_chip, draw_overlay_chip,
-    draw_overlay_chip_with_border_color, draw_overlay_chip_without_shadow, draw_overlay_ring,
-    overlay_accent_fill, overlay_text_color_for_fill,
+    OverlayView, OverlayVisuals, draw_overflow_member_chip, draw_overlay_backdrop_blur,
+    draw_overlay_chip, draw_overlay_chip_with_border_color, draw_overlay_chip_without_shadow,
+    draw_overlay_ring, overlay_accent_fill, overlay_text_color_for_fill,
     preview_source::{preview_src_uv, window_preview_source_rect},
     resolve_overlay_visuals, truncate_overlay_text_to_width,
 };
@@ -142,20 +142,17 @@ fn draw_window_preview(
         alpha,
     )?;
 
-    // Fullscreen windows capture to a black/unusable texture (video, keybind
-    // fullscreen), so skip the preview and show the app icon instead. Non-fullscreen
-    // windows with no captured texture yet also fall back to the icon.
-    let preview = (!overlay.node_is_fullscreen(tile.node_id))
-        .then(|| {
-            overlay
-                .render_state
-                .cache
-                .window_offscreen_cache
-                .get(&tile.node_id)
-                .filter(|cache| cache.has_content)
-                .and_then(|cache| Some((cache.texture.as_ref()?, cache.bbox?)))
-        })
-        .flatten();
+    // Preview from the captured offscreen texture when one is ready. Fullscreen and
+    // game tiles are now captured while apogee is open (they're composited then), so
+    // they get a real preview too; anything without a usable texture falls back to
+    // the app icon below.
+    let preview = overlay
+        .render_state
+        .cache
+        .window_offscreen_cache
+        .get(&tile.node_id)
+        .filter(|cache| cache.has_content)
+        .and_then(|cache| Some((cache.texture.as_ref()?, cache.bbox?)));
 
     if let Some((texture, bbox)) = preview {
         let source = window_preview_source_rect(overlay, tile.node_id, bbox);
@@ -270,10 +267,14 @@ fn draw_tile_label(
         (rect.loc.x + 8, rect.loc.y + rect.size.h - 8 - label_h).into(),
         ((rect.size.w - 16).max(1), label_h).into(),
     );
+    // Frosted label: a Dual-Kawase backdrop blur (no-op when overlay blur is off,
+    // leaving the plain tint below) plus a translucent tint so the text stays
+    // legible over the blurred window thumbnail behind it.
+    draw_overlay_backdrop_blur(frame, label_rect, 8.0, damage, alpha)?;
     let fill = if hovered {
-        overlay_accent_fill(visuals, 0.55, 0.88 * alpha)
+        overlay_accent_fill(visuals, 0.55, 0.62 * alpha)
     } else {
-        Color32F::new(0.02, 0.025, 0.035, 0.72 * alpha)
+        Color32F::new(0.02, 0.025, 0.035, 0.5 * alpha)
     };
     draw_overlay_chip_without_shadow(
         frame,

--- a/crates/halley-wl/src/overlay/observatory.rs
+++ b/crates/halley-wl/src/overlay/observatory.rs
@@ -384,6 +384,9 @@ fn draw_core_tile(
         damage,
         alpha,
     )?;
+    if hovered {
+        draw_core_hover_label(frame, overlay, visuals, tile, rect, alpha, damage)?;
+    }
     if let Some(icon) = crate::render::cluster_core_icon_texture(st, false) {
         let side = (rect.size.w.min(rect.size.h) as f32 * 0.62).round() as i32;
         let side = side.clamp(20, rect.size.w.min(rect.size.h).max(1));
@@ -432,6 +435,69 @@ fn draw_core_tile(
         &overlay.tuning.font,
         rect.loc.x + ((rect.size.w - text_w).max(0) / 2),
         rect.loc.y + ((rect.size.h - text_h).max(0) / 2),
+        label.as_str(),
+        1,
+        overlay_text_color_for_fill(fill, alpha),
+        damage,
+    )?;
+    Ok(())
+}
+
+/// Draw a frosted name chip just below a hovered/selected core tile. Cores otherwise
+/// show only their icon, so this surfaces the cluster's label on hover and keeps it up
+/// for the whole hover.
+fn draw_core_hover_label(
+    frame: &mut GlesFrame<'_, '_>,
+    overlay: &OverlayView<'_>,
+    visuals: &OverlayVisuals,
+    tile: &ApogeeTile,
+    rect: Rectangle<i32, Physical>,
+    alpha: f32,
+    damage: Rectangle<i32, Physical>,
+) -> Result<(), Box<dyn Error>> {
+    let text = tile_label(overlay, tile);
+    if text.is_empty() {
+        return Ok(());
+    }
+    let max_w = (rect.size.w * 2).clamp(120, 260);
+    let label = truncate_overlay_text_to_width(
+        overlay.render_state,
+        &overlay.tuning.font,
+        text.as_str(),
+        1,
+        max_w - 16,
+    );
+    let (text_w, text_h) =
+        ui_text_size_in(overlay.render_state, &overlay.tuning.font, label.as_str(), 1);
+    let chip_w = (text_w + 20).clamp(48, max_w);
+    let chip_h = (text_h + 12).clamp(22, 34);
+    let chip = Rectangle::<i32, Physical>::new(
+        (
+            rect.loc.x + (rect.size.w - chip_w) / 2,
+            rect.loc.y + rect.size.h + 8,
+        )
+            .into(),
+        (chip_w, chip_h).into(),
+    );
+    draw_overlay_backdrop_blur(frame, chip, 8.0, damage, alpha)?;
+    let fill = overlay_accent_fill(visuals, 0.55, 0.62 * alpha);
+    draw_overlay_chip_without_shadow(
+        frame,
+        overlay.render_state,
+        visuals,
+        chip,
+        8.0,
+        fill,
+        false,
+        damage,
+        alpha,
+    )?;
+    draw_ui_text_in(
+        frame,
+        overlay.render_state,
+        &overlay.tuning.font,
+        chip.loc.x + ((chip.size.w - text_w).max(0) / 2),
+        chip.loc.y + ((chip.size.h - text_h).max(0) / 2),
         label.as_str(),
         1,
         overlay_text_color_for_fill(fill, alpha),

--- a/crates/halley-wl/src/overlay/preview_source.rs
+++ b/crates/halley-wl/src/overlay/preview_source.rs
@@ -45,12 +45,19 @@ pub(super) fn window_preview_source_rect(
         .map(|node| node.intrinsic_size.x.max(1.0) / node.intrinsic_size.y.max(1.0))
         .filter(|aspect| aspect.is_finite() && *aspect >= 0.25 && *aspect <= 4.5);
 
-    if let Some((geo_x, geo_y, geo_w, geo_h)) = overlay
-        .render_state
-        .cache
-        .window_geometry
-        .get(&node_id)
-        .copied()
+    // A fullscreen window has no CSD inset — its whole surface is the content — so
+    // the `window_geometry` crop must not apply. Crucially, right after going
+    // fullscreen the captured texture is already fullscreen-size while the cached
+    // `window_geometry` still lags at the windowed rect; cropping to it would sample
+    // a tiny windowed sub-rect at the old offset (small, bottom-right). Use the full
+    // bbox for fullscreen tiles instead.
+    if !overlay.node_is_fullscreen(node_id)
+        && let Some((geo_x, geo_y, geo_w, geo_h)) = overlay
+            .render_state
+            .cache
+            .window_geometry
+            .get(&node_id)
+            .copied()
         && geo_w >= 1.0
         && geo_h >= 1.0
     {

--- a/crates/halley-wl/src/overlay/view.rs
+++ b/crates/halley-wl/src/overlay/view.rs
@@ -18,7 +18,6 @@ pub(crate) struct OverlayView<'a> {
     pub(crate) tuning: &'a RuntimeTuning,
     pub(crate) node_app_ids: &'a std::collections::HashMap<NodeId, String>,
     pub(crate) last_active_size: &'a std::collections::HashMap<NodeId, Vec2>,
-    pub(crate) fullscreen_active: &'a std::collections::HashMap<String, NodeId>,
     pub(crate) viewport: Viewport,
     pub(crate) camera_view_size: Vec2,
 }
@@ -34,16 +33,9 @@ impl<'a> OverlayView<'a> {
             tuning: &st.runtime.tuning,
             node_app_ids: &st.model.node_app_ids,
             last_active_size: &st.model.workspace_state.last_active_size,
-            fullscreen_active: &st.model.fullscreen_state.fullscreen_active_node,
             viewport: st.model.viewport,
             camera_view_size: crate::compositor::monitor::camera::camera_view_size(st),
         }
-    }
-
-    /// Whether `node_id` is the active fullscreen window on its monitor. A node is
-    /// fullscreen on at most its own monitor, so a values scan is correct.
-    pub(crate) fn node_is_fullscreen(&self, node_id: NodeId) -> bool {
-        self.fullscreen_active.values().any(|&n| n == node_id)
     }
 
     pub(crate) fn cluster_overflow_visible_for_monitor(&self, monitor: &str, now_ms: u64) -> bool {
@@ -120,39 +112,5 @@ impl<'a> OverlayView<'a> {
         let sx = (nx * w as f32).round() as i32;
         let sy = (ny * h as f32).round() as i32;
         (sx, sy)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use smithay::reexports::wayland_server::Display;
-
-    #[test]
-    fn node_is_fullscreen_reflects_active_fullscreen_node() {
-        let dh = Display::<Halley>::new().expect("display").handle();
-        let mut state = Halley::new_for_test(&dh, RuntimeTuning::default());
-        let win = state.model.field.spawn_surface(
-            "win",
-            Vec2 { x: 0.0, y: 0.0 },
-            Vec2 { x: 120.0, y: 90.0 },
-        );
-        let other = state.model.field.spawn_surface(
-            "other",
-            Vec2 { x: 200.0, y: 0.0 },
-            Vec2 { x: 120.0, y: 90.0 },
-        );
-        state.assign_node_to_current_monitor(win);
-        state.assign_node_to_current_monitor(other);
-        let monitor = state.focused_monitor().to_string();
-        state
-            .model
-            .fullscreen_state
-            .fullscreen_active_node
-            .insert(monitor, win);
-
-        let view = OverlayView::from_halley(&state);
-        assert!(view.node_is_fullscreen(win));
-        assert!(!view.node_is_fullscreen(other));
     }
 }

--- a/crates/halley-wl/src/overlay/view.rs
+++ b/crates/halley-wl/src/overlay/view.rs
@@ -18,6 +18,8 @@ pub(crate) struct OverlayView<'a> {
     pub(crate) tuning: &'a RuntimeTuning,
     pub(crate) node_app_ids: &'a std::collections::HashMap<NodeId, String>,
     pub(crate) last_active_size: &'a std::collections::HashMap<NodeId, Vec2>,
+    pub(crate) fullscreen_active: &'a std::collections::HashMap<String, NodeId>,
+    pub(crate) fullscreen_soft_suspended: &'a std::collections::HashMap<String, NodeId>,
     pub(crate) viewport: Viewport,
     pub(crate) camera_view_size: Vec2,
 }
@@ -33,9 +35,19 @@ impl<'a> OverlayView<'a> {
             tuning: &st.runtime.tuning,
             node_app_ids: &st.model.node_app_ids,
             last_active_size: &st.model.workspace_state.last_active_size,
+            fullscreen_active: &st.model.fullscreen_state.fullscreen_active_node,
+            fullscreen_soft_suspended: &st.model.fullscreen_state.fullscreen_soft_suspended_node,
             viewport: st.model.viewport,
             camera_view_size: crate::compositor::monitor::camera::camera_view_size(st),
         }
+    }
+
+    /// Whether `node_id` is a fullscreen window — either actively fullscreen or
+    /// soft-suspended (which is the state while apogee is open, so its preview must
+    /// still be treated as fullscreen, i.e. no CSD-geometry crop).
+    pub(crate) fn node_is_fullscreen(&self, node_id: NodeId) -> bool {
+        self.fullscreen_active.values().any(|&n| n == node_id)
+            || self.fullscreen_soft_suspended.values().any(|&n| n == node_id)
     }
 
     pub(crate) fn cluster_overflow_visible_for_monitor(&self, monitor: &str, now_ms: u64) -> bool {

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -422,7 +422,13 @@ impl XdgShellHandler for Halley {
                 grab.ungrab(PopupUngrabStrategy::All);
                 return;
             }
-            keyboard.set_focus(self, grab.current_grab(), serial);
+            // Route popup-grab focus through the choke point so it flushes stale forwarded
+            // keys like every other focus change (no surface inherits a stuck repeat).
+            crate::compositor::focus::system::set_keyboard_focus(
+                self,
+                grab.current_grab(),
+                serial,
+            );
             keyboard.set_grab(self, PopupKeyboardGrab::new(&grab), serial);
         }
 

--- a/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
+++ b/crates/halley-wl/src/protocol/wayland/handlers_xdg.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::compositor::{actions, fullscreen, monitor, spawn, surface, workspace};
 use crate::compositor::spawn::rules::ResolvedInitialWindowRule;
-use smithay::desktop::{PopupKind, find_popup_root_surface};
+use smithay::desktop::{
+    PopupKeyboardGrab, PopupKind, PopupPointerGrab, PopupUngrabStrategy, find_popup_root_surface,
+};
 use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode as XdgDecorationMode;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::protocol::{wl_output::WlOutput, wl_surface::WlSurface};
@@ -394,12 +396,49 @@ impl XdgShellHandler for Halley {
 
     fn grab(&mut self, surface: PopupSurface, _seat: wl_seat::WlSeat, serial: Serial) {
         let popup = PopupKind::from(surface);
-        if let Ok(root) = find_popup_root_surface(&popup) {
-            let _ = self.platform.popup_manager.grab_popup::<Self>(
-                root,
-                popup,
-                &self.platform.seat,
+        let Ok(root) = find_popup_root_surface(&popup) else {
+            return;
+        };
+        let seat = self.platform.seat.clone();
+        // Actually install the popup grab on the seat (standard Smithay flow,
+        // mirroring the DnD `set_grab`). Without this the grab is discarded and the
+        // menu only stays focused while the pointer is over its hit region — so a
+        // popup that overflows the parent window loses pointer focus in the overflow
+        // and Qt clients (kdenlive) dismiss it on motion. The installed grab keeps
+        // pointer + keyboard focus on the popup chain and dismisses on outside click.
+        let Ok(mut grab) =
+            self.platform
+                .popup_manager
+                .grab_popup::<Self>(root, popup, &seat, serial)
+        else {
+            return;
+        };
+
+        if let Some(keyboard) = seat.get_keyboard() {
+            if keyboard.is_grabbed()
+                && !(keyboard.has_grab(serial)
+                    || keyboard.has_grab(grab.previous_serial().unwrap_or(serial)))
+            {
+                grab.ungrab(PopupUngrabStrategy::All);
+                return;
+            }
+            keyboard.set_focus(self, grab.current_grab(), serial);
+            keyboard.set_grab(self, PopupKeyboardGrab::new(&grab), serial);
+        }
+
+        if let Some(pointer) = seat.get_pointer() {
+            if pointer.is_grabbed()
+                && !(pointer.has_grab(serial)
+                    || pointer.has_grab(grab.previous_serial().unwrap_or_else(|| grab.serial())))
+            {
+                grab.ungrab(PopupUngrabStrategy::All);
+                return;
+            }
+            pointer.set_grab(
+                self,
+                PopupPointerGrab::new(&grab),
                 serial,
+                smithay::input::pointer::Focus::Keep,
             );
         }
     }

--- a/crates/halley-wl/src/render/frame/draw.rs
+++ b/crates/halley-wl/src/render/frame/draw.rs
@@ -230,7 +230,7 @@ pub(super) fn draw_scene_below_windows(
     size: smithay::utils::Size<i32, Physical>,
     prepared: &PreparedFrameState,
     scene: &SceneCollections,
-    hover_node: Option<halley_core::field::NodeId>,
+    _hover_node: Option<halley_core::field::NodeId>,
     mut blur_ctx: Option<&mut FrameBlurContext<'_>>,
 ) -> Result<(), Box<dyn Error>> {
     draw_layer_groups(
@@ -246,16 +246,10 @@ pub(super) fn draw_scene_below_windows(
         blur_ctx.as_deref_mut(),
     )?;
 
-    draw_node_markers(
-        frame,
-        st,
-        size,
-        &scene.render_nodes,
-        hover_node,
-        prepared.damage,
-        prepared.now,
-    )?;
-
+    // Node/core markers used to be drawn here, beneath windows, which let a window
+    // grown over a marker hide it. They're now drawn in `draw_scene_windows_and_hud`
+    // (above window bodies, below popups/HUD and their own hover labels) so a landmark
+    // is never occluded. See that pass for the marker draw.
     draw_window_shadows(frame, size, prepared.damage, &scene.shadow_rects, st)?;
     Ok(())
 }
@@ -322,6 +316,21 @@ pub(super) fn draw_scene_windows_and_hud(
         &scene.resized_border_rects,
         st,
     )?;
+
+    // Node/core markers (landmarks: standalone nodes + cluster cores) draw above window
+    // bodies and borders so a window grown over a marker can't hide it, but below popups,
+    // overlay HUD, and the node hover labels that follow. Markers are screen-space
+    // constant, so this keeps them visible at every zoom without resizing them.
+    draw_node_markers(
+        frame,
+        st,
+        size,
+        &scene.render_nodes,
+        hover_node,
+        prepared.damage,
+        prepared.now,
+    )?;
+
     draw_offscreen_textures(
         frame,
         prepared.damage,

--- a/crates/halley-wl/src/render/frame/mod.rs
+++ b/crates/halley-wl/src/render/frame/mod.rs
@@ -334,6 +334,37 @@ pub(crate) fn draw_debug_frame_to_target(
             collect_layer_surfaces(renderer, st, size, prepared.now);
         let cursor = draw_software_cursor
             .then(|| collect_cursor_scene(renderer, cursor_screen, cursor_image));
+
+        // Optional backdrop blur for overlay chrome (apogee tile labels). Mirrors
+        // the main path's FrameBlurContext setup; no layer mask is needed here.
+        // `blur_textures` is taken from `gpu` for the frame and restored after
+        // `finish` so it isn't reallocated every frame.
+        let blur_cfg = st.runtime.tuning.effects.blur;
+        let blur_ready = halley_config::overlay_blur_enabled(
+            &blur_cfg,
+            &st.runtime.tuning.overlay_style,
+        ) && !st.ui.render_state.gpu.blur_programs_failed
+            && st.ui.render_state.gpu.blur_down_program.is_some()
+            && st.ui.render_state.gpu.blur_up_program.is_some()
+            && st.ui.render_state.gpu.blur_composite_program.is_some()
+            && st.ui.render_state.gpu.blur_composite_masked_program.is_some();
+        let down = st.ui.render_state.gpu.blur_down_program.clone();
+        let up = st.ui.render_state.gpu.blur_up_program.clone();
+        let composite = st.ui.render_state.gpu.blur_composite_program.clone();
+        let masked_composite = st.ui.render_state.gpu.blur_composite_masked_program.clone();
+        let mut blur_textures = None;
+        if blur_ready {
+            match crate::render::blur::ensure_blur_textures(
+                renderer,
+                &mut st.ui.render_state.gpu.blur_textures,
+                size,
+                blur_cfg.passes,
+            ) {
+                Ok(()) => blur_textures = st.ui.render_state.gpu.blur_textures.take(),
+                Err(err) => eventline::warn!("apogee overlay blur disabled this frame: {err}"),
+            }
+        }
+
         let mut frame = renderer.render(framebuffer, size, frame_transform)?;
         frame.clear(Color32F::new(0.04, 0.05, 0.06, 1.0), &[prepared.damage])?;
         draw_apogee_background_layers(
@@ -342,14 +373,44 @@ pub(crate) fn draw_debug_frame_to_target(
             &layer_background,
             &layer_bottom,
         )?;
-        crate::overlay::draw_observatory(
-            &mut frame,
-            st,
-            size.w,
-            size.h,
-            prepared.damage,
-            prepared.now,
-        )?;
+        {
+            let mut blur_ctx = match (
+                down.as_ref(),
+                up.as_ref(),
+                composite.as_ref(),
+                masked_composite.as_ref(),
+                blur_textures.as_mut(),
+            ) {
+                (Some(down), Some(up), Some(composite), Some(masked_composite), Some(textures)) => {
+                    Some(FrameBlurContext {
+                        textures,
+                        down_program: down,
+                        up_program: up,
+                        composite_program: composite,
+                        masked_composite_program: masked_composite,
+                        offset: crate::render::blur::blur_offset(blur_cfg.radius),
+                        saturation: blur_cfg.saturation,
+                        noise: blur_cfg.noise,
+                        layer_mask_texture: None,
+                    })
+                }
+                _ => None,
+            };
+            crate::overlay::with_overlay_blur_context(
+                blur_ctx.as_mut(),
+                || -> Result<(), Box<dyn Error>> {
+                    crate::overlay::draw_observatory(
+                        &mut frame,
+                        st,
+                        size.w,
+                        size.h,
+                        prepared.damage,
+                        prepared.now,
+                    )
+                    .map(|_| ())
+                },
+            )?;
+        }
         draw_apogee_aperture_layers(&mut frame, prepared.damage, &layer_background)?;
         draw_apogee_aperture_layers(&mut frame, prepared.damage, &layer_bottom)?;
         draw_apogee_aperture_layers(&mut frame, prepared.damage, &layer_top)?;
@@ -366,6 +427,9 @@ pub(crate) fn draw_debug_frame_to_target(
             )?;
         }
         let _ = frame.finish()?;
+        if let Some(blur_textures) = blur_textures {
+            st.ui.render_state.gpu.blur_textures = Some(blur_textures);
+        }
         return Ok(());
     }
 

--- a/crates/halley-wl/src/window/capture.rs
+++ b/crates/halley-wl/src/window/capture.rs
@@ -23,6 +23,13 @@ fn preview_offscreen_clip(
     f32,
     smithay::backend::renderer::gles::GlesTexProgram,
 )> {
+    // A fullscreen-active surface already IS the whole content (no window
+    // chrome/border to clip away), and its xdg window-geometry cache may still
+    // hold the stale windowed rect from before the client went fullscreen.
+    // Skip the clip so the entire fullscreen surface is captured.
+    if st.is_fullscreen_active(node_id) {
+        return None;
+    }
     let (x, y, w, h) = window_geometry_for_node(st, node_id)?;
     let program = st
         .ui
@@ -138,7 +145,10 @@ pub(crate) fn capture_closing_window_animation(
 
     let (view_center, viewport_size, view_size) = render_view_for_monitor(st, monitor);
     let render_scale = (viewport_size.x.max(1.0) / view_size.x.max(1.0)).max(0.01);
-    let local_geo = window_geometry_for_node(st, node_id).unwrap_or((
+    // For a fullscreen surface this returns None (no CSD crop; cached geometry can be
+    // stale), so we fall back to the live cache bbox `ob` — same rule the field render
+    // uses — instead of over-scaling a window closing straight out of fullscreen.
+    let local_geo = render_window_geometry_for_node(st, node_id).unwrap_or((
         ob.loc.x as f32,
         ob.loc.y as f32,
         ob.size.w.max(1) as f32,

--- a/crates/halley-wl/src/window/capture.rs
+++ b/crates/halley-wl/src/window/capture.rs
@@ -466,12 +466,10 @@ pub(crate) fn prewarm_focus_cycle_previews(
         let Some(wl) = node_surfaces.get(&node_id).cloned() else {
             continue;
         };
-        if node_requires_live_surface_render(st, node_id) {
-            continue;
-        }
-        if st.fullscreen_monitor_for_node(node_id).is_some() {
-            continue;
-        }
+        // This runs only during an alt+tab cycle, which releases the immersive
+        // fullscreen lock (the window is composited, off direct scanout), so even
+        // fullscreen/game surfaces are sampleable here — capture them for the
+        // preview card instead of falling back to the app icon.
         let Some(node) = st.model.field.node(node_id) else {
             continue;
         };
@@ -626,11 +624,6 @@ pub(crate) fn prewarm_apogee_previews(renderer: &mut GlesRenderer, st: &mut Hall
         .filter(|node_id| tile_node_ids.contains(node_id));
     let mut missing = Vec::new();
     for node_id in tile_node_ids {
-        // Fullscreen windows capture to a black texture; Apogee shows their app
-        // icon instead, so don't spend capture budget on them.
-        if st.fullscreen_monitor_for_node(node_id).is_some() {
-            continue;
-        }
         let cache = st
             .ui
             .render_state
@@ -702,12 +695,9 @@ pub(crate) fn prewarm_apogee_previews(renderer: &mut GlesRenderer, st: &mut Hall
         let Some(wl) = node_surfaces.get(&node_id).cloned() else {
             continue;
         };
-        if node_requires_live_surface_render(st, node_id) {
-            continue;
-        }
-        if st.fullscreen_monitor_for_node(node_id).is_some() {
-            continue;
-        }
+        // This runs only while apogee is open, where the fullscreen/game window is
+        // soft-suspended (composited, off direct scanout), so its surface is
+        // sampleable — capture it for the tile instead of falling back to the icon.
         let Some(node) = st.model.field.node(node_id) else {
             continue;
         };

--- a/crates/halley-wl/src/window/layout.rs
+++ b/crates/halley-wl/src/window/layout.rs
@@ -267,7 +267,15 @@ pub(super) fn resolve_window_render_layout(
         bbox.size.h.max(1) as f32,
     );
 
-    let local_geo = if stack_member_rendered {
+    let local_geo = if fullscreen_on_current_monitor {
+        // A fullscreen surface has no CSD inset — its whole buffer is content — and the
+        // cached xdg window-geometry can lag the buffer right after the client goes
+        // fullscreen (notably XWayland/Steam). Dividing the fullscreen visual size by the
+        // stale windowed geometry over-scales the texture so only its top-left shows. Use
+        // the live surface bbox so render_scale maps the actual buffer to the output.
+        // (`render_window_geometry_for_node` returns None for fullscreen by design.)
+        render_window_geometry_for_node(st, node_id).unwrap_or(local_bbox)
+    } else if stack_member_rendered {
         let base_geo = window_geometry_for_node(st, node_id).unwrap_or(local_bbox);
         let target_size = stack_transition_pose
             .map(|pose| pose.size)

--- a/crates/halley-wl/src/window/mod.rs
+++ b/crates/halley-wl/src/window/mod.rs
@@ -29,7 +29,7 @@ use crate::compositor::spawn::state::{
 };
 use crate::compositor::surface::{
     active_stacking_visible_members_for_monitor, is_active_cluster_workspace_member,
-    window_geometry_for_node,
+    render_window_geometry_for_node, window_geometry_for_node,
 };
 use crate::input::active_resize_geometry_screen;
 use crate::presentation::world_to_screen;

--- a/examples/halley.rune
+++ b/examples/halley.rune
@@ -502,6 +502,9 @@ keybinds:
   "$var.mod+up" "node-move up"
   "$var.mod+down" "node-move down"
 
+  # Pan the camera back to centre on the last focused node (quick "go back").
+  "$var.mod+h" "center-last-focused"
+
   # Switch active monitor focus.
   "$var.mod+shift+left" "monitor-focus left"
   "$var.mod+shift+right" "monitor-focus right"

--- a/examples/lift.rune
+++ b/examples/lift.rune
@@ -5,9 +5,9 @@ lift:
 
   width 760
   
-  max-results 12
-  
+  max-results 12 
   visible-results 8
+
   fuzzy true
   show-section-labels true
   

--- a/examples/split-config/halley.rune
+++ b/examples/split-config/halley.rune
@@ -36,6 +36,7 @@ keybinds:
   "$var.mod+q" "close-focused"
   "$var.mod+f" "toggle-fullscreen"
   "$var.mod+p" "toggle-focused-pin"
+  "$var.mod+h" "center-last-focused"
 
   "$var.mod+leftmouse" "move-window"
   "$var.mod+rightmouse" "resize-window"


### PR DESCRIPTION
This PR introduces keyboard navigation to Apogee, completely overhauls how fullscreen and maximize states interact (fixing jarring transitions and rendering bugs), and resolves several underlying input/focus issues including a general stuck-key-repeat fix.

### Apogee & Window Switching

 - **Apogee Keyboard Navigation**: Arrow keys now move a highlighted selection across the window mosaic and core rail in global screen space (crosses monitors, no wrap). Up/Down steps between the mosaic and rail. Enter activates; Escape closes. Cursor warps to the target to unify keyboard and pointer hover/focus paths.
 - **Center-Last-Focused Keybind**: Adds center-last-focused action (default mod+h) to pan the camera back to the last focused node. Shifts bare-defaults node-move bindings from vim hjkl to arrow keys to free up mod+h.
 - **Capture Fullscreen/Game Previews**: Immersive fullscreen/game locks are temporarily released while Apogee/Alt+Tab is open. This allows the compositor to sample the surface, granting real captured previews instead of app-icon fallbacks.
 - **Apogee Select Raises Above Fullscreen**: Selecting a window tile behind a fullscreen in Apogee raises it above the fullscreen and keeps the presentation (reverting a prior soft-suspend approach), as fullscreen/maximize are now strictly mutually exclusive (see below).
 - **Frosted Apogee Tile Labels**: Tile labels now paint a Dual-Kawase backdrop blur behind the text, keeping them legible over blurred thumbnails. Tint alphas were lowered to compensate.
 - **Core Rail Name Chips**: Frosted name chips now appear below hovered/keyboard-selected cluster core tiles.
 
### Fullscreen & Maximize Overhaul

 - **Fullscreen Grow-in-Place**: Entering fullscreen no longer snaps the monitor zoom to 1.0 about the camera center. It now animates the camera to center on the window while easing zoom to 1.0, so the window grows smoothly in place without shoving other windows sideways.
 - **Maximize ↔ Fullscreen Mutual Exclusivity**: Maximize and fullscreen can no longer coexist on the same monitor. Entering fullscreen aborts maximize, and maximizing exits fullscreen, preventing conflicting animations and stale-geometry restore bugs.
 - **Smooth Maximize/Fullscreen Transitions**: Switching between the two states no longer flashes to the windowed size. It captures the outgoing rect and eases directly to the incoming state.
 - **Stuck-at-Maximized-Size Fix**: Resolves a bug where maximize → fullscreen → maximize → unmaximize left a window stuck at maximized size. restore_fullscreen_snapshot now correctly pins the restored windowed size into the node's resize_footprint.
 - **Fullscreen Render-Geometry Fix**: A fullscreen surface's render geometry is now derived from its live buffer, not the cached xdg window-geometry (which lags right after going fullscreen, notably in XWayland/Steam). This fixes an issue where only the top-left corner of the texture filled the screen. Offscreen caches are now cleared on fullscreen enter/exit to prevent stale snapshots.
 
 ### Input Handling & Focus Fixes
 
 - **General Stuck-Key-Repeat Fix**: Introduces a physical key state tracker (keys_physically_down). After every key event, any key forwarded as pressed but no longer physically held is released via reconcile_forwarded_keys. This permanently fixes runaway key repeat (e.g., Enter repeating forever after opening a cluster) without needing per-case patches.
- **Popup Press Guard**: A press landing on a popup (e.g., a context menu) no longer accidentally triggers the window-side raise/drag/resize path for the toplevel beneath it. 
 - **Popup-Grab Focus Choke Point**: Routed popup-grab focus through set_keyboard_focus to ensure it flushes stale forwarded keys like every other focus change.
 
 ### Layout, Visuals & Performance
 
 - **Node Markers Above Windows**: Field node/core markers now draw above window bodies and borders (but below popups/HUD) so a grown window can no longer occlude its marker.
 - **Passive-Overlap Landmark Fix**: In mixed expanded/landmark overlap, the landmark is now treated as the fixed reference in passive mode, forcing windows to yield. Markers boxed between windows will no longer be overlapped. Pinning now only affects drag-carry behavior.
 - **Narrow Config-Reload Cache Invalidation**: apply_tuning now only rebuilds offscreen window textures when the baked window_border_radius_px actually changes, rather than flushing the cache on any decoration block diff.
 - **Halley Lift Config Glyph**: Adds a dedicated settings.svg glyph for config search mode and refreshes the apps.svg glyph strokes.
 
 ### Misc
  Bumps `rune-cfg` from 0.5.0 to 0.6.1.
 Updates `CHANGELOG` for v0.5.0.